### PR TITLE
[M564] Disable fish belt observations table sort

### DIFF
--- a/src/components/generic/Table/table.js
+++ b/src/components/generic/Table/table.js
@@ -66,7 +66,7 @@ export const Th = styled.th(
     vertical-align: top;
     &::after {
       content: ' \u25b2';
-      color: ${!props.isSortingDisabled
+      color: ${props.isSortingEnabled
         ? theme.color.secondaryDisabledColor
         : theme.color.white
       };
@@ -80,6 +80,13 @@ export const Th = styled.th(
     )}
   `,
 )
+Th.defaultProps = {
+  isSortedDescending: false,
+  isSortingEnabled: false,
+  isMultiSortColumn: false,
+  sortedIndex: -1
+}
+
 export const Td = styled.td(
   (props) => css`
     text-align: ${props.align || 'left'};

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -550,7 +550,7 @@ const Users = ({ currentUser }) => {
                     isSortedDescending={column.isSortedDesc}
                     sortedIndex={column.sortedIndex}
                     isMultiSortColumn={isMultiSortColumn}
-                    isSortingDisabled={column.disableSortBy}
+                    isSortingEnabled={!column.disableSortBy}
                   >
                     {column.render('Header')}
                   </Th>


### PR DESCRIPTION
Change `isSortingDisabled` to `isSortingEnabled` - default column will not display sort arrows.
Add defaultProps to Table's Th styled component.