### PR TITLE
quick collect record abstraction refactor

### DIFF
--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitForm.js
@@ -188,6 +188,24 @@ const BenthicPitForm = ({ isNewRecord }) => {
       })
   }
 
+  const PartiallyAppliedBenthicPitObservationsTable = useCallback(
+    (props) => {
+      // the conditional here makes tests happy
+      if (benthicAttributeSelectOptions.length) {
+        return (
+          <BenthicPitObservationsTable
+            benthicAttributeSelectOptions={benthicAttributeSelectOptions}
+            {...props}
+          />
+        )
+      }
+
+      return null
+    },
+
+    [benthicAttributeSelectOptions],
+  )
+
   return (
     <>
       <CollectRecordFormPageAlternative
@@ -200,7 +218,7 @@ const BenthicPitForm = ({ isNewRecord }) => {
         isNewRecord={isNewRecord}
         isParentDataLoading={isLoading}
         observationsTable1Reducer={observationsReducer}
-        ObservationTable1={BenthicPitObservationsTable}
+        ObservationTable1={PartiallyAppliedBenthicPitObservationsTable}
         sampleUnitFormatSaveFunction={reformatFormValuesIntoBenthicPitRecord}
         sampleUnitName="benthicpit"
         SampleUnitTransectInputs={BenthicPitTransectInputs}

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPageAlternative/CollectRecordFormPageAlternative.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPageAlternative/CollectRecordFormPageAlternative.js
@@ -19,7 +19,6 @@ import { getIsReadOnlyUserRole } from '../../../../App/currentUserProfileHelpers
 import { getObservationsPropertyNames } from '../../../../App/mermaidData/recordProtocolHelpers'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import { H2 } from '../../../generic/text'
-import { inputOptionsPropTypes } from '../../../../library/miscPropTypes'
 import { sortArrayByObjectKey } from '../../../../library/arrays/sortArrayByObjectKey'
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
 import { useDatabaseSwitchboardInstance } from '../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
@@ -44,7 +43,6 @@ import useIsMounted from '../../../../library/useIsMounted'
 
 const CollectRecordFormPageAlternative = ({
   areObservationsInputsDirty,
-  benthicAttributeSelectOptions,
   collectRecordBeingEdited,
   handleCollectRecordChange,
   idsNotAssociatedWithData,
@@ -424,7 +422,6 @@ const CollectRecordFormPageAlternative = ({
           <ObservationTable1
             testId="observations-section"
             areValidationsShowing={areValidationsShowing}
-            benthicAttributeSelectOptions={benthicAttributeSelectOptions}
             choices={choices}
             collectRecord={collectRecordBeingEdited}
             formik={formik}
@@ -497,7 +494,6 @@ const CollectRecordFormPageAlternative = ({
 
 CollectRecordFormPageAlternative.propTypes = {
   areObservationsInputsDirty: PropTypes.bool.isRequired,
-  benthicAttributeSelectOptions: inputOptionsPropTypes.isRequired,
   collectRecordBeingEdited: PropTypes.oneOfType([fishBeltPropType, benthicPhotoQuadratPropType]),
   handleCollectRecordChange: PropTypes.func.isRequired,
   idsNotAssociatedWithData: PropTypes.arrayOf(PropTypes.string).isRequired,


### PR DESCRIPTION
refactor CollectRecortFormPaggeAlternative abstraction to use a more generic observations table (removed notion of benthicAttributeOptions from abstraction)

Leave Tests to Kim (when whole feature is done)