### PR TITLE
Gravatar image update

### DIFF
--- a/src/components/NavMenu/NavMenu.js
+++ b/src/components/NavMenu/NavMenu.js
@@ -143,6 +143,11 @@ const NavMenu = ({ subNavNode }) => {
   const isManagementRegimeSubNode = managementRegimeId || pathname.includes('management-regimes')
   const isReadOnlyUser = getIsReadOnlyUserRole(currentUser, projectId)
 
+  const handleImageError = (event) => {
+    // eslint-disable-next-line no-param-reassign
+    event.target.style.display = 'none'
+  }
+
   return (
     <NavWrapper data-testid="content-page-side-nav">
       <NavList>
@@ -153,13 +158,7 @@ const NavMenu = ({ subNavNode }) => {
               <LiCollecting>
                 <NavLinkSidebar exact to={`${projectUrl}/collecting`}>
                   {currentUser.picture ? (
-                    <CollectionAvatar
-                      src={currentUser.picture}
-                      onError={(e) => {
-                        e.target.onerror = null
-                        e.target.src = ''
-                      }}
-                    />
+                    <CollectionAvatar src={currentUser.picture} onError={handleImageError} />
                   ) : null}
                   <IconCollect />
                   <span>Collecting</span>


### PR DESCRIPTION
additional fix for [this ticket](https://trello.com/c/VUqegAls/863-dont-show-avatar-in-side-nav-if-photo-doesnt-load). Had to try several different work arounds ... this one seemed to work the best
 
- Al brought up earlier that the image url itself can be broken
- used `onError` Image handling to hide the element if the src url is broken
- could use some improvement in the future. For example, we would need to refresh the page to see if it reloaded

To test:
1. Since this is difficult to reproduce, to test I updated to the src url in `NavMenu.js` to a 'bad' url (ex: badurl.com) - line 161
2. go into a project
3. see that the icon is hidden in the nav menu

before:
![Screen Shot 2023-01-06 at 2 44 23 PM](https://user-images.githubusercontent.com/26089140/211087859-61a3a1f8-9583-4704-8047-137b3d618f98.png)

after:
![Screen Shot 2023-01-06 at 2 44 43 PM](https://user-images.githubusercontent.com/26089140/211087872-2a2c8823-bd74-474d-821b-686831acef25.png)


