### PR TITLE
fix: M811 show fishbelt fishbin sizes for WCS India

### DIFF
--- a/src/components/pages/collectRecordFormPages/FishBeltForm/fishBeltBins.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/fishBeltBins.js
@@ -24,11 +24,19 @@ export const fishBeltBins = {
   ],
   AGRRA: [
     { label: '0 - 5', value: 2.5 },
-    { label: '6 - 10', value: 7.4 },
+    { label: '6 - 10', value: 7.5 },
     { label: '11 - 20', value: 15 },
     { label: '21 - 30', value: 25 },
     { label: '31 - 40', value: 35 },
     { label: '41 - 50', value: 45 },
+    { label: '50+', value: 50 },
+  ],
+  'WCS India': [
+    { label: '0 - 5', value: 2.5 },
+    { label: '5 - 10', value: 7.5 },
+    { label: '10 - 20', value: 15 },
+    { label: '20 - 30', value: 25 },
+    { label: '30 - 50', value: 40 },
     { label: '50+', value: 50 },
   ],
 }


### PR DESCRIPTION
steps to test:
- make a new fishbelt collect record
- select `WCS India` for a fish size bin
- create a new observation
- click the size select

Expected results. The options should look like this and not be empty
<img width="269" alt="Screen Shot 2022-12-22 at 1 00 45 PM" src="https://user-images.githubusercontent.com/1740152/209216753-cec3a817-138e-4faa-afda-57be00355c75.png">
