### PR TITLE
Feature: add Benthic Lit observation table to summary page

### DIFF
--- a/src/components/pages/submittedRecordPages/SubmittedBenthicLit/SubmittedBenthicLitObservationTable.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBenthicLit/SubmittedBenthicLitObservationTable.js
@@ -5,12 +5,7 @@ import {
 } from '../../../../App/mermaidData/mermaidDataProptypes'
 import { inputOptionsPropTypes } from '../../../../library/miscPropTypes'
 import { SubmittedObservationStickyTable, Tr, Td } from '../../../generic/Table/table'
-import {
-  TheadItem,
-  FormSubTitle,
-  // ObservationsSummaryStats,
-  UnderTableRow,
-} from '../SubmittedFormPage.styles'
+import { TheadItem, FormSubTitle, UnderTableRow } from '../SubmittedFormPage.styles'
 import { InputWrapper } from '../../../generic/form'
 import { StyledOverflowWrapper } from '../../collectRecordFormPages/CollectingFormPage.Styles'
 import { getObjectById } from '../../../../library/getObjectById'


### PR DESCRIPTION
- currently branched off `melissa/M477-benthic-lit-collect-record-part1` since its not merged in yet
- used reusable component for benthic lit/pit summary