### PR TITLE
fix: [M735] Delete projects from indexed DB after user is removed

### DIFF
--- a/src/App/mermaidData/pullApiData.js
+++ b/src/App/mermaidData/pullApiData.js
@@ -104,18 +104,15 @@ export const pullApiData = async ({
         // they have been removed.
         if (projectsResponse && apiDataType === 'projects') {
           const projectsResults = projectsResponse.data?.results
-          const indexedDBProjectsNeedToBeDeleted = projectsResults.length > indexedDbProjects.length
 
-          if (indexedDBProjectsNeedToBeDeleted) {
-            // Determine which projects in IndexedDB are not in the /projects API response
-            const deleteProjectIds = indexedDbProjects
-              .filter((indexedDBProject) => !isIndexedDBProjectInProjectResults(indexedDBProject, projectsResults))
-              .map((removedProject) => removedProject.id)
+          // Determine which projects in IndexedDB are not in the /projects API response
+          const deleteProjectIds = indexedDbProjects
+            .filter((indexedDBProject) => !isIndexedDBProjectInProjectResults(indexedDBProject, projectsResults))
+            .map((removedProject) => removedProject.id)
 
-            if (deleteProjectIds.length) {
-              // Delete the projects from IndexedDB as the user has been removed from them
-              dexiePerUserDataInstance.projects.bulkDelete(deleteProjectIds)
-            }
+          if (deleteProjectIds.length) {
+            // Delete the projects from IndexedDB as the user has been removed from them
+            dexiePerUserDataInstance.projects.bulkDelete(deleteProjectIds)
           }
         }
       })


### PR DESCRIPTION
Remove comparison of project array lengths because the logic was incorrect.
Fixing it would still not be ideal because relying on array length differences would not be accurate (e.g. if a user is removed from one project and added to another the lengths would remain the same)