### PR TITLE
fix: M818 handle apostrophes in filter words appropriately

### DIFF
--- a/src/components/pages/Projects/Projects.test.js
+++ b/src/components/pages/Projects/Projects.test.js
@@ -36,7 +36,7 @@ test('Projects component renders with the expected UI elements', async () => {
 
   const projectListItems = screen.getAllByTestId('project-card')
 
-  expect(projectListItems).toHaveLength(5)
+  expect(projectListItems).toHaveLength(6)
 
   // expect filter bar, sort buttons, new project button
   const newProjectButton = screen.getByRole('button', { name: 'New Project' })
@@ -375,7 +375,7 @@ test('Project sorted descending', async () => {
 
   const topProjectCard = screen.getAllByRole('listitem')[0]
 
-  expect(within(topProjectCard).getByText('Project V'))
+  expect(within(topProjectCard).getByText("Project Z has an apostrophe foo's"))
 })
 
 test('Project filter filters by name and country', async () => {
@@ -416,4 +416,36 @@ test('Project filter filters by name and country', async () => {
   projectCards = screen.getAllByTestId('project-card')
 
   expect(projectCards.length).toEqual(2)
+})
+test('Project filter can accomodate words containing apostrophes', async () => {
+  const { dexiePerUserDataInstance } = getMockDexieInstancesAllSuccess()
+
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
+  const apiSyncInstance = new SyncApiDataIntoOfflineStorage({
+    dexiePerUserDataInstance,
+    apiBaseUrl: process.env.REACT_APP_MERMAID_API,
+    getAccessToken: getFakeAccessToken,
+  })
+
+  renderAuthenticatedOnline(<Projects apiSyncInstance={apiSyncInstance} />, {
+    dexiePerUserDataInstance,
+    isSyncInProgressOverride: true,
+  })
+
+  await waitFor(() =>
+    expect(screen.queryByLabelText('projects list loading indicator')).not.toBeInTheDocument(),
+  )
+
+  const filterProjects = screen.getByRole('textbox', {
+    name: /Filter Projects By Name or Country/i,
+  })
+
+  // Filter by name
+  userEvent.type(filterProjects, '"foo\'s"')
+
+  const projectCards = screen.getAllByTestId('project-card')
+
+  expect(projectCards.length).toEqual(1)
+  expect(within(projectCards[0]).getByText("Project Z has an apostrophe foo's"))
 })

--- a/src/library/splitSearchQueryStrings.js
+++ b/src/library/splitSearchQueryStrings.js
@@ -4,8 +4,12 @@
 // Also supports multi quotes in string.
 // example B: splitSearchQueryStrings(`"to the" dustin "kim"`)
 export const splitSearchQueryStrings = (words) => {
-  // eslint-disable-next-line no-useless-escape
-  const regex = /"(.*?)"|([a-zA-Z0-9_,;\-\+]+)|(\|)/
+  const anythingInDoubleQuotes = /"(.*?)"/.source
+  const alphaNumericAndSomeOtherSymbolsIncludingApostrophe = /([a-zA-Z0-9_,;'/-/+]+)/.source
+  const pipeCharacter = /(\|)/.source
+  const regex = new RegExp(
+    `${anythingInDoubleQuotes}|${alphaNumericAndSomeOtherSymbolsIncludingApostrophe}|${pipeCharacter}`,
+  )
   const parts = words.split(regex)
   const searchItems = []
 

--- a/src/testUtilities/mockMermaidData.js
+++ b/src/testUtilities/mockMermaidData.js
@@ -109,6 +109,23 @@ const projects = [
     data_policy_habitatcomplexity: 100,
     members: ['697a1123-ef22-4acb-aea4-05abbd5589d0'],
   },
+  {
+    id: '6',
+    name: "Project Z has an apostrophe foo's",
+    countries: ['Mexico'],
+    tags: [],
+    num_sites: 33,
+    num_active_sample_units: 19,
+    num_sample_units: 29,
+    updated_on: '2001-01-21T08:00:00.000Z',
+    notes: '',
+    data_policy_beltfish: 50,
+    data_policy_benthiclit: 100,
+    data_policy_benthicpit: 100,
+    data_policy_bleachingqc: 10,
+    data_policy_habitatcomplexity: 100,
+    members: ['697a1123-ef22-4acb-aea4-05abbd5589d0'],
+  },
 ]
 
 const sampleUnitMethods = [


### PR DESCRIPTION
Steps to test:

Go to copy sites from another project

Search for `Glover'` <- notice `'`

Expected behaviour:
results for `Glover's` will show up

copied from https://trello.com/c/isPWmc8t/818-punctuation-in-filter-sites-mr-doesnt-work-as-intended