### PR TITLE
fix: M879 site form lat long inputs not type=number (making mapbox complain)

### DIFF
--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -127,6 +127,7 @@ const SiteForm = ({
           required
           label="Latitude"
           id="latitude"
+          type="number"
           {...formik.getFieldProps('latitude')}
           validationType={formik.errors.latitude && formik.touched.latitude ? 'error' : null}
           validationMessages={formik.errors.latitude}
@@ -137,6 +138,7 @@ const SiteForm = ({
           required
           label="Longitude"
           id="longitude"
+          type="number"
           {...formik.getFieldProps('longitude')}
           validationType={formik.errors.longitude && formik.touched.longitude ? 'error' : null}
           validationMessages={formik.errors.longitude}


### PR DESCRIPTION
To test:

- Go to sites, click on a site to edit
- Type in something other than numbers
- Expect the app not to crash with errors. Nothing should happen.