### PR TITLE
M1447 Updating testing template to utilize screen object for Testing Library instead of old way

### DIFF
--- a/plop-templates/componentSpec.js.hbs
+++ b/plop-templates/componentSpec.js.hbs
@@ -1,11 +1,11 @@
 import '@testing-library/jest-dom/extend-expect'
 import React from 'react'
-import { renderAuthenticated } from '../../testUtilities/testingLibraryWithHelpers'
+import { renderAuthenticated, screen } from '../../testUtilities/testingLibraryWithHelpers'
 
 import {{pascalCase name}} from './{{pascalCase name}}'
 
 test('{{pascalCase name}} component renders with the expected UI elements', () => {
-  const utilities = renderAuthenticated(<{{pascalCase name}} />)
+  renderAuthenticated(<{{pascalCase name}} />)
 
-  expect(utilities.getByText('I should fail'))
+  expect(screen.getByText('I should fail'))
 })

--- a/src/components/Footer/Footer.test.js
+++ b/src/components/Footer/Footer.test.js
@@ -1,10 +1,10 @@
 import '@testing-library/jest-dom/extend-expect'
 // import React from 'react'
-// import { render } from '@testing-library/react'
+// import { renderAuthenticated, screen } from '../../testUtilities/testingLibraryWithHelpers'
 
 // import Footer from './Footer'
 
 test('Footer component renders with the expected UI elements', () => {
-  // const utilities = render(<Footer />)
-  // expect(utilities.getByText('I should fail'))
+  // renderAuthenticated(<Footer />)
+  // expect(screen.getByText('I should fail'))
 })

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -1,11 +1,13 @@
 import '@testing-library/jest-dom/extend-expect'
 // import React from 'react'
-// import { render } from '@testing-library/react'
+// import {
+//   renderAuthenticated,
+//   screen,
+// } from '../../testUtilities/testingLibraryWithHelpers'
 
 // import Header from './Header'
 
 test('Header component renders with the expected UI elements', () => {
-  // const utilities = render(
-  // <Header />)
-  // expect(utilities.getByText('I should fail'))
+  // const utilities = renderAuthenticated(<Header />)
+  // expect(screen.getByText('I should fail'))
 })

--- a/src/components/generic/Breadcrumbs/Breadcrumbs.test.js
+++ b/src/components/generic/Breadcrumbs/Breadcrumbs.test.js
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom/extend-expect'
 // import React from 'react'
-// import { render } from '@testing-library/react'
+// import {
+//   renderAuthenticated,
+//   screen,
+// } from '../../../testUtilities/testingLibraryWithHelpers'
 
 // import Breadcrumbs from './Breadcrumbs'
 
 test('Breadcrumbs component renders with the expected UI elements', () => {
   // const utilities = render(<Breadcrumbs />)
-  // expect(utilities.getByText('I should fail'))
+  // expect(screen.getByText('I should fail'))
 })

--- a/src/components/generic/Layout/Layout.test.js
+++ b/src/components/generic/Layout/Layout.test.js
@@ -1,11 +1,13 @@
 import '@testing-library/jest-dom/extend-expect'
 // import React from 'react'
-// import { render } from '@testing-library/react'
+// import {
+//   renderAuthenticated,
+//   screen,
+// } from '../../../testUtilities/testingLibraryWithHelpers'
 
 // import Layout from './Layout'
 
 test('Layout component renders with the expected UI elements', () => {
-  // const utilities = render(
-  // <Layout />)
-  // expect(utilities.getByText('I should fail'))
+  // const utilities = renderAuthenticated(<Layout />)
+  // expect(screen.getByText('I should fail'))
 })

--- a/src/components/pages/Admin/Admin.test.js
+++ b/src/components/pages/Admin/Admin.test.js
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom/extend-expect'
 // import React from 'react'
-// import { renderAuthenticated } from '../../../testUtilities/testingLibraryWithHelpers'
+// import {
+//   renderAuthenticated,
+//   screen,
+// } from '../../../testUtilities/testingLibraryWithHelpers'
 
 // import Admin from './Admin'
 
 test('Admin component renders with the expected UI elements', () => {
   // const utilities = renderAuthenticated(<Admin />)
-  // expect(utilities.getByText('I should fail'))
+  // expect(screen.getByText('I should fail'))
 })

--- a/src/components/pages/Collect/Collect.test.js
+++ b/src/components/pages/Collect/Collect.test.js
@@ -1,11 +1,13 @@
 import '@testing-library/jest-dom/extend-expect'
 // import React from 'react'
-// import { render } from '@testing-library/react'
+// import {
+//   renderAuthenticated,
+//   screen,
+// } from '../../../testUtilities/testingLibraryWithHelpers'
 
 // import Collect from './Collect'
 
 test('Collect component renders with the expected UI elements', () => {
-  // const utilities = render(
-  // <Collect />)
-  // expect(utilities.getByText('I should fail'))
+  // const utilities = renderAuthenticated(<Collect />)
+  // expect(screen.getByText('I should fail'))
 })

--- a/src/components/pages/Details/Details.test.js
+++ b/src/components/pages/Details/Details.test.js
@@ -1,11 +1,13 @@
 import '@testing-library/jest-dom/extend-expect'
 // import React from 'react'
-// import { render } from '@testing-library/react'
+// import {
+//   renderAuthenticated,
+//   screen,
+// } from '../../../testUtilities/testingLibraryWithHelpers'
 
 // import Details from './Details'
 
 test('Details component renders with the expected UI elements', () => {
-  // const utilities = render(
-  // <Details />)
-  // expect(utilities.getByText('I should fail'))
+  // const utilities = renderAuthenticated(<Details />)
+  // expect(screen.getByText('I should fail'))
 })

--- a/src/components/pages/GraphsAndMaps/GraphsAndMaps.test.js
+++ b/src/components/pages/GraphsAndMaps/GraphsAndMaps.test.js
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom/extend-expect'
 // import React from 'react'
-// import { renderAuthenticated } from '../../../testUtilities/testingLibraryWithHelpers'
+// import {
+//   renderAuthenticated,
+//   screen,
+// } from '../../../testUtilities/testingLibraryWithHelpers'
 
 // import GraphsAndMaps from './GraphsAndMaps'
 
 test('GraphsAndMaps component renders with the expected UI elements', () => {
   // const utilities = renderAuthenticated(<GraphsAndMaps />)
-  // expect(utilities.getByText('I should fail'))
+  // expect(screen.getByText('I should fail'))
 })

--- a/src/components/pages/ManagementRegimes/ManagementRegimes.test.js
+++ b/src/components/pages/ManagementRegimes/ManagementRegimes.test.js
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom/extend-expect'
 // import React from 'react'
-// import { renderAuthenticated } from '../../../testUtilities/testingLibraryWithHelpers'
+// import {
+//   renderAuthenticated,
+//   screen,
+// } from '../../../testUtilities/testingLibraryWithHelpers'
 
 // import ManagementRegimes from './ManagementRegimes'
 
 test('ManagementRegimes component renders with the expected UI elements', () => {
   // const utilities = renderAuthenticated(<ManagementRegimes />)
-  // expect(utilities.getByText('I should fail'))
+  // expect(screen.getByText('I should fail'))
 })

--- a/src/components/pages/Projects/Projects.test.js
+++ b/src/components/pages/Projects/Projects.test.js
@@ -1,11 +1,13 @@
 import '@testing-library/jest-dom/extend-expect'
 // import React from 'react'
-// import { render } from '@testing-library/react'
+// import {
+//   renderAuthenticated,
+//   screen,
+// } from '../../../testUtilities/testingLibraryWithHelpers'
 
 // import Projects from './Projects'
 
 test('Projects component renders with the expected UI elements', () => {
-  // const utilities = render(
-  // <Projects />)
-  // expect(utilities.getByText('I should fail'))
+  // const utilities = renderAuthenticated(<Projects />)
+  // expect(screen.getByText('I should fail'))
 })

--- a/src/components/pages/Sites/Sites.test.js
+++ b/src/components/pages/Sites/Sites.test.js
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom/extend-expect'
 // import React from 'react'
-// import { renderAuthenticated } from '../../../testUtilities/testingLibraryWithHelpers'
+// import {
+//   renderAuthenticated,
+//   screen,
+// } from '../../../testUtilities/testingLibraryWithHelpers'
 
 // import Sites from './Sites'
 
 test('Sites component renders with the expected UI elements', () => {
   // const utilities = renderAuthenticated(<Sites />)
-  // expect(utilities.getByText('I should fail'))
+  // expect(screen.getByText('I should fail'))
 })


### PR DESCRIPTION
React Testing library has a new `screen` object which is preferable. Changed the templates and scaffold tests to be more consistent to make learning testing easier. 