### PR TITLE
Include app-dev in cloudfront Alternate domain names

### DIFF
--- a/iac/static-site.ts
+++ b/iac/static-site.ts
@@ -75,6 +75,9 @@ export class StaticSite extends Construct {
     const domainNames = [siteDomain]
 
     // allow the prod/preview domains into the cloudfront distribution
+    if (props.siteSubDomain === 'dev') {
+      domainNames.push("dev-app.datamermaid.org")
+    }
     if (props.siteSubDomain === 'prod') {
       domainNames.push("app.datamermaid.org")
     }


### PR DESCRIPTION
We needed to include `app-dev` in cloudfront's alternative domain names