### PR TITLE
[M441] Display site page map only when online

### DIFF
--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -163,7 +163,6 @@ const Site = () => {
               />
               {isAppOnline &&
                 <MermaidMap
-                  data-testid="map"
                   formLatitudeValue={formik.getFieldProps('latitude').value}
                   formLongitudeValue={formik.getFieldProps('longitude').value}
                   handleLatitudeChange={handleLatitudeChange}


### PR DESCRIPTION
Bug fix for: https://trello.com/c/39neG2UZ/441-hide-site-map-when-offline