### PR TITLE
add onError handling for gravatar image 

### DIFF
--- a/src/components/NavMenu/NavMenu.js
+++ b/src/components/NavMenu/NavMenu.js
@@ -152,7 +152,15 @@ const NavMenu = ({ subNavNode }) => {
             {!isReadOnlyUser && (
               <LiCollecting>
                 <NavLinkSidebar exact to={`${projectUrl}/collecting`}>
-                  {currentUser.picture ? <CollectionAvatar src={currentUser.picture} /> : null}
+                  {currentUser.picture ? (
+                    <CollectionAvatar
+                      src={currentUser.picture}
+                      onError={(e) => {
+                        e.target.onerror = null
+                        e.target.src = ''
+                      }}
+                    />
+                  ) : null}
                   <IconCollect />
                   <span>Collecting</span>
                   <CollectRecordsCount />


### PR DESCRIPTION
- additional fix for [gravatar ticket](https://trello.com/c/VUqegAls/863-dont-show-avatar-in-side-nav-if-photo-doesnt-load)
- Al noticed earlier today that we were getting buggy src urls occasionally
- this fix will now account for both cases of image url issues (no url or bad url)