### PR TITLE
[M732] Fix bug in BenthicPhotoQuadrat ignoreObservationValidations

### DIFF
--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadrat/BenthicPhotoQuadrat.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadrat/BenthicPhotoQuadrat.js
@@ -427,7 +427,7 @@ const BenthicPhotoQuadrat = ({ isNewRecord }) => {
           })
         })
     },
-    [collectRecordBeingEdited.id, databaseSwitchboardInstance, handleHttpResponseError],
+    [collectRecordBeingEdited, databaseSwitchboardInstance, handleHttpResponseError],
   )
 
   const resetObservationValidations = useCallback(


### PR DESCRIPTION
One of the arguments was passing collectRecordBeingEdited.id but to follow the pattern of Fish belt, the whole object should be passed (collectRecordBeingEdited)

Card: [#M732](https://trello.com/c/vOa811mw/732-pqt-form-causing-fatal-and-silent-error)