### PR TITLE
Melissa/m843 view submitted photo quadrat

### DIFF
--- a/src/components/pages/submittedRecordPages/SubmittedBenthicPit/SubmittedBenthicPit.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBenthicPit/SubmittedBenthicPit.js
@@ -24,6 +24,7 @@ import { ensureTrailingSlash } from '../../../../library/strings/ensureTrailingS
 import SubmittedBenthicPitInfoTable from './SubmittedBenthicPitInfoTable'
 import SubmittedBenthicPitObservationTable from './SubmittedBenthicPitObservationTable'
 import { getBenthicOptions } from '../../../../library/getOptions'
+import { useHttpResponseErrorHandler } from '../../../../App/HttpResponseErrorHandlerContext'
 
 const SubmittedBenthicPit = () => {
   const currentProjectPath = useCurrentProjectPath()
@@ -35,6 +36,7 @@ const SubmittedBenthicPit = () => {
   const { submittedRecordId, projectId } = useParams()
   const { isSyncInProgress } = useSyncStatus()
   const isMounted = useIsMounted()
+  const handleHttpResponseError = useHttpResponseErrorHandler()
 
   const [sites, setSites] = useState([])
   const [managementRegimes, setManagementRegimes] = useState([])
@@ -92,22 +94,28 @@ const SubmittedBenthicPit = () => {
           },
         )
         .catch((error) => {
-          const errorStatus = error.response?.status
+          handleHttpResponseError({
+            error,
+            callback: () => {
+              const errorStatus = error.response?.status
 
-          if ((errorStatus === 404 || errorStatus === 400) && isMounted.current) {
-            setIdsNotAssociatedWithData([projectId, submittedRecordId])
-            setIsLoading(false)
-          }
-          toast.error(...getToastArguments(language.error.submittedRecordUnavailable))
+              if ((errorStatus === 404 || errorStatus === 400) && isMounted.current) {
+                setIdsNotAssociatedWithData([projectId, submittedRecordId])
+                setIsLoading(false)
+              }
+              toast.error(...getToastArguments(language.error.submittedRecordUnavailable))
+            },
+          })
         })
     }
   }, [
     databaseSwitchboardInstance,
-    isMounted,
-    submittedRecordId,
-    projectId,
+    handleHttpResponseError,
     isAppOnline,
+    isMounted,
     isSyncInProgress,
+    projectId,
+    submittedRecordId,
   ])
 
   const handleMoveToCollect = () => {
@@ -124,9 +132,14 @@ const SubmittedBenthicPit = () => {
           `${ensureTrailingSlash(currentProjectPath)}collecting/benthicpit/${submittedRecordId}`,
         )
       })
-      .catch(() => {
-        toast.error(...getToastArguments(language.error.submittedRecordMoveToCollect))
-        setIsMoveToButtonDisabled(false)
+      .catch((error) => {
+        handleHttpResponseError({
+          error,
+          callback: () => {
+            toast.error(...getToastArguments(language.error.submittedRecordMoveToCollect))
+            setIsMoveToButtonDisabled(false)
+          },
+        })
       })
   }
 


### PR DESCRIPTION
just added the http response handler to the existing submitted record pages in hopes that a fresh deploy to develop will magically fix the bug which shouldnt be a bug, and that if it has anything to do with the 403s I was sometimes seeing, this would help. 

Hocus pocus basically, but also its good to update them to use the error handler 🤷 

~~To test:~~
~~Click on all of the submitted collect records in the list and make sure the page for each loads?~~

None of the submitted records I can find in the preview deploy include a benthic photo quadrat, so once we are ok with the code, we have to merge it to develop and test dev-app I suppose.