### PR TITLE
M158 fix date parsing bug + tests

### DIFF
--- a/src/App/integrationTests/App.fishBeltCreateUpdateDelete.test.js
+++ b/src/App/integrationTests/App.fishBeltCreateUpdateDelete.test.js
@@ -295,7 +295,7 @@ describe('New fishbelt', () => {
     expect(within(collectRecordRow).getByText('2m x 10m'))
     // depth
     expect(within(collectRecordRow).getByText('10'))
-    expect(within(collectRecordRow).getByText('20-Apr-2021'))
+    expect(within(collectRecordRow).getByText('April 21, 2021'))
   })
   test('New fishbelt save failure shows toast message with edits persisting', async () => {
     const dexieInstance = getMockDexieInstanceAllSuccess()

--- a/src/App/mermaidData/databaseSwitchboard/CollectRecordsMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/CollectRecordsMixin.js
@@ -128,16 +128,15 @@ const CollectRecordsMixin = (Base) =>
     }
 
     #getSampleDateLabel = (record) => {
-      const { sample_date } = record.data.sample_event
+      const [year, month, day] = record.data.sample_event.sample_date.split('-')
+      const zeroIndexedMonth = month - 1
+      const locale = navigator.language ?? 'en-US'
 
-      if (sample_date) {
-        const datePieces = new Date(sample_date).toDateString().split(' ')
-
-        // date format DD-MMM-YYYY as 01-Jan-2010
-        return `${datePieces[2]}-${datePieces[1]}-${datePieces[3]}`
-      }
-
-      return undefined
+      return new Date(year, zeroIndexedMonth, day).toLocaleDateString(locale, {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+      })
     }
 
     #getObserversLabel = (record) => {

--- a/src/components/pages/Collect/Collect.test.js
+++ b/src/components/pages/Collect/Collect.test.js
@@ -215,21 +215,21 @@ test('Collect Records table sorts properly by sample date column', async () => {
 
   const tableRows = within(table).getAllByRole('row')
 
-  expect(within(tableRows[1]).getByText('11-Mar-2021'))
+  expect(within(tableRows[1]).getByText('March 11, 2021'))
 
   // click once to change to ascending order
   userEvent.click(within(table).getByText('Sample Date'))
 
   const tableRowsAfter = within(table).getAllByRole('row')
 
-  expect(within(tableRowsAfter[1]).getByText('02-Mar-2021'))
+  expect(within(tableRowsAfter[1]).getByText('March 2, 2021'))
 
   // // click again to change to descending order
   userEvent.click(within(table).getByText('Sample Date'))
 
   const tableRowsAfterFirstClick = within(table).getAllByRole('row')
 
-  expect(within(tableRowsAfterFirstClick[1]).getByText('11-Mar-2021'))
+  expect(within(tableRowsAfterFirstClick[1]).getByText('March 11, 2021'))
 })
 test('Collect Records table sorts properly by observers column', async () => {
   renderAuthenticatedOnline(


### PR DESCRIPTION
We had a funny date parsing bug. Its fixed. Basically direct parsing of date strings with `Date` is inconsistent across environments, and that was why our tests were failing in GH actions (not performance). It was a real failing test, lol. 

Also changed the data display format to be the browser locale string instead of our custom format (approved by Al)

![Screen Shot 2021-05-01 at 11 23 36 AM](https://user-images.githubusercontent.com/1740152/116790108-db2a3400-aa6f-11eb-8977-a528dc3f3679.png)
