### PR TITLE
Don't show avatar if src url missing in Nav Menu

### DIFF
--- a/src/components/NavMenu/NavMenu.js
+++ b/src/components/NavMenu/NavMenu.js
@@ -152,7 +152,7 @@ const NavMenu = ({ subNavNode }) => {
             {!isReadOnlyUser && (
               <LiCollecting>
                 <NavLinkSidebar exact to={`${projectUrl}/collecting`}>
-                  <CollectionAvatar src={currentUser.picture} />
+                  {currentUser.picture ? <CollectionAvatar src={currentUser.picture} /> : null}
                   <IconCollect />
                   <span>Collecting</span>
                   <CollectRecordsCount />


### PR DESCRIPTION
[trello card here](https://trello.com/c/VUqegAls/863-dont-show-avatar-in-side-nav-if-photo-doesnt-load)

small fix - if we are missing `currentUser.picture`, do not show the avatar div

there *may* be a case where we still get broken image links if something is up with the image the url points to, however, I'm thinking this is more of an edge case. 