### PR TITLE
update effect to follow best practices for hooks

### DIFF
--- a/src/components/generic/InputWithLabelAndValidation/InputWithLabelAndValidation.js
+++ b/src/components/generic/InputWithLabelAndValidation/InputWithLabelAndValidation.js
@@ -15,14 +15,15 @@ const InputWithLabelAndValidation = ({
 
   const _preventScrollingFromChangingValues = useEffect(() => {
     const handleWheel = (e) => e.preventDefault()
+    const snapshotOfTextFieldRef = textFieldRef.current
 
-    textFieldRef.current.addEventListener('wheel', handleWheel)
+    snapshotOfTextFieldRef.addEventListener('wheel', handleWheel)
 
     return () => {
-      if (textFieldRef.current)
-        textFieldRef.current.removeEventListener('wheel', handleWheel)
+      if (snapshotOfTextFieldRef)
+        snapshotOfTextFieldRef.removeEventListener('wheel', handleWheel)
     }
-  }, [textFieldRef])
+  }, [])
 
   return (
     <InputRow validationType={validationType}>


### PR DESCRIPTION
This is to get rid of the following warning:

> The ref value 'textFieldRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'textFieldRef.current' to a variable inside the effect, and use that variable in the cleanup function


