### PR TITLE
[M541] Prevent users refresh when role changed

### DIFF
--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -323,8 +323,6 @@ const Users = ({ currentUser }) => {
 
   const handleRoleChange = useCallback(
     ({ event, projectProfileId }) => {
-      setIsLoading(true)
-
       const roleCode = parseInt(event.target.value, 10)
 
       databaseSwitchboardInstance
@@ -342,7 +340,6 @@ const Users = ({ currentUser }) => {
           )
 
           setObserverProfiles(updatedObserverProfiles)
-          setIsLoading(false)
           toast.success(
             language.success.getUserRoleChangeSuccessMessage({
               userName: editedUserName,


### PR DESCRIPTION
Remove `setIsLoading()` calls in  `handleRoleChange`.
Toasts exist which provide adequate feedback. The requests take place in the background.