### PR TITLE
NaN bug fix on bleaching summary stats

### DIFF
--- a/src/components/BleachingColoniesBleachedSummaryStats/BleachingColoniesBleachedSummaryStats.js
+++ b/src/components/BleachingColoniesBleachedSummaryStats/BleachingColoniesBleachedSummaryStats.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-/* eslint-disable no-unused-expressions */
 import React from 'react'
 import { observationsColoniesBleachedPropType } from '../../App/mermaidData/mermaidDataProptypes'
 import { Td, Th, Tr } from '../generic/Table/table'


### PR DESCRIPTION
[Trello ticket here](https://trello.com/c/4HBLY7QP/875-nan-in-bleaching-observation-table-summary)

Issue: we we're dividing by 0 in the case where getTotalOfColonies was 0

To test:

Create a new bleaching form
Add a row to the first table
No longer see NaN in any of the summary items