### PR TITLE
Add gravatar fallback icon in Nav menu instead

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -62,6 +62,7 @@ const Header = ({ logout, currentUser }) => {
   const closeProfileModal = () => setIsProfileModalOpen(false)
   const { notifications } = useBellNotifications()
   const { isAppOnline } = useOnlineStatus()
+  const [hasImageError, setHasImageError] = useState(false)
 
   const UserMenuDropDownContent = () => (
     <OfflineHide>
@@ -70,17 +71,25 @@ const Header = ({ logout, currentUser }) => {
     </OfflineHide>
   )
 
-  const handleImageError = (event) => {
-    // eslint-disable-next-line no-param-reassign
-    event.target.style.display = 'none'
+  const handleImageError = () => {
+    setHasImageError(true)
   }
 
   const getUserButton = () => {
-    // Avatar
-    if (currentUser && currentUser.picture) {
+    // Avatar with user image
+    if (currentUser && currentUser.picture && !hasImageError) {
       return (
         <AvatarWrapper>
           <CurrentUserImg src={currentUser.picture} alt="" onError={handleImageError} />
+        </AvatarWrapper>
+      )
+    }
+
+    // Avatar with fallback image
+    if (currentUser && currentUser.picture && hasImageError) {
+      return (
+        <AvatarWrapper>
+          <BiggerIconUser />
         </AvatarWrapper>
       )
     }

--- a/src/components/Header/Header.styles.js
+++ b/src/components/Header/Header.styles.js
@@ -26,6 +26,10 @@ export const AvatarWrapper = styled('button')`
   background: none;
   border: none;
 `
+export const AvatarWrapperFallback = styled('button')`
+  color: white;
+`
+
 export const CurrentUserImg = styled('img')`
   height: calc(${theme.spacing.headerHeight} - 10px);
   width: calc(${theme.spacing.headerHeight} - 10px);
@@ -148,6 +152,8 @@ export const BiggerIconMenu = styled(IconMenu)`
 `
 export const BiggerIconUser = styled(IconUser)`
   ${biggerIcons}
+  color: white;
+  position: inherit;
 `
 export const NotificationIndicator = styled.span`
   color: red;


### PR DESCRIPTION
- added generic user icon as fallback incase image fails
- Al made a good point that we shouldn't be hiding the nav menu icon if the image fails, as this is also a nav button menu
- the gravtar icon in the left hand menu is still hidden incase the src url fails to load

to test:
- open up Header.js and add a bad src url (line 83, ex: `src='aefsdf'`)
- refresh page
- user icon in header menu should display a generic white user icon