### PR TITLE
fix: M840 untouched new collect form shows disabled 'save' button (instead of disabled 'saved' button)

### DIFF
--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
@@ -91,7 +91,9 @@ const CollectRecordFormPage = ({
   const [isFormDirty, setIsFormDirty] = useState(false)
   const [areValidationsShowing, setAreValidationsShowing] = useState(false)
   const [areObservationsInputsDirty, setAreObservationsInputsDirty] = useState(false)
-  const [saveButtonState, setSaveButtonState] = useState(buttonGroupStates.saved)
+  const [saveButtonState, setSaveButtonState] = useState(
+    isNewRecord ? buttonGroupStates.untouchedEmptyForm : buttonGroupStates.saved,
+  )
   const [submitButtonState, setSubmitButtonState] = useState(buttonGroupStates.submittable)
   const [validateButtonState, setValidateButtonState] = useState(buttonGroupStates.validatable)
   const [isNewObservationModalOpen, setIsNewObservationModalOpen] = useState(false)

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPageAlternative/CollectRecordFormPageAlternative.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPageAlternative/CollectRecordFormPageAlternative.js
@@ -78,7 +78,9 @@ const CollectRecordFormPageAlternative = ({
   const [observationsTable1State, observationsTable1Dispatch] = observationsTable1Reducer
   const [observationsTable2State, observationsTable2Dispatch = () => {}] = observationsTable2Reducer
   const [observerProfiles, setObserverProfiles] = useState([])
-  const [saveButtonState, setSaveButtonState] = useState(buttonGroupStates.saved)
+  const [saveButtonState, setSaveButtonState] = useState(
+    isNewRecord ? buttonGroupStates.untouchedEmptyForm : buttonGroupStates.saved,
+  )
   const [sites, setSites] = useState([])
   const [submitButtonState, setSubmitButtonState] = useState(buttonGroupStates.submittable)
   const [validateButtonState, setValidateButtonState] = useState(buttonGroupStates.validatable)

--- a/src/components/pages/collectRecordFormPages/SaveValidateSubmitButtonGroup/SaveValidateSubmitButtonGroup.js
+++ b/src/components/pages/collectRecordFormPages/SaveValidateSubmitButtonGroup/SaveValidateSubmitButtonGroup.js
@@ -95,6 +95,7 @@ const SaveValidateSubmitButtonGroup = ({
     submitButtonState === buttonGroupStates.submitting ? 'Submitting' : 'Submit'
 
   const isSaveDisabled =
+    saveButtonState === buttonGroupStates.untouchedEmptyForm ||
     saveButtonState === buttonGroupStates.saved ||
     saveButtonState === buttonGroupStates.saving ||
     validateButtonState === buttonGroupStates.validating

--- a/src/library/buttonGroupStates.js
+++ b/src/library/buttonGroupStates.js
@@ -4,6 +4,7 @@ export const buttonGroupStates = {
   submittable: 'submitable',
   submitting: 'submitting',
   unsaved: 'unsaved',
+  untouchedEmptyForm: 'untouchedEmptyForm',
   validatable: 'validatable',
   validated: 'validated',
   validating: 'validating',


### PR DESCRIPTION
To test:

-create a new fishbelt or benthic photo quadrat (to test the first collect record form abstraction)
- make sure the button is disabled and says 'save' (not 'saved'). 
- change something in the form. It should now be enabled and have the 'save' text.
- click save. 
- click refresh to reload the existing record. The save button should have 'saved' as its text (since the form is displaying an existing record)

- create a new Benthic PIT (or another protocol not listed in tthe first step - to test the newer abstraction)
- make sure the button is disabled and says 'save'
- change something in the form. It should now be enabled and have the 'save' text.
- click save. 
- click refresh to reload the existing record. The save button should have 'saved' as its text (since the form is displaying an existing record)