### PR TITLE
Add NaN bug fix to bleaching summary stats

### DIFF
--- a/src/components/BleachingColoniesBleachedSummaryStats/BleachingColoniesBleachedSummaryStats.js
+++ b/src/components/BleachingColoniesBleachedSummaryStats/BleachingColoniesBleachedSummaryStats.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+/* eslint-disable no-unused-expressions */
 import React from 'react'
 import { observationsColoniesBleachedPropType } from '../../App/mermaidData/mermaidDataProptypes'
 import { Td, Th, Tr } from '../generic/Table/table'
@@ -28,7 +30,7 @@ const BleachincColoniesBleachedSummaryStats = ({ observationsColoniesBleached })
   }
 
   const getPercentageOfColonies = (colonyType) => {
-    if (!observationsColoniesBleached.length) {
+    if (!observationsColoniesBleached.length || getTotalOfColonies() === 0) {
       return 0
     }
 


### PR DESCRIPTION
[Trello ticket here](https://trello.com/c/4HBLY7QP/875-nan-in-bleaching-observation-table-summary)

Issue: we we're dividing by 0 in the case where `getTotalOfColonies` was 0

To test:
1.  Create a new bleaching form
2. Add a row to the first table
3. No longer see NaN in any of the summary items