### PR TITLE
M214 init app load pull

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -31,15 +31,38 @@ function App({ dexieInstance }) {
     logoutMermaid,
   } = useAuthentication({ dexieInstance })
   const apiBaseUrl = process.env.REACT_APP_MERMAID_API
-  const [isOfflineStorageHydrated, setIsOfflineStorageHydrated] = useState(true)
+  const [isOfflineStorageHydrated, setIsOfflineStorageHydrated] = useState(
+    false,
+  )
 
   const _initiallyHydrateOfflineStorageWithApiData = useEffect(() => {
-    if (dexieInstance && isMounted.current && isOnline) {
-      initiallyHydrateOfflineStorageWithApiData(dexieInstance)
-        .then(setIsOfflineStorageHydrated(true))
-        .catch(() => toast.error(language.error.initialApiDataPull))
+    const isOnlineAndReadyForHydration =
+      apiBaseUrl && auth0Token && dexieInstance && isMounted.current && isOnline
+
+    const isOfflineAndReadyAndAlreadyHydrated =
+      apiBaseUrl &&
+      !auth0Token &&
+      dexieInstance &&
+      isMounted.current &&
+      !isOnline
+
+    if (isOnlineAndReadyForHydration) {
+      initiallyHydrateOfflineStorageWithApiData({
+        dexieInstance,
+        apiBaseUrl,
+        auth0Token,
+      })
+        .then(() => {
+          setIsOfflineStorageHydrated(true)
+        })
+        .catch(() => {
+          toast.error(language.error.initialApiDataPull)
+        })
     }
-  }, [dexieInstance, isMounted, isOnline])
+    if (isOfflineAndReadyAndAlreadyHydrated) {
+      setIsOfflineStorageHydrated(true)
+    }
+  }, [dexieInstance, isMounted, isOnline, apiBaseUrl, auth0Token])
   const { current: apiSyncInstance } = useRef(
     new ApiSync({
       dexieInstance,

--- a/src/App/initiallyHydrateOfflineStorageWithApiData.js
+++ b/src/App/initiallyHydrateOfflineStorageWithApiData.js
@@ -1,19 +1,99 @@
-import { initiallyHydrateOfflineStorageWithMockData } from '../testUtilities/initiallyHydrateOfflineStorageWithMockData'
+import axios from 'axios'
+import mockMermaidData from '../testUtilities/mockMermaidData'
+import {
+  getLastRevisionNumbersPulled,
+  persistLastRevisionNumbersPulled,
+} from './mermaidData/lastRevisionNumbers'
 
-export const initiallyHydrateOfflineStorageWithApiData = (dexieInstance) => {
-  /** this is very WIP.
-   * Currently we only have fish species, and collect records being loaded into storage here
-   * (so that suggesting a new species will work now and will work later with minimal refactor),
-   * but the rest will come as we transition away
-   * from using mocked data and mature the architecture*/
+export const initiallyHydrateOfflineStorageWithApiData = async ({
+  dexieInstance,
+  auth0Token,
+  apiBaseUrl,
+}) => {
+  const apiDataNames = [
+    'benthic_attributes',
+    'choices',
+    'fish_families',
+    'fish_genera',
+    'fish_species',
+    'projects',
+  ]
 
+  const lastRevisionNumbersPulled = await getLastRevisionNumbersPulled({
+    dexieInstance,
+  })
+
+  // were not using the apiDataNames here to create a request body
+  // for the purposes of maintainability and troubleshooting.
+  const { data: apiData } = await axios.post(
+    `${apiBaseUrl}/pull/`,
+    {
+      benthic_attributes: {
+        last_revision: lastRevisionNumbersPulled?.benthic_attributes ?? null,
+      },
+      fish_families: {
+        last_revision: lastRevisionNumbersPulled?.fish_families ?? null,
+      },
+      fish_genera: {
+        last_revision: lastRevisionNumbersPulled?.fish_genera ?? null,
+      },
+      fish_species: {
+        last_revision: lastRevisionNumbersPulled?.fish_species ?? null,
+      },
+      choices: { last_revision: lastRevisionNumbersPulled?.choices ?? null },
+      projects: { last_revision: lastRevisionNumbersPulled?.projects ?? null },
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${auth0Token}`,
+      },
+    },
+  )
+
+  await persistLastRevisionNumbersPulled({
+    dexieInstance,
+    apiData,
+  })
 
   return dexieInstance.transaction(
     'rw',
-    dexieInstance.fishSpecies,
-    dexieInstance.collectRecords,
+    dexieInstance.benthic_attributes,
+    dexieInstance.choices,
+    dexieInstance.collect_records,
+    dexieInstance.fish_families,
+    dexieInstance.fish_genera,
+    dexieInstance.fish_species,
+    dexieInstance.projects,
     async () => {
-      initiallyHydrateOfflineStorageWithMockData(dexieInstance)
+      apiDataNames.forEach((apiDataType) => {
+        if (apiDataType === 'choices') {
+          // choices deletes property will always be empty, so we just ignore it
+          // additionally the updates property is an object, not an array, so we just store it directly
+
+          dexieInstance[apiDataType].put({
+            id: 'enforceOnlyOneRecordEverStoredAndOverwritten',
+            choices: apiData[apiDataType]?.updates,
+          })
+        }
+        if (apiDataType !== 'choices') {
+          const updates = apiData[apiDataType]?.updates ?? []
+          const deletes = apiData[apiDataType]?.deletes ?? []
+
+          updates.forEach((specie) => {
+            dexieInstance[apiDataType].put(specie)
+          })
+          deletes.deletes?.forEach(({ id }) => {
+            dexieInstance[apiDataType].delete(id)
+          })
+        }
+      })
+
+      // for now we load some fake mock collect records here.
+      // Later this will be triggered elsewhere
+      // (see this ticket: https://trello.com/c/4uIfcdvr/274-wire-up-sync-triggers)
+      mockMermaidData.collectRecords.forEach((record) => {
+        dexieInstance.collect_records.put(record)
+      })
     },
   )
 }

--- a/src/App/integrationTests/App.projects.test.js
+++ b/src/App/integrationTests/App.projects.test.js
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom/extend-expect'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
+import { initiallyHydrateOfflineStorageWithMockData } from '../../testUtilities/initiallyHydrateOfflineStorageWithMockData'
 import { getMockDexieInstanceAllSuccess } from '../../testUtilities/mockDexie'
 import {
   renderAuthenticatedOffline,
@@ -10,9 +11,13 @@ import {
 import App from '../App'
 
 test('Clicking anywhere on a project card navigates to the project collect page when offline', async () => {
-  renderAuthenticatedOffline(
-    <App dexieInstance={getMockDexieInstanceAllSuccess()} />,
-  )
+  const dexieInstance = getMockDexieInstanceAllSuccess()
+
+  await initiallyHydrateOfflineStorageWithMockData(dexieInstance)
+
+  renderAuthenticatedOffline(<App dexieInstance={dexieInstance} />, {
+    dexieInstance,
+  })
 
   expect(
     await screen.findByText('Projects', {

--- a/src/App/integrationTests/fishBelt/App.fishBeltCreate.test.js
+++ b/src/App/integrationTests/fishBelt/App.fishBeltCreate.test.js
@@ -8,6 +8,7 @@ import {
 } from '../../../testUtilities/testingLibraryWithHelpers'
 import App from '../../App'
 import { getMockDexieInstanceAllSuccess } from '../../../testUtilities/mockDexie'
+import { initiallyHydrateOfflineStorageWithMockData } from '../../../testUtilities/initiallyHydrateOfflineStorageWithMockData'
 
 const saveFishbeltRecord = async () => {
   userEvent.selectOptions(await screen.findByLabelText('Site'), '1')
@@ -35,11 +36,16 @@ const saveFishbeltRecord = async () => {
 
 describe('Offline', () => {
   test('New fishbelt save success shows toast, and navigates to edit fishbelt page for new record', async () => {
+    const dexieInstance = getMockDexieInstanceAllSuccess()
+
+    await initiallyHydrateOfflineStorageWithMockData(dexieInstance)
+
     renderAuthenticatedOffline(
-      <App dexieInstance={getMockDexieInstanceAllSuccess()} />,
+      <App dexieInstance={dexieInstance} />,
       {
         initialEntries: ['/projects/fakewhatever/collecting/fishbelt/'],
       },
+      dexieInstance,
     )
 
     await saveFishbeltRecord()
@@ -102,9 +108,12 @@ describe('Offline', () => {
   test('New fishbelt save failure shows toast message with edits persisting', async () => {
     const dexieInstance = getMockDexieInstanceAllSuccess()
 
-    dexieInstance.collectRecords.put = () => Promise.reject()
+    await initiallyHydrateOfflineStorageWithMockData(dexieInstance)
+
+    dexieInstance.collect_records.put = () => Promise.reject()
     renderAuthenticatedOffline(<App dexieInstance={dexieInstance} />, {
       initialEntries: ['/projects/fakewhatever/collecting/fishbelt/'],
+      dexieInstance,
     })
 
     await saveFishbeltRecord()

--- a/src/App/integrationTests/fishBelt/App.fishBeltDelete1.test.js
+++ b/src/App/integrationTests/fishBelt/App.fishBeltDelete1.test.js
@@ -15,10 +15,11 @@ describe('Offline', () => {
     const dexieInstance = getMockDexieInstanceAllSuccess()
 
     // make sure there is a collect record to edit in dexie
-    await dexieInstance.collectRecords.put(mockMermaidData.collectRecords[1])
+    await dexieInstance.collect_records.put(mockMermaidData.collectRecords[1])
 
     renderAuthenticatedOffline(<App dexieInstance={dexieInstance} />, {
       initialEntries: ['/projects/fakewhatever/collecting/fishbelt/2'],
+      dexieInstance,
     })
 
     userEvent.click(await screen.findByText('Delete Record'))
@@ -51,10 +52,11 @@ describe('Offline', () => {
     const dexieInstance = getMockDexieInstanceAllSuccess()
 
     // make sure there is a collect record to edit in dexie
-    await dexieInstance.collectRecords.put(mockMermaidData.collectRecords[1])
+    await dexieInstance.collect_records.put(mockMermaidData.collectRecords[1])
 
     renderAuthenticatedOffline(<App dexieInstance={dexieInstance} />, {
       initialEntries: ['/projects/fakewhatever/collecting/fishbelt/2'],
+      dexieInstance,
     })
 
     // make an unsaved change

--- a/src/App/integrationTests/fishBelt/App.fishBeltDelete2.test.js
+++ b/src/App/integrationTests/fishBelt/App.fishBeltDelete2.test.js
@@ -15,10 +15,11 @@ describe('Offline', () => {
     const dexieInstance = getMockDexieInstanceAllSuccess()
 
     // make sure there is a collect record to edit in dexie
-    await dexieInstance.collectRecords.put(mockMermaidData.collectRecords[1])
+    await dexieInstance.collect_records.put(mockMermaidData.collectRecords[1])
 
     renderAuthenticatedOffline(<App dexieInstance={dexieInstance} />, {
       initialEntries: ['/projects/fakewhatever/collecting/fishbelt/2'],
+      dexieInstance,
     })
 
     userEvent.click(await screen.findByText('Delete Record'))
@@ -51,10 +52,11 @@ describe('Offline', () => {
     const dexieInstance = getMockDexieInstanceAllSuccess()
 
     // make sure there is a collect record to edit in dexie
-    await dexieInstance.collectRecords.put(mockMermaidData.collectRecords[1])
+    await dexieInstance.collect_records.put(mockMermaidData.collectRecords[1])
 
     renderAuthenticatedOffline(<App dexieInstance={dexieInstance} />, {
       initialEntries: ['/projects/fakewhatever/collecting/fishbelt/2'],
+      dexieInstance,
     })
 
     // make an unsaved change

--- a/src/App/integrationTests/fishBelt/App.fishBeltNewSpecies.test.js
+++ b/src/App/integrationTests/fishBelt/App.fishBeltNewSpecies.test.js
@@ -5,7 +5,6 @@ import userEvent from '@testing-library/user-event'
 import {
   renderAuthenticatedOnline,
   screen,
-  waitFor,
   waitForElementToBeRemoved,
   within,
 } from '../../../testUtilities/testingLibraryWithHelpers'
@@ -27,12 +26,6 @@ test('Fishbelt observations add new species - filling out new species form adds 
   const observationsTable = (
     await within(fishbeltForm).findAllByRole('table')
   )[0]
-
-  await waitFor(() =>
-    expect(
-      screen.queryAllByLabelText('fish name loading indicator').length,
-    ).toEqual(0),
-  )
 
   const firstFishNameInput = within(observationsTable).getByDisplayValue(
     'Lethrinus rubrioperculatus',
@@ -105,7 +98,7 @@ test('Fishbelt observations add new species - filling out new species form adds 
 
   expect(proposedSpeciesSavedToast).toBeInTheDocument()
 
-  const updatedSpeciesInOfflineStorage = await dexieInstance.fishSpecies.toArray()
+  const updatedSpeciesInOfflineStorage = await dexieInstance.fish_species.toArray()
   const nameOfLastSpeciesInOfflineStorage =
     updatedSpeciesInOfflineStorage[updatedSpeciesInOfflineStorage.length - 1]
       .display_name
@@ -129,15 +122,9 @@ test('Fishbelt observations add new species - proposing new species that already
     await within(fishbeltForm).findAllByRole('table')
   )[0]
 
-  await waitFor(() =>
-    expect(
-      screen.queryAllByLabelText('fish name loading indicator').length,
-    ).toEqual(0),
-  )
-
   // need to wait until app loaded and offline storage hydration before getting species count
   const speciesInOfflineStorageCount = (
-    await dexieInstance.fishSpecies.toArray()
+    await dexieInstance.fish_species.toArray()
   ).length
 
   expect(speciesInOfflineStorageCount).toEqual(4)
@@ -203,7 +190,7 @@ test('Fishbelt observations add new species - proposing new species that already
   expect(proposedSpeciesIsDuplicateToast).toBeInTheDocument()
 
   const speciesInOfflineStorageCountAfterRedundantNewSpeciesSubmit = (
-    await dexieInstance.fishSpecies.toArray()
+    await dexieInstance.fish_species.toArray()
   ).length
 
   const isSpeciesInOfflineStorageUnchanged =

--- a/src/App/integrationTests/fishBelt/App.fishBeltUpdate.test.js
+++ b/src/App/integrationTests/fishBelt/App.fishBeltUpdate.test.js
@@ -15,10 +15,11 @@ describe('Offline', () => {
     const dexieInstance = getMockDexieInstanceAllSuccess()
 
     // make sure there is a collect record to edit in dexie
-    await dexieInstance.collectRecords.put(mockMermaidData.collectRecords[1])
+    await dexieInstance.collect_records.put(mockMermaidData.collectRecords[1])
 
     renderAuthenticatedOffline(<App dexieInstance={dexieInstance} />, {
       initialEntries: ['/projects/fakewhatever/collecting/fishbelt/2'],
+      dexieInstance,
     })
 
     // make a change
@@ -56,10 +57,11 @@ describe('Offline', () => {
     const dexieInstance = getMockDexieInstanceAllSuccess()
 
     // make sure there is a collect record to edit in dexie
-    await dexieInstance.collectRecords.put(mockMermaidData.collectRecords[1])
+    await dexieInstance.collect_records.put(mockMermaidData.collectRecords[1])
 
     renderAuthenticatedOffline(<App dexieInstance={dexieInstance} />, {
       initialEntries: ['/projects/fakewhatever/collecting/fishbelt/2'],
+      dexieInstance,
     })
 
     // test all observers format too
@@ -102,7 +104,7 @@ describe('Offline', () => {
     )
 
     expect(await screen.findByText('Collect record saved.'))
-    const savedCollectRecord = await dexieInstance.collectRecords.toArray()
+    const savedCollectRecord = await dexieInstance.collect_records.toArray()
     const newObservation = savedCollectRecord[0].data.obs_belt_fishes[3]
 
     expect(newObservation.fish_attribute).toEqual(
@@ -115,10 +117,11 @@ describe('Offline', () => {
     const dexieInstance = getMockDexieInstanceAllSuccess()
 
     // make sure there is a collect record to edit in dexie
-    await dexieInstance.collectRecords.put(mockMermaidData.collectRecords[1])
+    await dexieInstance.collect_records.put(mockMermaidData.collectRecords[1])
 
     renderAuthenticatedOffline(<App dexieInstance={dexieInstance} />, {
       initialEntries: ['/projects/fakewhatever/collecting/fishbelt/2'],
+      dexieInstance,
     })
 
     // test all observers format too
@@ -153,7 +156,7 @@ describe('Offline', () => {
     )
 
     expect(await screen.findByText('Collect record saved.'))
-    const savedCollectRecord = await dexieInstance.collectRecords.toArray()
+    const savedCollectRecord = await dexieInstance.collect_records.toArray()
     const newObservation = savedCollectRecord[0].data.obs_belt_fishes[3]
 
     expect(newObservation.size).toEqual(50367)
@@ -162,13 +165,14 @@ describe('Offline', () => {
     const dexieInstance = getMockDexieInstanceAllSuccess()
 
     // make sure there is a collect record to edit in dexie
-    await dexieInstance.collectRecords.put(mockMermaidData.collectRecords[1])
+    await dexieInstance.collect_records.put(mockMermaidData.collectRecords[1])
 
     // make sure the next save will fail
-    dexieInstance.collectRecords.put = jest.fn().mockRejectedValueOnce()
+    dexieInstance.collect_records.put = jest.fn().mockRejectedValueOnce()
 
     renderAuthenticatedOffline(<App dexieInstance={dexieInstance} />, {
       initialEntries: ['/projects/fakewhatever/collecting/fishbelt/2'],
+      dexieInstance,
     })
 
     // make an unsaved change

--- a/src/App/mermaidData/ApiSync/ApiSync.js
+++ b/src/App/mermaidData/ApiSync/ApiSync.js
@@ -37,7 +37,7 @@ const ApiSync = class {
         collect_records: {
           project: projectId,
           profile: profileId,
-          last_revision: lastRevisionNumbersPulled?.collectRecords ?? null,
+          last_revision: lastRevisionNumbersPulled?.collect_records ?? null,
         },
       })
       .then(async (response) => {
@@ -52,13 +52,13 @@ const ApiSync = class {
 
         await this._dexieInstance.transaction(
           'rw',
-          this._dexieInstance.collectRecords,
+          this._dexieInstance.collect_records,
           () => {
             collectRecordUpdates.forEach((updatedRecord) => {
-              this._dexieInstance.collectRecords.put(updatedRecord)
+              this._dexieInstance.collect_records.put(updatedRecord)
             })
             collectRecordDeletes.forEach(({ id }) => {
-              this._dexieInstance.collectRecords.delete(id)
+              this._dexieInstance.collect_records.delete(id)
             })
           },
         )

--- a/src/App/mermaidData/ApiSync/ApiSync.test.js
+++ b/src/App/mermaidData/ApiSync/ApiSync.test.js
@@ -94,12 +94,12 @@ test('pullChangeWithChoices updates IDB with API data', async () => {
   })
 
   // add records to IDB that will be updated/deleted with mock api response
-  await dexieInstance.transaction('rw', dexieInstance.collectRecords, () => {
-    dexieInstance.collectRecords.put({
+  await dexieInstance.transaction('rw', dexieInstance.collect_records, () => {
+    dexieInstance.collect_records.put({
       ...mockMermaidData.collectRecords[1],
       somePropertyThatWillBeWipedOutByTheVersionOnTheApi: 'So long, farewell',
     })
-    dexieInstance.collectRecords.put(mockMermaidData.collectRecords[0])
+    dexieInstance.collect_records.put(mockMermaidData.collectRecords[0])
   })
 
   mockMermaidApiAllSuccessful.use(
@@ -120,7 +120,7 @@ test('pullChangeWithChoices updates IDB with API data', async () => {
   await apiSync
     .pullApiDataMinimal({ profileId: '1', projectId: '1' })
     .then(async () => {
-      const collectRecordsStored = await dexieInstance.collectRecords.toArray()
+      const collectRecordsStored = await dexieInstance.collect_records.toArray()
 
       expect(
         collectRecordsStored[0]

--- a/src/App/mermaidData/databaseSwitchboard/CollectRecordsMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/CollectRecordsMixin.js
@@ -128,7 +128,7 @@ const CollectRecordsMixin = (Base) =>
 
       if (this._isOnlineAuthenticatedAndReady) {
         // put it in IDB just in case the network craps out before the API can return
-        await this._dexieInstance.collectRecords.put(recordToSubmit)
+        await this._dexieInstance.collect_records.put(recordToSubmit)
 
         return this._authenticatedAxios
           .post(
@@ -166,7 +166,7 @@ const CollectRecordsMixin = (Base) =>
           })
       }
       if (this._isOfflineAuthenticatedAndReady) {
-        return this._dexieInstance.collectRecords
+        return this._dexieInstance.collect_records
           .put(recordToSubmit)
           .then(() => recordToSubmit)
       }
@@ -183,7 +183,7 @@ const CollectRecordsMixin = (Base) =>
       }
 
       if (this._isOfflineAuthenticatedAndReady) {
-        return this._dexieInstance.collectRecords.get(id)
+        return this._dexieInstance.collect_records.get(id)
       }
 
       return Promise.reject(this._notAuthenticatedAndReadyError)
@@ -211,7 +211,7 @@ const CollectRecordsMixin = (Base) =>
         this._isOnlineAuthenticatedAndReady
       ) {
         // put it in IDB just in case the network craps out before the API can return
-        await this._dexieInstance.collectRecords.put(recordMarkedToBeDeleted)
+        await this._dexieInstance.collect_records.put(recordMarkedToBeDeleted)
 
         return this._authenticatedAxios
           .post(
@@ -254,14 +254,14 @@ const CollectRecordsMixin = (Base) =>
         hasCorrespondingRecordInTheApi &&
         this._isOfflineAuthenticatedAndReady
       ) {
-        return this._dexieInstance.collectRecords.put(recordMarkedToBeDeleted)
+        return this._dexieInstance.collect_records.put(recordMarkedToBeDeleted)
       }
       if (
         !hasCorrespondingRecordInTheApi &&
         (this._isOnlineAuthenticatedAndReady ||
           this._isOfflineAuthenticatedAndReady)
       ) {
-        return this._dexieInstance.collectRecords.delete(record.id)
+        return this._dexieInstance.collect_records.delete(record.id)
       }
 
       return Promise.reject(this._notAuthenticatedAndReadyError)
@@ -281,7 +281,7 @@ const CollectRecordsMixin = (Base) =>
 
     getCollectRecords = () => {
       if (this._isAuthenticatedAndReady) {
-        return this._dexieInstance.collectRecords.toArray()
+        return this._dexieInstance.collect_records.toArray()
       }
 
       return Promise.reject(this._notAuthenticatedAndReadyError)

--- a/src/App/mermaidData/databaseSwitchboard/FishNamesMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/FishNamesMixin.js
@@ -5,7 +5,7 @@ const FishNameMixin = (Base) =>
   class extends Base {
     getFishSpecies = () => {
       if (this._isAuthenticatedAndReady) {
-        return this._dexieInstance.fishSpecies.toArray()
+        return this._dexieInstance.fish_species.toArray()
       }
 
       return Promise.reject(this._notAuthenticatedAndReadyError)
@@ -43,7 +43,7 @@ const FishNameMixin = (Base) =>
         genus: genusId,
       }
 
-      return this._dexieInstance.fishSpecies
+      return this._dexieInstance.fish_species
         .put(newFishObject)
         .then(() => newFishObject)
     }

--- a/src/App/mermaidData/databaseSwitchboard/tests/deleteFishbeltOffline.DatabaseSwitchboard.test.js
+++ b/src/App/mermaidData/databaseSwitchboard/tests/deleteFishbeltOffline.DatabaseSwitchboard.test.js
@@ -32,7 +32,7 @@ describe('Offline delete fishbelt', () => {
     }
 
     // save a record in IDB so we can delete it
-    await dbInstanceOffline.dexieInstance.collectRecords.put(
+    await dbInstanceOffline.dexieInstance.collect_records.put(
       fishBeltToBeDeleted,
     )
 
@@ -56,7 +56,7 @@ describe('Offline delete fishbelt', () => {
     }
 
     // save a record in IDB so we can delete it
-    await dbInstanceOffline.dexieInstance.collectRecords.put(
+    await dbInstanceOffline.dexieInstance.collect_records.put(
       fishBeltToBeDeleted,
     )
 

--- a/src/App/mermaidData/databaseSwitchboard/tests/deleteFishbeltOnline.DatabaseSwitchboard.test.js
+++ b/src/App/mermaidData/databaseSwitchboard/tests/deleteFishbeltOnline.DatabaseSwitchboard.test.js
@@ -41,7 +41,7 @@ test('deleteFishBelt online deletes the IDB record if there is no corresponding 
     randomUnexpectedProperty: 'whatever',
   }
 
-  await dbInstance.dexieInstance.collectRecords.put(fishBeltToBeDeleted)
+  await dbInstance.dexieInstance.collect_records.put(fishBeltToBeDeleted)
 
   await dbInstance.deleteFishBelt({
     record: fishBeltToBeDeleted, // doesnt have a  _last_revision_num property, which means the API call get skipped
@@ -50,7 +50,7 @@ test('deleteFishBelt online deletes the IDB record if there is no corresponding 
   })
 
   expect(
-    await dbInstance.dexieInstance.collectRecords.get('foo'),
+    await dbInstance.dexieInstance.collect_records.get('foo'),
   ).toBeUndefined()
 })
 test('deleteFishBelt online deletes the record if there is a corresponding copy on the server', async () => {
@@ -103,7 +103,7 @@ test('deleteFishBelt online deletes the record if there is a corresponding copy 
   const dbInstance = getDatabaseSwitchboardInstanceAuthenticatedOnlineDexieSuccess()
 
   // save a record in IDB so we can delete it
-  await dbInstance.dexieInstance.collectRecords.put(fishBeltToBeDeleted)
+  await dbInstance.dexieInstance.collect_records.put(fishBeltToBeDeleted)
 
   const serverResponse = await dbInstance.deleteFishBelt({
     record: fishBeltToBeDeleted,
@@ -112,7 +112,7 @@ test('deleteFishBelt online deletes the record if there is a corresponding copy 
   })
 
   expect(
-    await dbInstance.dexieInstance.collectRecords.get('foo'),
+    await dbInstance.dexieInstance.collect_records.get('foo'),
   ).toBeUndefined()
   expect(serverResponse.data.proofOfServerCall).toBeTruthy()
 })
@@ -152,7 +152,7 @@ test('deleteFishBelt online returns a rejected promise if the status code from t
   }
 
   // save a record in IDB so we can delete it
-  await dbInstance.dexieInstance.collectRecords.put(fishBeltToBeDeleted)
+  await dbInstance.dexieInstance.collect_records.put(fishBeltToBeDeleted)
 
   await dbInstance
     .deleteFishBelt({
@@ -191,7 +191,7 @@ test('deleteFishBelt online marks a record in indexedDB with _deleted in the cas
   }
 
   // save a record in IDB so we can delete it
-  await dbInstance.dexieInstance.collectRecords.put(fishBeltToBeDeleted)
+  await dbInstance.dexieInstance.collect_records.put(fishBeltToBeDeleted)
 
   await dbInstance
     .deleteFishBelt({
@@ -205,6 +205,6 @@ test('deleteFishBelt online marks a record in indexedDB with _deleted in the cas
     .catch((error) => expect(error.message).toEqual('Network Error'))
 
   expect(
-    (await dbInstance.dexieInstance.collectRecords.get('foo'))._deleted,
+    (await dbInstance.dexieInstance.collect_records.get('foo'))._deleted,
   ).toBeTruthy()
 })

--- a/src/App/mermaidData/databaseSwitchboard/tests/saveFishbeltOnline.DatabaseSwitchboard.test.js
+++ b/src/App/mermaidData/databaseSwitchboard/tests/saveFishbeltOnline.DatabaseSwitchboard.test.js
@@ -153,7 +153,7 @@ test('saveFishBelt online returns a rejected promise if the status code from the
     the db switchboard's getFishBelt would try to hit the real or mocked API
     which is boyond the scope of the test.
      */
-  expect(await dbInstance.dexieInstance.collectRecords.get('foo'))
+  expect(await dbInstance.dexieInstance.collect_records.get('foo'))
 })
 test('saveFishBelt online returns saved record with protocol info automatically included and stores it ', async () => {
   const dbInstance = getDatabaseSwitchboardInstanceAuthenticatedOnlineDexieSuccess()
@@ -213,7 +213,7 @@ test('saveFishBelt online returns saved record with protocol info automatically 
     fishBeltToBeSaved.randomUnexpectedProperty,
   )
 
-  const recordStoredInDexie = await dbInstance.dexieInstance.collectRecords.get(
+  const recordStoredInDexie = await dbInstance.dexieInstance.collect_records.get(
     'foo',
   )
 
@@ -261,7 +261,9 @@ test('saveFishBelt online replaces previous fishBelt record with same id (acts l
       the db switchboard's getFishBelt would try to hit the real or mocked API
       which is boyond the scope of the test.
      */
-  const savedFishBelt = await dbInstance.dexieInstance.collectRecords.get('foo')
+  const savedFishBelt = await dbInstance.dexieInstance.collect_records.get(
+    'foo',
+  )
 
   expect(savedFishBelt.data.randomProperty).toEqual(
     replacementFishbelt.data.randomProperty,
@@ -360,7 +362,7 @@ test('saveFishBelt online returns and stores a saved record including existing i
   expect(savedFishBeltResponse.profile).toEqual('1234')
   expect(savedFishBeltResponse.project).toEqual('4321')
 
-  const recordStoredInDexie = await dbInstance.dexieInstance.collectRecords.get(
+  const recordStoredInDexie = await dbInstance.dexieInstance.collect_records.get(
     savedFishBeltResponse.id,
   )
 
@@ -409,7 +411,7 @@ test('saveFishBelt online saves the record in indexeddb in the case of network e
     })
     .catch((error) => expect(error.message).toEqual('Network Error'))
 
-  const recordStoredInDexie = await dbInstance.dexieInstance.collectRecords.get(
+  const recordStoredInDexie = await dbInstance.dexieInstance.collect_records.get(
     'foo',
   )
 

--- a/src/App/mermaidData/dexieInstance.js
+++ b/src/App/mermaidData/dexieInstance.js
@@ -4,13 +4,15 @@ import PropTypes from 'prop-types'
 const dexieInstance = new Dexie('mermaid')
 
 dexieInstance.version(1).stores({
-  currentUser: 'id, first_name, last_name, full_name, email',
-})
-dexieInstance.version(4).stores({
+  benthic_attributes: 'id',
+  choices: 'id',
+  collect_records: 'id',
   currentUser: 'id',
-  collectRecords: 'id',
+  fish_families: 'id',
+  fish_genera: 'id',
+  fish_species: 'id',
   lastRevisionNumbersPulled: 'id',
-  fishSpecies: 'id',
+  projects: 'id',
 })
 
 // If This were TypeScript, types would be easy to obtain for Dexie

--- a/src/testUtilities/initiallyHydrateOfflineStorageWithMockData.js
+++ b/src/testUtilities/initiallyHydrateOfflineStorageWithMockData.js
@@ -3,15 +3,15 @@ import mockMermaidData from './mockMermaidData'
 export const initiallyHydrateOfflineStorageWithMockData = (dexieInstance) => {
   return dexieInstance.transaction(
     'rw',
-    dexieInstance.fishSpecies,
-    dexieInstance.collectRecords,
+    dexieInstance.fish_species,
+    dexieInstance.collect_records,
     async () => {
       mockMermaidData.fishSpecies.forEach((specie) => {
-        dexieInstance.fishSpecies.put(specie)
+        dexieInstance.fish_species.put(specie)
       })
 
       mockMermaidData.collectRecords.forEach((record) => {
-        dexieInstance.collectRecords.put(record)
+        dexieInstance.collect_records.put(record)
       })
     },
   )

--- a/src/testUtilities/mockDexie.js
+++ b/src/testUtilities/mockDexie.js
@@ -7,10 +7,15 @@ const getMockDexieInstanceAllSuccess = () => {
   })
 
   dexieInstance.version(1).stores({
+    benthic_attributes: 'id',
+    choices: 'id',
+    collect_records: 'id',
     currentUser: 'id',
-    collectRecords: 'id',
+    fish_families: 'id',
+    fish_genera: 'id',
+    fish_species: 'id',
     lastRevisionNumbersPulled: 'id',
-    fishSpecies: 'id',
+    projects: 'id',
   })
 
   dexieInstance.currentUser

--- a/src/testUtilities/mockMermaidApiAllSuccessful.js
+++ b/src/testUtilities/mockMermaidApiAllSuccessful.js
@@ -1,5 +1,6 @@
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
+import mockMermaidData from './mockMermaidData'
 
 const mockMermaidApiAllSuccessful = setupServer(
   rest.get(`${process.env.REACT_APP_MERMAID_API}/me`, (req, res, ctx) => {
@@ -22,6 +23,19 @@ const mockMermaidApiAllSuccessful = setupServer(
     )
 
     const response = { collect_records: collectRecordsWithStatusCodes }
+
+    return res(ctx.json(response))
+  }),
+
+  rest.post(`${process.env.REACT_APP_MERMAID_API}/pull/`, (req, res, ctx) => {
+    const response = {
+      benthic_attributes: { updates: mockMermaidData.benthic_attributes },
+      fish_families: { updates: mockMermaidData.fishFamilies },
+      fish_genera: { updates: mockMermaidData.fishGenera },
+      fish_species: { updates: mockMermaidData.fishSpecies },
+      choices: { updates: mockMermaidData.choices },
+      projects: { updates: mockMermaidData.projects },
+    }
 
     return res(ctx.json(response))
   }),


### PR DESCRIPTION
This diff has a lot of minor refactor of names and tests. 

I also refactored how the last revision numbers are stored (they are numbers which indicate to the API which data needs to be sent back so it doesnt have to send everything back, just updates.

A test flag was built to get past a loading screen ` overrideIsOfflineStorageHydratedWhenTestEnvironmentIsOffline` a nutso long name, but better than `isTest` which I initially had which led me to be super confused by my own code only three days later, and is too generic of a name for such a specific thing.

Main purpose of ticket: have the app hydrate indexeddb with API data on both initial load and all page reloads so that indexed db is our source of truth for mermaid data state.  


