### PR TITLE
Duplicate project name error

### DIFF
--- a/src/components/ProjectCard/ProjectModal.js
+++ b/src/components/ProjectCard/ProjectModal.js
@@ -25,7 +25,12 @@ const CheckBoxLabel = styled.label`
 
 const ProjectModal = ({ isOpen, onDismiss, project, addProjectToProjectsPage }) => {
   const [isLoading, setIsLoading] = useState(false)
-  // const [projectNameAlreadyExists, setProjectNameAlreadyExists] = useState(false)
+  const [nameAlreadyExists, setNameAlreadyExists] = useState(false)
+  const [existingName, setExistingName] = useState('')
+  // using same error format as Formik so message can be used in InputWithLabelAndValidation
+  const nameExistsError = [
+    { code: language.error.formValidation.projectNameExists, id: 'Name Exists' },
+  ]
 
   const initialFormValues = project
     ? {
@@ -61,6 +66,8 @@ const ProjectModal = ({ isOpen, onDismiss, project, addProjectToProjectsPage }) 
             error.response.data?.new_project_name === 'Project name already exists')
 
         if (isDuplicateError) {
+          setNameAlreadyExists(true)
+          setExistingName(formik.values.name)
           toast.error(
             ...getToastArguments(...getToastArguments(language.error.duplicateNewProject)),
           )
@@ -76,6 +83,8 @@ const ProjectModal = ({ isOpen, onDismiss, project, addProjectToProjectsPage }) 
     formik.resetForm()
     addProjectToProjectsPage(response)
     setIsLoading(false)
+    setNameAlreadyExists(false)
+    setExistingName('')
     onDismiss()
   }
 
@@ -113,6 +122,19 @@ const ProjectModal = ({ isOpen, onDismiss, project, addProjectToProjectsPage }) 
   const handleOnSubmit = () => {
     project ? copyExistingProject() : createNewProject()
   }
+
+  const checkValidationMessage = () => {
+    let errorMessage = []
+
+    if (formik.errors.name) {
+      errorMessage = formik.errors.name
+    } else if (nameAlreadyExists) {
+      errorMessage = nameExistsError
+    }
+
+    return errorMessage
+  }
+
   const getModalContent = (placeholderName) => {
     return (
       <ModalInputRow>
@@ -125,9 +147,13 @@ const ProjectModal = ({ isOpen, onDismiss, project, addProjectToProjectsPage }) 
           type="text"
           value={formik.values.name}
           onChange={formik.handleChange}
-          validationType={formik.errors.name ? 'error' : null}
+          validationType={
+            formik.errors.name || (existingName && existingName === formik.values.name)
+              ? 'error'
+              : null
+          }
           placeholder={placeholderName || ''}
-          validationMessages={formik.errors.name}
+          validationMessages={checkValidationMessage()}
           setErrors={language.error.formValidation.required}
         />
       </ModalInputRow>

--- a/src/language.js
+++ b/src/language.js
@@ -45,6 +45,7 @@ const error = {
     latitude: 'Latitude should be between -90° and 90°',
     longitude: 'Longitude should be between -180° and 180°',
     required: 'This field is required',
+    projectNameExists: 'Project name already exists',
     managementPartialRestrictionRequired: 'At least one rule is required',
   },
   generaUnavailable: 'Fish genera data is currently unavailable. Please try again.',


### PR DESCRIPTION
This one required some creativity with formik  and the `InputWithLabelAndValidation` component- I couldn't really find an elegant way for it to handle api validation. I tried setting up the error within `useFormik` initially, but this didn't work properly. It wouldn't show the error until you typed or removed a character -  which is when validation updates. This happens after we get the api response so it doesn't show right away. In addition, the error message wouldn't disappear until you re-submitted (even if the current name value no longer matches what the existing project name is). 

with the current solution, the error display shows up the same way as in formik - it appears or disappears depending if there is an existing project name, and whether that matches what the name value is

![name-exists-error](https://user-images.githubusercontent.com/26089140/205734886-386469b2-8453-401f-89c2-457e04487741.gif)

