### PR TITLE
M402 Enable submit when validation succeeds + test

### DIFF
--- a/src/App/integrationTests/fishBelt/App.fishBeltButtonGroup.test.js
+++ b/src/App/integrationTests/fishBelt/App.fishBeltButtonGroup.test.js
@@ -7,6 +7,8 @@ import App from '../../App'
 import { getMockDexieInstanceAllSuccess } from '../../../testUtilities/mockDexie'
 import { initiallyHydrateOfflineStorageWithMockData } from '../../../testUtilities/initiallyHydrateOfflineStorageWithMockData'
 import mockMermaidApiAllSuccessful from '../../../testUtilities/mockMermaidApiAllSuccessful'
+import mockMermaidData from '../../../testUtilities/mockMermaidData'
+import mockFishbeltValidationsObject from '../../../testUtilities/mockFishbeltValidationsObject'
 
 const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 
@@ -42,32 +44,103 @@ describe('Online', () => {
     expect(screen.getByText('Validate', { selector: 'button' })).toBeEnabled()
   })
 
-  test('Edit Fishbelt - Validate button clicked -> send record to validate api endpoint -> Record is failed to validate, and ready to validate again.', async () => {
+  test('Validate fishbelt: fails to validate, shows button able to run validation again.', async () => {
     const dexieInstance = getMockDexieInstanceAllSuccess()
 
     await initiallyHydrateOfflineStorageWithMockData(dexieInstance)
 
     renderAuthenticatedOnline(<App dexieInstance={dexieInstance} />, {
-      initialEntries: ['/projects/5/collecting/fishbelt/2'],
+      initialEntries: ['/projects/5/collecting/fishbelt/1'],
       dexieInstance,
     })
 
     userEvent.click(await screen.findByText('Validate', { selector: 'button' }))
 
     mockMermaidApiAllSuccessful.use(
-      rest.post(`${apiBaseUrl}/projects/5/collecting/validate`, (req, res, ctx) => {
-        const project = req.url.searchParams('projectId')
+      rest.post(`${apiBaseUrl}/projects/5/collectrecords/validate/`, (req, res, ctx) => {
+        return res(ctx.status(200))
+      }),
 
-        if (!project) {
-          return res.once(ctx.status(404))
+      // append the validated data on the pull response, because that is what the UI uses to update itself
+      rest.post(`${apiBaseUrl}/pull/`, (req, res, ctx) => {
+        const collectRecordWithValidation = {
+          ...mockMermaidData.collect_records[0],
+          validations: mockFishbeltValidationsObject, // fails validation
         }
 
-        return res(ctx.status(200))
+        const response = {
+          benthic_attributes: { updates: mockMermaidData.benthic_attributes },
+          choices: { updates: mockMermaidData.choices },
+          collect_records: { updates: [collectRecordWithValidation] },
+          fish_families: { updates: mockMermaidData.fish_families },
+          fish_genera: { updates: mockMermaidData.fish_genera },
+          fish_species: { updates: mockMermaidData.fish_species },
+          project_managements: { updates: mockMermaidData.project_managements },
+          project_profiles: { updates: mockMermaidData.project_profiles },
+          project_sites: { updates: mockMermaidData.project_sites },
+          projects: { updates: mockMermaidData.projects },
+        }
+
+        return res(ctx.json(response))
       }),
     )
 
     expect(await screen.findByText('Validating', { selector: 'button' }))
 
     expect(await screen.findByText('Validate', { selector: 'button' }))
+    expect(
+      screen.queryByText('Validation is currently unavailable for this record.'),
+    ).not.toBeInTheDocument()
+  })
+
+  test('Validate fishbelt: validation passes, shows validate button disabled with proper text, submit is enabled.', async () => {
+    const dexieInstance = getMockDexieInstanceAllSuccess()
+
+    await initiallyHydrateOfflineStorageWithMockData(dexieInstance)
+
+    renderAuthenticatedOnline(<App dexieInstance={dexieInstance} />, {
+      initialEntries: ['/projects/5/collecting/fishbelt/1'],
+      dexieInstance,
+    })
+
+    userEvent.click(await screen.findByText('Validate', { selector: 'button' }))
+
+    mockMermaidApiAllSuccessful.use(
+      rest.post(`${apiBaseUrl}/projects/5/collectrecords/validate/`, (req, res, ctx) => {
+        return res(ctx.status(200))
+      }),
+
+      // append the validated data on the pull response, because that is what the UI uses to update itself
+      rest.post(`${apiBaseUrl}/pull/`, (req, res, ctx) => {
+        const collectRecordWithValidation = {
+          ...mockMermaidData.collect_records[0],
+          validations: { status: 'ok' },
+        }
+
+        const response = {
+          benthic_attributes: { updates: mockMermaidData.benthic_attributes },
+          choices: { updates: mockMermaidData.choices },
+          collect_records: { updates: [collectRecordWithValidation] },
+          fish_families: { updates: mockMermaidData.fish_families },
+          fish_genera: { updates: mockMermaidData.fish_genera },
+          fish_species: { updates: mockMermaidData.fish_species },
+          project_managements: { updates: mockMermaidData.project_managements },
+          project_profiles: { updates: mockMermaidData.project_profiles },
+          project_sites: { updates: mockMermaidData.project_sites },
+          projects: { updates: mockMermaidData.projects },
+        }
+
+        return res(ctx.json(response))
+      }),
+    )
+
+    expect(await screen.findByText('Validating', { selector: 'button' }))
+
+    expect(await screen.findByText('Validated', { selector: 'button' }))
+    expect(
+      screen.queryByText('Validation is currently unavailable for this record.'),
+    ).not.toBeInTheDocument()
+
+    expect(await screen.findByText('Submit', { selector: 'button' })).toBeEnabled()
   })
 })

--- a/src/App/integrationTests/fishBelt/App.fishBeltValidationDisplay.test.js
+++ b/src/App/integrationTests/fishBelt/App.fishBeltValidationDisplay.test.js
@@ -559,7 +559,7 @@ test('Validating an empty collect record, and then editing an input with errors 
   expect(
     within(screen.getByLabelText('Observations')).getByText('observation error'),
   ).toBeInTheDocument()
-}, 35000)
+}, 45000)
 
 test('Fishbelt validations will show passed input validations', async () => {
   const dexieInstance = getMockDexieInstanceAllSuccess()

--- a/src/App/integrationTests/fishBelt/App.fishBeltValidationIgnoring.test.js
+++ b/src/App/integrationTests/fishBelt/App.fishBeltValidationIgnoring.test.js
@@ -362,7 +362,7 @@ test('Validation: user can dismiss non-observations input warnings ', async () =
   )
   expect(within(observersRow).queryByText('secondWarning')).not.toBeInTheDocument()
   expect(within(observersRow).getByText('Ignored')).toBeInTheDocument()
-}, 35000)
+}, 45000)
 
 test('Validation: user can dismiss record-level warnings ', async () => {
   const dexieInstance = getMockDexieInstanceAllSuccess()
@@ -899,7 +899,7 @@ test('user can reset dismissed non-observation input warnings', async () => {
   expect(within(observersRow).queryByText('firstWarning')).not.toBeInTheDocument()
   expect(within(observersRow).queryByText('secondWarning')).not.toBeInTheDocument()
   expect(within(observersRow).queryByLabelText('Passed validation')).not.toBeInTheDocument()
-}, 40000)
+}, 45000)
 
 test('Validation: user can reset ignored observation warnings ', async () => {
   const dexieInstance = getMockDexieInstanceAllSuccess()
@@ -984,7 +984,7 @@ test('Validation: user can reset ignored observation warnings ', async () => {
   expect(within(observationsTable).queryByText('firstWarning')).not.toBeInTheDocument()
   expect(within(observationsTable).queryByText('secondWarning')).not.toBeInTheDocument()
   expect(within(observationsTable).queryByLabelText('Passed validation')).not.toBeInTheDocument()
-})
+}, 35000)
 
 test('user can reset dismissed record-level warnings', async () => {
   const dexieInstance = getMockDexieInstanceAllSuccess()

--- a/src/App/mermaidData/databaseSwitchboard/CollectRecordsMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/CollectRecordsMixin.js
@@ -143,8 +143,9 @@ const CollectRecordsMixin = (Base) =>
           )
           .then((response) => {
             const [recordResponseFromApiPush] = response.data.collect_records
-            const isRecordStatusCodeSuccessful =
-              this._getIsResponseStatusSuccessful(recordResponseFromApiPush)
+            const isRecordStatusCodeSuccessful = this._isStatusCodeSuccessful(
+              recordResponseFromApiPush.status_code,
+            )
 
             if (isRecordStatusCodeSuccessful) {
               // do a pull of data related to collect records
@@ -205,8 +206,9 @@ const CollectRecordsMixin = (Base) =>
           )
           .then((apiPushResponse) => {
             const recordReturnedFromApiPush = apiPushResponse.data.collect_records[0]
-            const isRecordStatusCodeSuccessful =
-              this._getIsResponseStatusSuccessful(recordReturnedFromApiPush)
+            const isRecordStatusCodeSuccessful = this._isStatusCodeSuccessful(
+              recordReturnedFromApiPush.status_code,
+            )
 
             if (isRecordStatusCodeSuccessful) {
               // do a pull of data related to collect records
@@ -248,9 +250,9 @@ const CollectRecordsMixin = (Base) =>
             version: '2',
           })
           .then((response) => {
-            const isRecordStatusCodeSuccessful = this._getIsResponseStatusSuccessful(response)
+            const isApiResponseStatusSuccessful = this._isStatusCodeSuccessful(response.status)
 
-            if (isRecordStatusCodeSuccessful) {
+            if (isApiResponseStatusSuccessful) {
               return this._apiSyncInstance
                 .pushThenPullEverythingForAProjectButChoices(projectId)
                 .then((_dataSetsReturnedFromApiPull) => {
@@ -260,11 +262,7 @@ const CollectRecordsMixin = (Base) =>
                 })
             }
 
-            return Promise.reject(
-              new Error(
-                'the API record returned from validateFishBelt doesnt have a successful status code',
-              ),
-            )
+            return Promise.reject(new Error('The API status is unsuccessful'))
           })
       }
 

--- a/src/App/mermaidData/databaseSwitchboard/DatabaseSwitchboardState.js
+++ b/src/App/mermaidData/databaseSwitchboard/DatabaseSwitchboardState.js
@@ -8,6 +8,8 @@ const DatabaseSwitchboardState = class {
 
   _authenticatedAxios
 
+  _dexieInstance
+
   _isAuthenticatedAndReady
 
   _isOfflineAuthenticatedAndReady
@@ -16,7 +18,9 @@ const DatabaseSwitchboardState = class {
 
   _isOnlineAuthenticatedAndReady
 
-  _dexieInstance
+  _isStatusCodeSuccessful = function _isStatusCodeSuccessful(statusValue) {
+    return statusValue >= 200 && statusValue < 300
+  }
 
   _notAuthenticatedAndReadyError = new Error(language.error.appNotAuthenticatedOrReady)
 
@@ -25,8 +29,6 @@ const DatabaseSwitchboardState = class {
   _operationMissingParameterError = new Error(
     "This operation requires a parameter that isn't being supplied",
   )
-
-  _getIsResponseStatusSuccessful
 
   constructor({
     apiBaseUrl,
@@ -53,12 +55,6 @@ const DatabaseSwitchboardState = class {
     this._isOnlineAuthenticatedAndLoading =
       this._isAuthenticatedAndReady && isAppOnline && !this._authenticatedAxios
     this._isOfflineAuthenticatedAndReady = this._isAuthenticatedAndReady && !isAppOnline
-  }
-
-  _getIsResponseStatusSuccessful = recordResponseFromServer => {
-    const statusCode = recordResponseFromServer.status_code || recordResponseFromServer.status
-
-    return statusCode >= 200 && statusCode < 300
   }
 }
 

--- a/src/App/mermaidData/databaseSwitchboard/ProjectsMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/ProjectsMixin.js
@@ -75,9 +75,9 @@ const ProjectsMixin = (Base) =>
             email,
           })
           .then((response) => {
-            const isRecordStatusCodeSuccessful = this._getIsResponseStatusSuccessful(response)
+            const isApiResponseSuccessful = this._isStatusCodeSuccessful(response.status)
 
-            if (isRecordStatusCodeSuccessful) {
+            if (isApiResponseSuccessful) {
               return this._apiSyncInstance
                 .pushThenPullEverythingForAProjectButChoices(projectId)
                 .then(() => {
@@ -85,11 +85,7 @@ const ProjectsMixin = (Base) =>
                 })
             }
 
-            return Promise.reject(
-              new Error(
-                `the API record returned from Add User doesn't have a successful status code`,
-              ),
-            )
+            return Promise.reject(new Error(`'The API status is unsuccessful',`))
           })
       }
 
@@ -108,9 +104,9 @@ const ProjectsMixin = (Base) =>
             to_profile: toProfileId,
           })
           .then((response) => {
-            const isRecordStatusCodeSuccessful = this._getIsResponseStatusSuccessful(response)
+            const isApiResponseSuccessful = this._isStatusCodeSuccessful(response.status)
 
-            if (isRecordStatusCodeSuccessful) {
+            if (isApiResponseSuccessful) {
               return this._apiSyncInstance
                 .pushThenPullEverythingForAProjectButChoices(projectId)
                 .then(() => {
@@ -118,11 +114,7 @@ const ProjectsMixin = (Base) =>
                 })
             }
 
-            return Promise.reject(
-              new Error(
-                `the API record returned from Transfer Sample Units doesn't have a successful status code`,
-              ),
-            )
+            return Promise.reject(new Error(`'The API status is unsuccessful',`))
           })
       }
 

--- a/src/App/mermaidData/databaseSwitchboard/SitesMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/SitesMixin.js
@@ -91,8 +91,9 @@ const SitesMixin = (Base) =>
           .then((response) => {
             const [siteResponseFromApiPush] = response.data.project_sites
 
-            const isSiteStatusCodeSuccessful =
-              this._getIsResponseStatusSuccessful(siteResponseFromApiPush)
+            const isSiteStatusCodeSuccessful = this._isStatusCodeSuccessful(
+              siteResponseFromApiPush.status_code,
+            )
 
             if (isSiteStatusCodeSuccessful) {
               // do a pull of data related to collect records

--- a/src/components/pages/collectRecordFormPages/SaveValidateSubmitButtonGroup/SaveValidateSubmitButtonGroup.js
+++ b/src/components/pages/collectRecordFormPages/SaveValidateSubmitButtonGroup/SaveValidateSubmitButtonGroup.js
@@ -55,8 +55,15 @@ const SaveValidateSubmitButtonGroup = ({
 
   const isValidateDisabled =
     saveButtonState === possibleCollectButtonGroupStates.unsaved ||
+    saveButtonState === possibleCollectButtonGroupStates.saving ||
     validateButtonState === possibleCollectButtonGroupStates.validated ||
     validateButtonState === possibleCollectButtonGroupStates.validating
+
+  const isSubmitDisabled =
+    validateButtonState === possibleCollectButtonGroupStates.validating ||
+    validateButtonState === possibleCollectButtonGroupStates.validatable ||
+    saveButtonState === possibleCollectButtonGroupStates.unsaved ||
+    saveButtonState === possibleCollectButtonGroupStates.saving
 
   const saveButton = (
     <ButtonCallout type="button" disabled={isSaveDisabled} onClick={onSave}>
@@ -73,7 +80,7 @@ const SaveValidateSubmitButtonGroup = ({
   )
 
   const submitButton = (
-    <ButtonCallout disabled={saveButtonState !== possibleCollectButtonGroupStates.validated}>
+    <ButtonCallout disabled={isSubmitDisabled}>
       <IconUpload />
       Submit
     </ButtonCallout>


### PR DESCRIPTION
Updated fishbelt submit button to be enabled upon successful validation 

Also found an invisible bug, fixed it by making utility function do less and updating usage (`isStatusCodeSuccessful`)

