### PR TITLE
[M365] Format FishBelt Value bug before saving to API 

### DIFF
--- a/src/components/pages/collectRecordFormPages/FishBelt/reformatFormValuesIntoFishbeltRecord.js
+++ b/src/components/pages/collectRecordFormPages/FishBelt/reformatFormValuesIntoFishbeltRecord.js
@@ -9,6 +9,20 @@ const reformatObservationsForFishBeltRecord = (observations) =>
     }
   })
 
+const removeEmptyProperty = (formValues) => {
+  const result = []
+
+  for (const [key, value] of Object.entries(formValues)) {
+    if (value !== '') {
+      result.push(key)
+    }
+  }
+
+  return result.reduce((obj, item) => {
+    return { ...obj, [item]: formValues[item] }
+  }, {})
+}
+
 export const reformatFormValuesIntoFishBeltRecord = (
   formikValues,
   observationsValues,
@@ -29,25 +43,29 @@ export const reformatFormValuesIntoFishBeltRecord = (
     width,
   } = formikValues
 
+  const fishBeltTransectData = removeEmptyProperty({
+    depth,
+    label,
+    len_surveyed,
+    number,
+    reef_slope,
+    sample_time,
+    size_bin,
+    width,
+  })
+
+  const sampleEventData = removeEmptyProperty({
+    management,
+    notes,
+    sample_date,
+    site,
+  })
+
   return {
     ...collectRecordBeingEdited,
     data: {
-      fishbelt_transect: {
-        depth,
-        label,
-        len_surveyed,
-        number,
-        reef_slope,
-        sample_time,
-        size_bin,
-        width,
-      },
-      sample_event: {
-        management,
-        notes,
-        sample_date,
-        site,
-      },
+      fishbelt_transect: fishBeltTransectData,
+      sample_event: sampleEventData,
       obs_belt_fishes: reformatObservationsForFishBeltRecord(
         observationsValues,
       ),


### PR DESCRIPTION
This adds the method to prevent all empty values for a Fish Belt object from passing to api => It breaks validation check.
I found this fix based on the "old app" when I execute the Save button in Collect Fish Belt form.
