### PR TITLE
Navigate to Sites page after creating a project

### DIFF
--- a/src/components/ProjectCard/ProjectModal.js
+++ b/src/components/ProjectCard/ProjectModal.js
@@ -1,6 +1,7 @@
 import { toast } from 'react-toastify'
 import { useFormik } from 'formik'
 import React, { useState } from 'react'
+import { useHistory } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { ButtonPrimary, ButtonSecondary } from '../generic/buttons'
@@ -24,6 +25,7 @@ const CheckBoxLabel = styled.label`
 `
 
 const ProjectModal = ({ isOpen, onDismiss, project, addProjectToProjectsPage }) => {
+  const history = useHistory()
   const [isLoading, setIsLoading] = useState(false)
   const [nameAlreadyExists, setNameAlreadyExists] = useState(false)
   const [existingName, setExistingName] = useState('')
@@ -86,6 +88,7 @@ const ProjectModal = ({ isOpen, onDismiss, project, addProjectToProjectsPage }) 
     setNameAlreadyExists(false)
     setExistingName('')
     onDismiss()
+    history.push(`/projects/${response.id}/sites`)
   }
 
   const copyExistingProject = () => {
@@ -190,7 +193,7 @@ const ProjectModal = ({ isOpen, onDismiss, project, addProjectToProjectsPage }) 
   const footerContent = (
     <RightFooter>
       <ButtonSecondary onClick={onDismiss}>Cancel</ButtonSecondary>
-      <ButtonPrimary onClick={handleOnSubmit}>
+      <ButtonPrimary disabled={isLoading} onClick={handleOnSubmit}>
         <IconSend />
         {modalTitle}
       </ButtonPrimary>


### PR DESCRIPTION
[Trello card](https://trello.com/c/oTPq1VVO/791-users-should-be-navigated-to-the-project-that-theyve-just-created-or-copied)

- disable 'create project' button when loading
- navigate to Sites page on success

To test: 
1. Go to `/projects`
2. Create a new project or copy an existing one
3. after you click the 'create' button, page should navigate to the new project's Sites page
4. create button should also be disabled when loading