### PR TITLE
Add decimal degrees helper text to lng & lat

### DIFF
--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -132,6 +132,7 @@ const SiteForm = ({
           validationType={formik.errors.latitude && formik.touched.latitude ? 'error' : null}
           validationMessages={formik.errors.latitude}
           testId="latitude"
+          helperText="Decimal Degrees"
         />
         <InputWithLabelAndValidation
           required
@@ -142,6 +143,7 @@ const SiteForm = ({
           validationType={formik.errors.longitude && formik.touched.longitude ? 'error' : null}
           validationMessages={formik.errors.longitude}
           testId="longitude"
+          helperText="Decimal Degrees"
         />
         {isAppOnline && (
           <SingleSiteMap


### PR DESCRIPTION
[trello card](https://trello.com/c/zn2X9AHp/839-include-expected-format-for-lat-lng-on-site-page)

add lng lat format in helper text