### PR TITLE
fix: [M607] Sort sample unit form lists

### DIFF
--- a/src/components/ProjectCard/ProjectCard.js
+++ b/src/components/ProjectCard/ProjectCard.js
@@ -10,7 +10,7 @@ import {
   ProjectInfoWrapper,
   ProjectNameWrapper,
 } from './ProjectCard.styles'
-import { pluralize } from '../../library/pluralize'
+import { pluralize } from '../../library/strings/pluralize'
 import { projectPropType } from '../../App/mermaidData/mermaidDataProptypes'
 import { useOnlineStatus } from '../../library/onlineStatusContext'
 import language from '../../language'

--- a/src/components/pages/Projects/Projects.js
+++ b/src/components/pages/Projects/Projects.js
@@ -17,6 +17,7 @@ import { useOnlineStatus } from '../../../library/onlineStatusContext'
 import { getObjectById } from '../../../library/getObjectById'
 import PageNoData from '../PageNoData'
 import useDocumentTitle from '../../../library/useDocumentTitle'
+import { sortArrayByObjectKey } from '../../../library/arrays/sortArrayByObjectKey'
 
 /**
  * All Projects page (lists projects)
@@ -82,17 +83,7 @@ const Projects = ({ apiSyncInstance }) => {
   }
 
   const getSortedProjects = (projectsToSort) => {
-    const sortedProjects = projectsToSort.sort((a, b) => {
-      return a[projectSortKey].toString().localeCompare(b[projectSortKey], 'en', {
-        numeric: true,
-        caseFirst: 'upper',
-      })
-    })
-
-    // Reverse array for descending sort
-    if (!isProjectSortAsc) { return sortedProjects.reverse() }
-
-    return sortedProjects
+    return sortArrayByObjectKey(projectsToSort, projectSortKey, isProjectSortAsc)
   }
 
   const getFilteredSortedProjects = () => {

--- a/src/components/pages/collectRecordFormPages/FishBelt/FishBelt.js
+++ b/src/components/pages/collectRecordFormPages/FishBelt/FishBelt.js
@@ -45,6 +45,7 @@ import useCurrentProjectPath from '../../../../library/useCurrentProjectPath'
 import useIsMounted from '../../../../library/useIsMounted'
 import { getRecordName } from '../../../../library/getRecordName'
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
+import { sortArrayByObjectKey } from '../../../../library/arrays/sortArrayByObjectKey'
 
 /*
   Fishbelt component lets a user edit and delete a record as well as create a new record.
@@ -192,10 +193,10 @@ const FishBelt = ({ isNewRecord }) => {
                   ? getRecordName(collectRecordResponse.data, sitesResponse, 'fishbelt_transect')
                   : { name: 'Fish Belt' }
 
-              setSites(sitesResponse)
-              setManagementRegimes(managementRegimesResponse)
+              setSites(sortArrayByObjectKey(sitesResponse, "name"))
+              setManagementRegimes(sortArrayByObjectKey(managementRegimesResponse, "name"))
               setChoices(choicesResponse)
-              setObserverProfiles(projectProfilesResponse)
+              setObserverProfiles(sortArrayByObjectKey(projectProfilesResponse, "profile_name"))
               setCollectRecordBeingEdited(collectRecordResponse)
               setFishNameConstants(updateFishNameConstants)
               setFishNameOptions(updateFishNameOptions)

--- a/src/library/arrays/sortArrayByObjectKey.js
+++ b/src/library/arrays/sortArrayByObjectKey.js
@@ -1,0 +1,13 @@
+export const sortArrayByObjectKey = (arrayToSort, key, isAsc = true) => {
+  const sorted = arrayToSort.sort((a, b) => {
+    return a[key].toString().localeCompare(b[key], 'en', {
+      numeric: true,
+      caseFirst: 'upper',
+    })
+  })
+
+  // Reverse array for descending sort
+  if (!isAsc) { return sorted.reverse() }
+
+  return sorted
+}

--- a/src/library/numbers/roundToOneDecimal.js
+++ b/src/library/numbers/roundToOneDecimal.js
@@ -1,0 +1,1 @@
+export const roundToOneDecimal = number => (Math.round(number * 10) / 10).toFixed(1)

--- a/src/library/pluralize.js
+++ b/src/library/pluralize.js
@@ -1,7 +1,0 @@
-export const pluralize = (val, singularWord, pluralWord) => {
-  if (val === 1) {
-    return singularWord
-  }
-
-  return pluralWord
-}

--- a/src/library/strings/pluralize.js
+++ b/src/library/strings/pluralize.js
@@ -1,6 +1,6 @@
-export const pluralize = (val, singluar, plural) => {
+export const pluralize = (val, singularWord, plural) => {
   if (val === 1) {
-    return singluar
+    return singularWord
   }
 
   return plural


### PR DESCRIPTION
Sort sites, management regimes and observer profiles.
Create sortArrayByObjectKey function.
Update Projects to use sortArrayByObjectKey.
Remove redundant pluralize function.
Rename `library/numbers` directory for consistency.