### PR TITLE
feat: 828 add copy site/mr button when no sites or MRs instead of no data text

### DIFF
--- a/src/components/pages/ManagementRegimes/ManagementRegimes.js
+++ b/src/components/pages/ManagementRegimes/ManagementRegimes.js
@@ -29,6 +29,7 @@ import {
   ToolbarButtonWrapper,
   ButtonSecondary,
   LinkLooksLikeButtonSecondary,
+  ButtonPrimary,
 } from '../../generic/buttons'
 import { useDatabaseSwitchboardInstance } from '../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 import { useSyncStatus } from '../../../App/mermaidData/syncApiDataIntoOfflineStorage/SyncStatusContext'
@@ -325,7 +326,7 @@ const ManagementRegimes = () => {
           <IconPlus /> New MR
         </LinkLooksLikeButtonSecondary>
         <ButtonSecondary type="button" onClick={openCopyManagementRegimesModal}>
-          <IconCopy /> Copy MRs from other projects
+          <IconCopy /> {language.pages.managementRegimeTable.copyManagementRegimeButtonText}
         </ButtonSecondary>
         {readOnlyMrsHeaderContent}
       </ToolbarButtonWrapper>
@@ -400,7 +401,11 @@ const ManagementRegimes = () => {
   ) : (
     <PageUnavailable
       mainText={language.pages.managementRegimeTable.noDataMainText}
-      subText={language.pages.managementRegimeTable.noDataSubText}
+      subText={
+        <ButtonPrimary type="button" onClick={openCopyManagementRegimesModal}>
+          <IconCopy /> {language.pages.managementRegimeTable.copyManagementRegimeButtonText}
+        </ButtonPrimary>
+      }
     />
   )
 

--- a/src/components/pages/Sites/Sites.js
+++ b/src/components/pages/Sites/Sites.js
@@ -26,9 +26,10 @@ import {
 } from '../../generic/Table/reactTableNaturalSort'
 import { splitSearchQueryStrings } from '../../../library/splitSearchQueryStrings'
 import {
-  ToolbarButtonWrapper,
+  ButtonPrimary,
   ButtonSecondary,
   LinkLooksLikeButtonSecondary,
+  ToolbarButtonWrapper,
 } from '../../generic/buttons'
 import { ToolBarRow } from '../../generic/positioning'
 import {
@@ -287,7 +288,7 @@ const Sites = () => {
           <IconPlus /> New site
         </LinkLooksLikeButtonSecondary>
         <ButtonSecondary type="button" onClick={openCopySitesModal}>
-          <IconCopy /> Copy sites from other projects
+          <IconCopy /> {language.pages.siteTable.copySitesButtonText}
         </ButtonSecondary>
         {readOnlySitesHeaderContent}
       </ToolbarButtonWrapper>
@@ -365,7 +366,11 @@ const Sites = () => {
   ) : (
     <PageUnavailable
       mainText={language.pages.siteTable.noDataMainText}
-      subText={language.pages.siteTable.noDataSubText}
+      subText={
+        <ButtonPrimary type="button" onClick={openCopySitesModal}>
+          <IconCopy /> {language.pages.siteTable.copySitesButtonText}
+        </ButtonPrimary>
+      }
     />
   )
 

--- a/src/language.js
+++ b/src/language.js
@@ -278,20 +278,20 @@ const pages = {
     title: 'Site',
   },
   siteTable: {
-    title: 'Sites',
-    filterToolbarText: 'Filter this table by name, reef (type, zone, and exposure)',
-    noDataMainText: `This project has no sites.`,
-    noDataSubText: `You can add sites by creating a new one or copying them from another project.`,
     controlZoomText: 'Use Ctrl + Scroll to zoom the map',
+    copySitesButtonText: 'Copy sites from other projects',
+    filterToolbarText: 'Filter this table by name, reef (type, zone, and exposure)',
+    noDataMainText: 'This project has no sites.',
+    title: 'Sites',
   },
   managementRegimeForm: {
     title: 'Management Regime',
   },
   managementRegimeTable: {
-    title: 'Management Regimes',
+    copyManagementRegimeButtonText: 'Copy MRs from other projects',
     filterToolbarText: 'Filter this table by name or year',
     noDataMainText: `This project has no management regimes.`,
-    noDataSubText: `You can add management regimes by creating a new one or copying them from another project.`,
+    title: 'Management Regimes',
   },
   usersAndTransectsTable: {
     title: 'Users and Transects',


### PR DESCRIPTION
To test:
- Find a project that has no sites and no MRs (or create a new one)
- On both the sites and MR list pages:
  - see that there is a second button to copy sites/MRs that shows instead of the old 'there are no sites/MRs' text. 
  - the button should be a primary button (blue), not a secondary button like the copy button on the top right that does the exact same thing
  - clicking on the button opens the copy sites/MRs modal