### PR TITLE
Hide copy site/MR buttons when offline

### DIFF
--- a/src/components/pages/ManagementRegimes/ManagementRegimes.js
+++ b/src/components/pages/ManagementRegimes/ManagementRegimes.js
@@ -46,6 +46,7 @@ import usePersistUserTablePreferences from '../../generic/Table/usePersistUserTa
 import useIsMounted from '../../../library/useIsMounted'
 import PageUnavailable from '../PageUnavailable'
 import { getIsReadOnlyUserRole } from '../../../App/currentUserProfileHelpers'
+import { useOnlineStatus } from '../../../library/onlineStatusContext'
 
 const ManagementRegimes = () => {
   const [idsNotAssociatedWithData, setIdsNotAssociatedWithData] = useState([])
@@ -61,6 +62,7 @@ const ManagementRegimes = () => {
   const [isCopyManagementRegimesModalOpen, setIsCopyManagementRegimesModalOpen] = useState(false)
   const openCopyManagementRegimesModal = () => setIsCopyManagementRegimesModalOpen(true)
   const closeCopyManagementRegimesModal = () => setIsCopyManagementRegimesModalOpen(false)
+  const { isAppOnline } = useOnlineStatus()
 
   useDocumentTitle(`${language.pages.managementRegimeTable.title} - ${language.title.mermaid}`)
 
@@ -325,9 +327,11 @@ const ManagementRegimes = () => {
         <LinkLooksLikeButtonSecondary to={`${currentProjectPath}/management-regimes/new`}>
           <IconPlus /> New MR
         </LinkLooksLikeButtonSecondary>
-        <ButtonSecondary type="button" onClick={openCopyManagementRegimesModal}>
-          <IconCopy /> {language.pages.managementRegimeTable.copyManagementRegimeButtonText}
-        </ButtonSecondary>
+        {isAppOnline ? (
+          <ButtonSecondary type="button" onClick={openCopyManagementRegimesModal}>
+            <IconCopy /> {language.pages.managementRegimeTable.copyManagementRegimeButtonText}
+          </ButtonSecondary>
+        ) : null}
         {readOnlyMrsHeaderContent}
       </ToolbarButtonWrapper>
       <CopyManagementRegimesModal

--- a/src/components/pages/Sites/Sites.js
+++ b/src/components/pages/Sites/Sites.js
@@ -287,9 +287,11 @@ const Sites = () => {
         <LinkLooksLikeButtonSecondary to={`${currentProjectPath}/sites/new`}>
           <IconPlus /> New site
         </LinkLooksLikeButtonSecondary>
-        <ButtonSecondary type="button" onClick={openCopySitesModal}>
-          <IconCopy /> {language.pages.siteTable.copySitesButtonText}
-        </ButtonSecondary>
+        {isAppOnline ? (
+          <ButtonSecondary type="button" onClick={openCopySitesModal}>
+            <IconCopy /> {language.pages.siteTable.copySitesButtonText}
+          </ButtonSecondary>
+        ) : null}
         {readOnlySitesHeaderContent}
       </ToolbarButtonWrapper>
       <CopySitesModal


### PR DESCRIPTION
trello ticket [here](https://trello.com/c/5AHIwNMq/890-hide-copy-sites-from-other-projects-and-copy-mrs-from-other-projects-buttons-when-offline)

to test:

1. go to sites or management regimes
2. toggle offline/online button
3. copy sites + copy MR buttons should disappear when offline