### PR TITLE
Fix: Persist pagination choices

### DIFF
--- a/src/components/pages/Collect/Collect.js
+++ b/src/components/pages/Collect/Collect.js
@@ -225,7 +225,7 @@ const Collect = () => {
       columns: tableColumns,
       data: tableCellData,
       initialState: {
-        pageSize: 15,
+        pageSize: tableUserPrefs.pageSize ? tableUserPrefs.pageSize : 15,
         sortBy: tableUserPrefs.sortBy,
         globalFilter: tableUserPrefs.globalFilter,
       },
@@ -250,6 +250,10 @@ const Collect = () => {
   const _setFilterPrefs = useEffect(() => {
     handleSetTableUserPrefs({ propertyKey: 'globalFilter', currentValue: globalFilter })
   }, [globalFilter, handleSetTableUserPrefs])
+
+  const _setPageSizePrefs = useEffect(() => {
+    handleSetTableUserPrefs({ propertyKey: 'pageSize', currentValue: pageSize })
+  }, [pageSize, handleSetTableUserPrefs])
 
   const table = collectRecordsForUiDisplay.length ? (
     <>

--- a/src/components/pages/ManagementRegimes/ManagementRegimes.js
+++ b/src/components/pages/ManagementRegimes/ManagementRegimes.js
@@ -270,7 +270,7 @@ const ManagementRegimes = () => {
       columns: tableColumns,
       data: tableCellData,
       initialState: {
-        pageSize: 15,
+        pageSize: tableUserPrefs.pageSize ? tableUserPrefs.pageSize : 15,
         sortBy: tableUserPrefs.sortBy,
         globalFilter: tableUserPrefs.globalFilter,
       },
@@ -286,6 +286,9 @@ const ManagementRegimes = () => {
     setPageSize(Number(e.target.value))
   }
 
+  // eslint-disable-next-line no-console
+  // console.log(tableUserPrefs.pageSize)
+
   const handleGlobalFilterChange = (value) => setGlobalFilter(value)
 
   const _setSortByPrefs = useEffect(() => {
@@ -295,6 +298,10 @@ const ManagementRegimes = () => {
   const _setFilterPrefs = useEffect(() => {
     handleSetTableUserPrefs({ propertyKey: 'globalFilter', currentValue: globalFilter })
   }, [globalFilter, handleSetTableUserPrefs])
+
+  const _setPageSizePrefs = useEffect(() => {
+    handleSetTableUserPrefs({ propertyKey: 'pageSize', currentValue: pageSize })
+  }, [pageSize, handleSetTableUserPrefs])
 
   const readOnlyMrsHeaderContent = (
     <>

--- a/src/components/pages/ManagementRegimesOverview/ManagementRegimesOverview.js
+++ b/src/components/pages/ManagementRegimesOverview/ManagementRegimesOverview.js
@@ -250,7 +250,7 @@ const ManagementRegimesOverview = () => {
       columns: tableColumns,
       data: tableCellData,
       initialState: {
-        pageSize: 100,
+        pageSize: tableUserPrefs.pageSize ? tableUserPrefs.pageSize : 100,
         sortBy: tableUserPrefs.sortBy,
         globalFilter: tableUserPrefs.globalFilter,
       },
@@ -273,6 +273,10 @@ const ManagementRegimesOverview = () => {
   const _setFilterPrefs = useEffect(() => {
     handleSetTableUserPrefs({ propertyKey: 'globalFilter', currentValue: globalFilter })
   }, [globalFilter, handleSetTableUserPrefs])
+
+  const _setPageSizePrefs = useEffect(() => {
+    handleSetTableUserPrefs({ propertyKey: 'pageSize', currentValue: pageSize })
+  }, [pageSize, handleSetTableUserPrefs])
 
   const table = (
     <>

--- a/src/components/pages/Sites/Sites.js
+++ b/src/components/pages/Sites/Sites.js
@@ -207,7 +207,7 @@ const Sites = () => {
       columns: tableColumns,
       data: tableCellData,
       initialState: {
-        pageSize: 15,
+        pageSize: tableUserPrefs.pageSize ? tableUserPrefs.pageSize : 15,
         sortBy: tableUserPrefs.sortBy,
         globalFilter: tableUserPrefs.globalFilter,
       },
@@ -232,6 +232,10 @@ const Sites = () => {
   const _setFilterPrefs = useEffect(() => {
     handleSetTableUserPrefs({ propertyKey: 'globalFilter', currentValue: globalFilter })
   }, [globalFilter, handleSetTableUserPrefs])
+
+  const _setPageSizePrefs = useEffect(() => {
+    handleSetTableUserPrefs({ propertyKey: 'pageSize', currentValue: pageSize })
+  }, [pageSize, handleSetTableUserPrefs])
 
   const getDataForCSV = useMemo(() => {
     const countryChoices = choices?.countries?.data

--- a/src/components/pages/Submitted/Submitted.js
+++ b/src/components/pages/Submitted/Submitted.js
@@ -206,7 +206,7 @@ const Submitted = () => {
       columns: tableColumns,
       data: tableCellData,
       initialState: {
-        pageSize: 15,
+        pageSize: tableUserPrefs.pageSize ? tableUserPrefs.pageSize : 15,
         sortBy: tableUserPrefs.sortBy,
         globalFilter: tableUserPrefs.globalFilter,
       },
@@ -230,6 +230,10 @@ const Submitted = () => {
   const _setFilterPrefs = useEffect(() => {
     handleSetTableUserPrefs({ propertyKey: 'globalFilter', currentValue: globalFilter })
   }, [globalFilter, handleSetTableUserPrefs])
+
+  const _setPageSizePrefs = useEffect(() => {
+    handleSetTableUserPrefs({ propertyKey: 'pageSize', currentValue: pageSize })
+  }, [pageSize, handleSetTableUserPrefs])
 
   const handleExportToCSV = (transect) => {
     const isBleachingTransect =

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -645,7 +645,7 @@ const Users = () => {
       columns: isAdminUser ? tableColumnsForAdmin : tableColumnsForNonAdmin,
       data: isAdminUser ? tableCellDataForAdmin : tableCellDataForNonAdmin,
       initialState: {
-        pageSize: 15,
+        pageSize: tableUserPrefs.pageSize ? tableUserPrefs.pageSize : 15,
         sortBy: tableUserPrefs.sortBy,
         globalFilter: tableUserPrefs.globalFilter,
       },
@@ -669,6 +669,10 @@ const Users = () => {
   const _setFilterPrefs = useEffect(() => {
     handleSetTableUserPrefs({ propertyKey: 'globalFilter', currentValue: globalFilter })
   }, [globalFilter, handleSetTableUserPrefs])
+
+  const _setPageSizePrefs = useEffect(() => {
+    handleSetTableUserPrefs({ propertyKey: 'pageSize', currentValue: pageSize })
+  }, [pageSize, handleSetTableUserPrefs])
 
   const table = (
     <>

--- a/src/components/pages/UsersAndTransects/UsersAndTransects.js
+++ b/src/components/pages/UsersAndTransects/UsersAndTransects.js
@@ -352,7 +352,7 @@ const UsersAndTransects = () => {
       columns: tableColumns,
       data: tableCellData,
       initialState: {
-        pageSize: 100,
+        pageSize: tableUserPrefs.pageSize ? tableUserPrefs.pageSize : 100,
         sortBy: tableUserPrefs.sortBy,
         globalFilter: tableUserPrefs.globalFilter,
       },
@@ -375,6 +375,10 @@ const UsersAndTransects = () => {
   const _setFilterPrefs = useEffect(() => {
     handleSetTableUserPrefs({ propertyKey: 'globalFilter', currentValue: globalFilter })
   }, [globalFilter, handleSetTableUserPrefs])
+
+  const _setPageSizePrefs = useEffect(() => {
+    handleSetTableUserPrefs({ propertyKey: 'pageSize', currentValue: pageSize })
+  }, [pageSize, handleSetTableUserPrefs])
 
   const table = (
     <>


### PR DESCRIPTION
[trello ticket ](https://trello.com/c/zmZKAwHi/777-persist-pagination-choice)

Tables to persist pagination state with:
- Users and transects table (project health)
- Management regimes and overview table (project health)
- Collect record list (collecting)
- Sites list 
- Management Regimes
- Submitted
- Users

to test:
1. navigate to any of the pages listed above
2. scroll down to 'Show x rows'
3. change row number
4. navigate to a different page
5. return back to same page
6. row number should persist