### PR TITLE
fix: [M735] Enable project info form save button

### DIFF
--- a/src/components/pages/Admin/Admin.js
+++ b/src/components/pages/Admin/Admin.js
@@ -357,7 +357,8 @@ const Admin = () => {
               <SaveButton
                 formId="project-info-form"
                 saveButtonState={saveButtonState}
-                formik={formik}
+                formHasErrors={!!Object.keys(formik.errors).length}
+                formDirty={formik.dirty}
               />
             )}
           </ContentPageToolbarWrapper>


### PR DESCRIPTION
Fix a regression caused by a change in SaveButton's required properties.
Add formHasErrors and formDirty props to SaveButton in Admin.js.