### PR TITLE
fix: M815 make sure copy site and copy MR modals filter cause proper input focus.

### DIFF
--- a/src/components/CopyManagementRegimesModal/CopyManagementRegimesModal.js
+++ b/src/components/CopyManagementRegimesModal/CopyManagementRegimesModal.js
@@ -391,6 +391,7 @@ const CopyManagementRegimesModal = ({ isOpen, onDismiss, addCopiedMRsToManagemen
         name={language.pages.copyManagementRegimeTable.filterToolbarText}
         value={tableUserPrefs.globalFilter}
         handleGlobalFilterChange={handleGlobalFilterChange}
+        id="copy-management-regimes-filter"
       />
     </CopyModalToolbarWrapper>
   )

--- a/src/components/CopySitesModal/CopySitesModal.js
+++ b/src/components/CopySitesModal/CopySitesModal.js
@@ -358,6 +358,7 @@ const CopySitesModal = ({ isOpen, onDismiss, addCopiedSitesToSiteTable }) => {
         name={language.pages.copySiteTable.filterToolbarText}
         value={tableUserPrefs.globalFilter}
         handleGlobalFilterChange={handleGlobalFilterChange}
+        id="copy-sites-filter"
       />
     </CopyModalToolbarWrapper>
   )

--- a/src/components/FilterSearchToolbar/FilterSearchToolbar.js
+++ b/src/components/FilterSearchToolbar/FilterSearchToolbar.js
@@ -15,37 +15,30 @@ const FilterLabelWrapper = styled.label`
   }
 `
 
-const FilterSearchToolbar = ({
-  name,
-  handleGlobalFilterChange,
-  value
-}) => {
-  const handleFilterChange = event => {
+const FilterSearchToolbar = ({ name, handleGlobalFilterChange, value, id }) => {
+  const handleFilterChange = (event) => {
     const { value: eventValue } = event.target
 
     handleGlobalFilterChange(eventValue)
   }
 
   return (
-    <FilterLabelWrapper htmlFor="filter-search">
+    <FilterLabelWrapper htmlFor={id}>
       {name}
-      <Input
-        type="text"
-        id="filter-search"
-        value={value}
-        onChange={handleFilterChange}
-      />
+      <Input type="text" id={id} value={value} onChange={handleFilterChange} />
     </FilterLabelWrapper>
   )
 }
 
 FilterSearchToolbar.defaultProps = {
-  value: undefined
+  id: 'filter-search',
+  value: undefined,
 }
 
 FilterSearchToolbar.propTypes = {
-  name: PropTypes.string.isRequired,
   handleGlobalFilterChange: PropTypes.func.isRequired,
+  id: PropTypes.string,
+  name: PropTypes.string.isRequired,
   value: PropTypes.string,
 }
 


### PR DESCRIPTION
brief description of bug https://trello.com/c/Vn83VUcI/815-clicking-on-the-label-of-the-input-in-the-copy-sites-copy-mr-modal-focuses-the-input-on-the-main-page-out-of-the-modal

To test:
- go to the sites page
- click on 'copy sites from other projects' button
- in modal click on the _label_ for 'filter sites by name, project, or country'
- focus shoudl be on the modal filter, not the sites page filter

Do same test for copy MR. 