### PR TITLE
fix/feat: 891 reset all collect record input/observations on input ch…

### DIFF
--- a/src/App/mermaidData/databaseSwitchboard/CollectRecordsMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/CollectRecordsMixin.js
@@ -520,11 +520,9 @@ const CollectRecordsMixin = (Base) =>
       const originalRecordLevelValidations = record.validations.results.$record
       const recordLevelValidationsWithReset = originalRecordLevelValidations.map((validation) => {
         if (validation.validation_id === validationId) {
-          const currentValidationStatus = validation.status
-
           return {
             ...validation,
-            status: currentValidationStatus === 'ignore' ? 'reset' : currentValidationStatus,
+            status: 'reset',
           }
         }
 
@@ -542,7 +540,7 @@ const CollectRecordsMixin = (Base) =>
         .then(() => recordWithResetValidation)
     }
 
-    resetNonObservationFieldValidations = function resetNonObservationFieldValidations({
+    resetNonObservationFieldValidations = async function resetNonObservationFieldValidations({
       record,
       validationPath,
     }) {
@@ -557,18 +555,18 @@ const CollectRecordsMixin = (Base) =>
         path,
       })
 
+      if (!currentValidations) {
+        return record
+      }
+
       const currentValidationsProperties = Object.keys(currentValidations)
 
       const resettedValidations = currentValidationsProperties.map((currentValidationsProperty) => {
         const currentValidationObject = currentValidations[currentValidationsProperty]
-        const currentValidationStatus = currentValidationObject.status
 
         return {
           ...currentValidationObject,
-          status:
-            currentValidationStatus === 'ignore' || currentValidationStatus === 'warning'
-              ? 'reset'
-              : currentValidationStatus,
+          status: 'reset',
         }
       })
 
@@ -612,12 +610,10 @@ const CollectRecordsMixin = (Base) =>
             return singleObservationValidations.map((validation) => {
               const isValidationBelongingToObservation =
                 validation.context?.observation_id === observationId
-              const isIgnored = validation.status === 'ignore'
 
               return {
                 ...validation,
-                status:
-                  isValidationBelongingToObservation && isIgnored ? 'reset' : validation.status,
+                status: isValidationBelongingToObservation ? 'reset' : validation.status,
               }
             })
           },

--- a/src/components/generic/InlineMessage/InlineMessage.js
+++ b/src/components/generic/InlineMessage/InlineMessage.js
@@ -33,13 +33,11 @@ const InlineMessageWrapper = styled.div`
 `
 
 const InlineMessage = ({ type, children, className }) => {
-  const typeToUse = type === 'reset' ? 'warning' : type
-
   return (
     <>
       {type && (
-        <MessagePill type={typeToUse} className={className}>
-          {language.inlineMessage[typeToUse]}
+        <MessagePill type={type} className={className}>
+          {language.inlineMessage[type]}
         </MessagePill>
       )}
       <InlineMessageWrapper className={className}>{children}</InlineMessageWrapper>

--- a/src/components/mermaidInputs/InputValidationInfo/InputValidationInfo.js
+++ b/src/components/mermaidInputs/InputValidationInfo/InputValidationInfo.js
@@ -26,7 +26,6 @@ const InputValidationInfo = ({
   const areThereValidationMessages = validationMessages.length
   const isWarningValidation = areThereValidationMessages && validationType === 'warning'
   const isIgnoredWarningValidation = validationType === 'ignore'
-  const isResetIgnoredWarningValidation = validationType === 'reset'
   const isErrorValidation = validationType === 'error'
   const isValidationPassing = validationType === 'ok'
 
@@ -88,8 +87,7 @@ const InputValidationInfo = ({
           </InlineMessage>
         </>
       ) : null}
-      {areThereValidationMessages &&
-      (isErrorValidation || isWarningValidation || isResetIgnoredWarningValidation) ? (
+      {areThereValidationMessages && (isErrorValidation || isWarningValidation) ? (
         <>
           {validationMessages.map((validation) => (
             <InlineMessage
@@ -102,9 +100,7 @@ const InputValidationInfo = ({
           ))}
         </>
       ) : null}
-      {isWarningValidation || isIgnoredWarningValidation || isResetIgnoredWarningValidation
-        ? getWarningValidationButtons()
-        : null}
+      {isWarningValidation || isIgnoredWarningValidation ? getWarningValidationButtons() : null}
       {isValidationPassing ? <span aria-label="Passed Validation">&nbsp;</span> : null}
     </ValidationWrapper>
   )

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -109,7 +109,6 @@ const BenthicLitObservationsTable = ({
         hasObservationIgnoredValidation,
         observationValidationMessages,
         observationValidationType,
-        hasObservationResetIgnoredValidation,
       } = getObservationValidationInfo({
         observationId,
         collectRecord,
@@ -137,6 +136,9 @@ const BenthicLitObservationsTable = ({
             observationId,
           },
         })
+        resetObservationValidations({
+          observationId,
+        })
       }
 
       const handleGrowthFormChange = (selectedOption) => {
@@ -150,6 +152,9 @@ const BenthicLitObservationsTable = ({
             observationId,
           },
         })
+        resetObservationValidations({
+          observationId,
+        })
       }
 
       const handleLengthChange = (event) => {
@@ -162,6 +167,9 @@ const BenthicLitObservationsTable = ({
             newValue,
             observationId,
           },
+        })
+        resetObservationValidations({
+          observationId,
         })
       }
 
@@ -241,7 +249,6 @@ const BenthicLitObservationsTable = ({
             <ObservationValidationInfo
               hasObservationErrorValidation={hasObservationErrorValidation}
               hasObservationIgnoredValidation={hasObservationIgnoredValidation}
-              hasObservationResetIgnoredValidation={hasObservationResetIgnoredValidation}
               hasObservationWarningValidation={hasObservationWarningValidation}
               ignoreObservationValidations={ignoreObservationValidations}
               isObservationValid={isObservationValid}

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitTransectInputs.js
@@ -30,7 +30,6 @@ const BenthicLitTransectInputs = ({
   areValidationsShowing,
   choices,
   formik,
-  setIgnoredItemsToBeRevalidated,
   ignoreNonObservationFieldValidations,
   resetNonObservationFieldValidations,
   validationsApiData,
@@ -97,95 +96,84 @@ const BenthicLitTransectInputs = ({
 
   const handleTransectNumberChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'number',
-      validationProperties: transectNumberValidationProperties,
       validationPath: TRANSECT_NUMBER_VALIDATION_PATH,
     })
   }
 
   const handleLabelChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'label',
-      validationProperties: labelValidationProperties,
       validationPath: LABEL_VALIDATION_PATH,
     })
   }
 
   const handleLengthSurveyedChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'len_surveyed',
-      validationProperties: lengthSurveyedValidationProperties,
       validationPath: LENGHT_SURVEYED_VALIDATION_PATH,
     })
   }
 
   const handleReefSlopeChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'reef_slope',
-      validationProperties: reefSlopeValidationProperties,
       validationPath: REEF_SLOPE_VALIDATION_PATH,
     })
   }
   const handleRelativeDepthChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'relative_depth',
-      validationProperties: relativeDepthValidationProperties,
       validationPath: RELATIVE_DEPTH_VALIDATION_PATH,
     })
   }
   const handleVisibilityChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'visibility',
-      validationProperties: visibilityValidationProperties,
       validationPath: VISIBILITY_VALIDATION_PATH,
     })
   }
   const handleCurrentChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'current',
-      validationProperties: currentValidationProperties,
       validationPath: CURRENT_VALIDATION_PATH,
     })
   }
 
   const handleNotesChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'notes',
-      validationProperties: notesValidationProperties,
       validationPath: NOTES_VALIDATION_PATH,
     })
   }
   const handleTideChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'tide',
-      validationProperties: tideValidationProperties,
       validationPath: TIDE_VALIDATION_PATH,
     })
   }
 
   const handleSampleTimeChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'sample_time',
-      validationProperties: sampleTimeValidationProperties,
       validationPath: SAMPLE_TIME_VALIDATION_PATH,
     })
   }
 
   const handleDepthChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'depth',
-      validationProperties: depthValidationProperties,
       validationPath: DEPTH_VALIDATION_PATH,
     })
   }
@@ -402,7 +390,6 @@ BenthicLitTransectInputs.propTypes = {
   areValidationsShowing: PropTypes.bool.isRequired,
   choices: choicesPropType.isRequired,
   formik: formikPropType.isRequired,
-  setIgnoredItemsToBeRevalidated: PropTypes.func.isRequired,
   ignoreNonObservationFieldValidations: PropTypes.func.isRequired,
   resetNonObservationFieldValidations: PropTypes.func.isRequired,
   validationsApiData: benthicPitValidationPropType.isRequired,

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicAttributeTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicAttributeTransectInputs.js
@@ -33,7 +33,6 @@ const TransectInputs = ({
   areValidationsShowing,
   choices,
   formik,
-  setIgnoredItemsToBeRevalidated,
   ignoreNonObservationFieldValidations,
   resetNonObservationFieldValidations,
   validationsApiData,
@@ -106,105 +105,79 @@ const TransectInputs = ({
   )
 
   const handleTransectNumberChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'number',
-      validationProperties: transectNumberValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: TRANSECT_NUMBER_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
   const handleLabelChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'label',
-      validationProperties: labelValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: LABEL_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
   const handleSampleTimeChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'sample_time',
-      validationProperties: sampleTimeValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: SAMPLE_TIME_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
   const handleDepthChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'depth',
-      validationProperties: depthValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: DEPTH_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
   const handleLengthSurveyedChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'len_surveyed',
-      validationProperties: lengthSurveyedValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: LENGTH_SURVEYED_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
   const handleQuadratNumberStartChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'quadrat_number_start',
-      validationProperties: quadratNumberStartValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: QUADRAT_NUMBER_START_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
   const handleQuadratSizeChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'quadrat_size',
-      validationProperties: quadratSizeValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: QUADRAT_SIZE_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
   const handleNumberOfQuadratsChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'num_quadrats',
-      validationProperties: numberOfQuadratsValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: NUM_QUADRATS_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
   const handleNumberOfPointsPerQuadratChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'num_points_per_quadrat',
-      validationProperties: numberOfPointsPerQuadratValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: NUM_POINTS_PER_QUADRAT_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
   const handleVisibilityChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'visibility',
-      validationProperties: visibilityValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: VISIBILITY_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
   const handleCurrentChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'current',
-      validationProperties: currentValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: CURRENT_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
   const handleRelativeDepthChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'relative_depth',
-      validationProperties: relativeDepthValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: RELATIVE_DEPTH_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
   const handleTideChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'tide',
-      validationProperties: tideValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: TIDE_VALIDATION_PATH,
     })
     formik.handleChange(event)
@@ -212,9 +185,7 @@ const TransectInputs = ({
 
   const handleNotesChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'notes',
-      validationProperties: notesValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: NOTES_VALIDATION_PATH,
     })
   }
@@ -492,7 +463,6 @@ TransectInputs.propTypes = {
   areValidationsShowing: PropTypes.bool.isRequired,
   choices: choicesPropType.isRequired,
   formik: formikPropType.isRequired,
-  setIgnoredItemsToBeRevalidated: PropTypes.func.isRequired,
   ignoreNonObservationFieldValidations: PropTypes.func.isRequired,
   resetNonObservationFieldValidations: PropTypes.func.isRequired,
   validationsApiData: PropTypes.shape({ quadrat_transect: benthicpqtValidationPropType })

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -199,7 +199,6 @@ const BenthicPhotoQuadratObservationTable = ({
         hasObservationIgnoredValidation,
         observationValidationMessages,
         observationValidationType,
-        hasObservationResetIgnoredValidation,
       } = getObservationValidationInfo({
         observationId,
         collectRecord,
@@ -218,6 +217,9 @@ const BenthicPhotoQuadratObservationTable = ({
           type: 'updateQuadratNumber',
           payload: { newQuadratNumber: event.target.value, observationId },
         })
+        resetObservationValidations({
+          observationId,
+        })
       }
 
       const handleBenthicAttributeChange = (selectedOption) => {
@@ -230,6 +232,9 @@ const BenthicPhotoQuadratObservationTable = ({
             newBenthicAttribute,
             observationId,
           },
+        })
+        resetObservationValidations({
+          observationId,
         })
       }
 
@@ -244,6 +249,9 @@ const BenthicPhotoQuadratObservationTable = ({
             observationId,
           },
         })
+        resetObservationValidations({
+          observationId,
+        })
       }
 
       const handleNumberOfPointsChange = (event) => {
@@ -251,6 +259,9 @@ const BenthicPhotoQuadratObservationTable = ({
         observationsDispatch({
           type: 'updateNumberOfPoints',
           payload: { newNumberOfPoints: event.target.value, observationId },
+        })
+        resetObservationValidations({
+          observationId,
         })
       }
 
@@ -347,7 +358,6 @@ const BenthicPhotoQuadratObservationTable = ({
             <ObservationValidationInfo
               hasObservationErrorValidation={hasObservationErrorValidation}
               hasObservationIgnoredValidation={hasObservationIgnoredValidation}
-              hasObservationResetIgnoredValidation={hasObservationResetIgnoredValidation}
               hasObservationWarningValidation={hasObservationWarningValidation}
               ignoreObservationValidations={ignoreObservationValidations}
               isObservationValid={isObservationValid}

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
@@ -135,7 +135,6 @@ const BenthicPitObservationsTable = ({
         hasObservationIgnoredValidation,
         observationValidationMessages,
         observationValidationType,
-        hasObservationResetIgnoredValidation,
       } = getObservationValidationInfo({
         observationId,
         collectRecord,
@@ -163,6 +162,9 @@ const BenthicPitObservationsTable = ({
             observationId,
           },
         })
+        resetObservationValidations({
+          observationId,
+        })
       }
 
       const handleGrowthFormChange = (selectedOption) => {
@@ -175,6 +177,9 @@ const BenthicPitObservationsTable = ({
             newGrowthForm,
             observationId,
           },
+        })
+        resetObservationValidations({
+          observationId,
         })
       }
 
@@ -248,7 +253,6 @@ const BenthicPitObservationsTable = ({
             <ObservationValidationInfo
               hasObservationErrorValidation={hasObservationErrorValidation}
               hasObservationIgnoredValidation={hasObservationIgnoredValidation}
-              hasObservationResetIgnoredValidation={hasObservationResetIgnoredValidation}
               hasObservationWarningValidation={hasObservationWarningValidation}
               ignoreObservationValidations={ignoreObservationValidations}
               isObservationValid={isObservationValid}

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitTransectInputs.js
@@ -32,7 +32,6 @@ const BenthicPitTransectInputs = ({
   areValidationsShowing,
   choices,
   formik,
-  setIgnoredItemsToBeRevalidated,
   ignoreNonObservationFieldValidations,
   resetNonObservationFieldValidations,
   validationsApiData,
@@ -109,113 +108,87 @@ const BenthicPitTransectInputs = ({
 
   const handleTransectNumberChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'number',
-      validationProperties: transectNumberValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: TRANSECT_NUMBER_VALIDATION_PATH,
     })
   }
 
   const handleLabelChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'label',
-      validationProperties: labelValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: LABEL_VALIDATION_PATH,
     })
   }
 
   const handleLengthSurveyedChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'len_surveyed',
-      validationProperties: lengthSurveyedValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: LENGHT_SURVEYED_VALIDATION_PATH,
     })
   }
 
   const handleReefSlopeChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'reef_slope',
-      validationProperties: reefSlopeValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: REEF_SLOPE_VALIDATION_PATH,
     })
   }
   const handleRelativeDepthChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'relative_depth',
-      validationProperties: relativeDepthValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: RELATIVE_DEPTH_VALIDATION_PATH,
     })
   }
   const handleVisibilityChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'visibility',
-      validationProperties: visibilityValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: VISIBILITY_VALIDATION_PATH,
     })
   }
   const handleCurrentChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'current',
-      validationProperties: currentValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: CURRENT_VALIDATION_PATH,
     })
   }
 
   const handleNotesChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'notes',
-      validationProperties: notesValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: NOTES_VALIDATION_PATH,
     })
   }
   const handleTideChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'tide',
-      validationProperties: tideValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: TIDE_VALIDATION_PATH,
     })
   }
 
   const handleSampleTimeChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'sample_time',
-      validationProperties: sampleTimeValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: SAMPLE_TIME_VALIDATION_PATH,
     })
   }
 
   const handleDepthChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'depth',
-      validationProperties: depthValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: DEPTH_VALIDATION_PATH,
     })
   }
 
   const handleIntervalSizeChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'interval_size',
-      validationProperties: intervalSizeValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: INTERVAL_SIZE_VALIDATION_PATH,
     })
   }
 
   const handleIntervalStartChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'interval_start',
-      validationProperties: intervalStartValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: INTERVAL_START_VALIDATION_PATH,
     })
   }
@@ -476,7 +449,6 @@ BenthicPitTransectInputs.propTypes = {
   areValidationsShowing: PropTypes.bool.isRequired,
   choices: choicesPropType.isRequired,
   formik: formikPropType.isRequired,
-  setIgnoredItemsToBeRevalidated: PropTypes.func.isRequired,
   ignoreNonObservationFieldValidations: PropTypes.func.isRequired,
   resetNonObservationFieldValidations: PropTypes.func.isRequired,
   validationsApiData: benthicPitValidationPropType.isRequired,

--- a/src/components/pages/collectRecordFormPages/BleachingForm/BleachingTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/BleachingTransectInputs.js
@@ -28,7 +28,6 @@ const BleachingTransectInputs = ({
   areValidationsShowing,
   choices,
   formik,
-  setIgnoredItemsToBeRevalidated,
   ignoreNonObservationFieldValidations,
   resetNonObservationFieldValidations,
   validationsApiData,
@@ -84,78 +83,60 @@ const BleachingTransectInputs = ({
 
   const handleLabelChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'label',
-      validationProperties: labelValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: LABEL_VALIDATION_PATH,
     })
   }
 
   const handleQuadratSizeChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'quadrat_size',
-      validationProperties: quadratSizeValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: QUADRAT_SIZE_VALIDATION_PATH,
     })
   }
 
   const handleRelativeDepthChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'relative_depth',
-      validationProperties: relativeDepthValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: RELATIVE_DEPTH_VALIDATION_PATH,
     })
   }
   const handleVisibilityChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'visibility',
-      validationProperties: visibilityValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: VISIBILITY_VALIDATION_PATH,
     })
   }
   const handleCurrentChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'current',
-      validationProperties: currentValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: CURRENT_VALIDATION_PATH,
     })
   }
 
   const handleNotesChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'notes',
-      validationProperties: notesValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: NOTES_VALIDATION_PATH,
     })
   }
   const handleTideChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'tide',
-      validationProperties: tideValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: TIDE_VALIDATION_PATH,
     })
   }
 
   const handleSampleTimeChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'sample_time',
-      validationProperties: sampleTimeValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: SAMPLE_TIME_VALIDATION_PATH,
     })
   }
 
   const handleDepthChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'depth',
-      validationProperties: depthValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: DEPTH_VALIDATION_PATH,
     })
   }
@@ -334,7 +315,6 @@ BleachingTransectInputs.propTypes = {
   areValidationsShowing: PropTypes.bool.isRequired,
   choices: choicesPropType.isRequired,
   formik: formikPropType.isRequired,
-  setIgnoredItemsToBeRevalidated: PropTypes.func.isRequired,
   ignoreNonObservationFieldValidations: PropTypes.func.isRequired,
   resetNonObservationFieldValidations: PropTypes.func.isRequired,
   validationsApiData: benthicPitValidationPropType.isRequired,

--- a/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
@@ -127,7 +127,6 @@ const ColoniesBleachedObservationTable = ({
         hasObservationIgnoredValidation,
         observationValidationMessages,
         observationValidationType,
-        hasObservationResetIgnoredValidation,
       } = getObservationValidationInfo({
         observationId,
         collectRecord,
@@ -155,6 +154,9 @@ const ColoniesBleachedObservationTable = ({
             observationId,
           },
         })
+        resetObservationValidations({
+          observationId,
+        })
       }
 
       const handleGrowthFormChange = (selectedOption) => {
@@ -168,6 +170,9 @@ const ColoniesBleachedObservationTable = ({
             observationId,
           },
         })
+        resetObservationValidations({
+          observationId,
+        })
       }
 
       const handleObservationInputChange = ({ event, dispatchType }) => {
@@ -180,6 +185,9 @@ const ColoniesBleachedObservationTable = ({
             newValue,
             observationId,
           },
+        })
+        resetObservationValidations({
+          observationId,
         })
       }
 
@@ -328,7 +336,6 @@ const ColoniesBleachedObservationTable = ({
             <ObservationValidationInfo
               hasObservationErrorValidation={hasObservationErrorValidation}
               hasObservationIgnoredValidation={hasObservationIgnoredValidation}
-              hasObservationResetIgnoredValidation={hasObservationResetIgnoredValidation}
               hasObservationWarningValidation={hasObservationWarningValidation}
               ignoreObservationValidations={ignoreObservationValidations}
               isObservationValid={isObservationValid}

--- a/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
@@ -105,7 +105,6 @@ const PercentCoverObservationTable = ({
         hasObservationIgnoredValidation,
         observationValidationMessages,
         observationValidationType,
-        hasObservationResetIgnoredValidation,
       } = getObservationValidationInfo({
         observationId,
         collectRecord,
@@ -132,6 +131,9 @@ const PercentCoverObservationTable = ({
             newValue,
             observationId,
           },
+        })
+        resetObservationValidations({
+          observationId,
         })
       }
 
@@ -184,7 +186,6 @@ const PercentCoverObservationTable = ({
             <ObservationValidationInfo
               hasObservationErrorValidation={hasObservationErrorValidation}
               hasObservationIgnoredValidation={hasObservationIgnoredValidation}
-              hasObservationResetIgnoredValidation={hasObservationResetIgnoredValidation}
               hasObservationWarningValidation={hasObservationWarningValidation}
               ignoreObservationValidations={ignoreObservationValidations}
               isObservationValid={isObservationValid}

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
@@ -370,21 +370,23 @@ const CollectRecordFormPage = ({
 
   const resetObservationValidations = useCallback(
     ({ observationId }) => {
-      databaseSwitchboardInstance
-        .resetObservationValidations({ recordId: collectRecordBeingEdited.id, observationId })
-        .then((recordWithResetValidations) => {
-          handleCollectRecordChange(recordWithResetValidations)
+      if (collectRecordBeingEdited && observationId) {
+        databaseSwitchboardInstance
+          .resetObservationValidations({ recordId: collectRecordBeingEdited.id, observationId })
+          .then((recordWithResetValidations) => {
+            handleCollectRecordChange(recordWithResetValidations)
 
-          setIsFormDirty(true)
-        })
-        .catch((error) => {
-          handleHttpResponseError({
-            error,
-            callback: () => {
-              toast.error(...getToastArguments(language.error.collectRecordValidationReset))
-            },
+            setIsFormDirty(true)
           })
-        })
+          .catch((error) => {
+            handleHttpResponseError({
+              error,
+              callback: () => {
+                toast.error(...getToastArguments(language.error.collectRecordValidationReset))
+              },
+            })
+          })
+      }
     },
     [
       collectRecordBeingEdited,
@@ -424,23 +426,25 @@ const CollectRecordFormPage = ({
 
   const resetNonObservationFieldValidations = useCallback(
     ({ validationPath }) => {
-      databaseSwitchboardInstance
-        .resetNonObservationFieldValidations({
-          record: collectRecordBeingEdited,
-          validationPath,
-        })
-        .then((recordWithResetValidations) => {
-          handleCollectRecordChange(recordWithResetValidations)
-          setIsFormDirty(true)
-        })
-        .catch((error) => {
-          handleHttpResponseError({
-            error,
-            callback: () => {
-              toast.error(...getToastArguments(language.error.collectRecordValidationReset))
-            },
+      if (collectRecordBeingEdited && validationPath) {
+        databaseSwitchboardInstance
+          .resetNonObservationFieldValidations({
+            record: collectRecordBeingEdited,
+            validationPath,
           })
-        })
+          .then((recordWithResetValidations) => {
+            handleCollectRecordChange(recordWithResetValidations)
+            setIsFormDirty(true)
+          })
+          .catch((error) => {
+            handleHttpResponseError({
+              error,
+              callback: () => {
+                toast.error(...getToastArguments(language.error.collectRecordValidationReset))
+              },
+            })
+          })
+      }
     },
     [
       collectRecordBeingEdited,
@@ -469,15 +473,6 @@ const CollectRecordFormPage = ({
       setSaveButtonState(buttonGroupStates.unsaved)
     }
   }, [isFormDirty, setSaveButtonState])
-
-  const setIgnoredItemsToBeRevalidated = ({ validationProperties, validationPath, inputName }) => {
-    const isInputDirty = formik.initialValues[inputName] === formik.values[inputName]
-    const doesFieldHaveIgnoredValidation = validationProperties.validationType === 'ignore'
-
-    if (doesFieldHaveIgnoredValidation && isInputDirty) {
-      resetNonObservationFieldValidations({ validationPath })
-    }
-  }
 
   const validationPropertiesWithDirtyResetOnInputChange = (validationProperties, property) => {
     // for UX purpose only, validation is cleared when input is on change after page is validated
@@ -539,7 +534,6 @@ const CollectRecordFormPage = ({
       areValidationsShowing={areValidationsShowing}
       choices={choices}
       formik={formik}
-      setIgnoredItemsToBeRevalidated={setIgnoredItemsToBeRevalidated}
       ignoreNonObservationFieldValidations={ignoreNonObservationFieldValidations}
       onSizeBinChange={handleSizeBinChange}
       resetNonObservationFieldValidations={resetNonObservationFieldValidations}
@@ -553,7 +547,6 @@ const CollectRecordFormPage = ({
       areValidationsShowing={areValidationsShowing}
       choices={choices}
       formik={formik}
-      setIgnoredItemsToBeRevalidated={setIgnoredItemsToBeRevalidated}
       ignoreNonObservationFieldValidations={ignoreNonObservationFieldValidations}
       resetNonObservationFieldValidations={resetNonObservationFieldValidations}
       validationsApiData={validationsApiData}
@@ -624,7 +617,6 @@ const CollectRecordFormPage = ({
           handleManagementRegimesChange={handleManagementRegimesChange}
           sites={sites}
           handleSitesChange={handleSitesChange}
-          setIgnoredItemsToBeRevalidated={setIgnoredItemsToBeRevalidated}
           ignoreNonObservationFieldValidations={ignoreNonObservationFieldValidations}
           resetNonObservationFieldValidations={resetNonObservationFieldValidations}
           validationPropertiesWithDirtyResetOnInputChange={
@@ -638,7 +630,6 @@ const CollectRecordFormPage = ({
           formik={formik}
           ignoreNonObservationFieldValidations={ignoreNonObservationFieldValidations}
           observers={observerProfiles}
-          setIgnoredItemsToBeRevalidated={setIgnoredItemsToBeRevalidated}
           resetNonObservationFieldValidations={resetNonObservationFieldValidations}
           validationsApiData={validationsApiData}
           validationPropertiesWithDirtyResetOnInputChange={

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPageAlternative/CollectRecordFormPageAlternative.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPageAlternative/CollectRecordFormPageAlternative.js
@@ -276,7 +276,6 @@ const CollectRecordFormPageAlternative = ({
   )
 
   const {
-    setIgnoredItemsToBeRevalidated,
     handleScrollToObservation,
     handleValidate,
     ignoreNonObservationFieldValidations,
@@ -429,7 +428,6 @@ const CollectRecordFormPageAlternative = ({
           handleManagementRegimesChange={handleManagementRegimesChange}
           sites={sites}
           handleSitesChange={handleSitesChange}
-          setIgnoredItemsToBeRevalidated={setIgnoredItemsToBeRevalidated}
           ignoreNonObservationFieldValidations={ignoreNonObservationFieldValidations}
           resetNonObservationFieldValidations={resetNonObservationFieldValidations}
           validationPropertiesWithDirtyResetOnInputChange={
@@ -440,7 +438,6 @@ const CollectRecordFormPageAlternative = ({
           areValidationsShowing={areValidationsShowing}
           choices={choices}
           formik={formik}
-          setIgnoredItemsToBeRevalidated={setIgnoredItemsToBeRevalidated}
           ignoreNonObservationFieldValidations={ignoreNonObservationFieldValidations}
           resetNonObservationFieldValidations={resetNonObservationFieldValidations}
           validationsApiData={validationsApiData}
@@ -455,7 +452,6 @@ const CollectRecordFormPageAlternative = ({
           formik={formik}
           ignoreNonObservationFieldValidations={ignoreNonObservationFieldValidations}
           observers={observerProfiles}
-          setIgnoredItemsToBeRevalidated={setIgnoredItemsToBeRevalidated}
           resetNonObservationFieldValidations={resetNonObservationFieldValidations}
           validationsApiData={validationsApiData}
           validationPropertiesWithDirtyResetOnInputChange={

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPageAlternative/useCollectRecordValidation.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPageAlternative/useCollectRecordValidation.js
@@ -139,21 +139,23 @@ const useCollectRecordValidation = ({
 
   const resetObservationValidations = useCallback(
     ({ observationId }) => {
-      databaseSwitchboardInstance
-        .resetObservationValidations({ recordId: collectRecordBeingEdited.id, observationId })
-        .then((recordWithResetValidations) => {
-          handleCollectRecordChange(recordWithResetValidations)
+      if (collectRecordBeingEdited && observationId) {
+        databaseSwitchboardInstance
+          .resetObservationValidations({ recordId: collectRecordBeingEdited.id, observationId })
+          .then((recordWithResetValidations) => {
+            handleCollectRecordChange(recordWithResetValidations)
 
-          setIsFormDirty(true)
-        })
-        .catch((error) => {
-          handleHttpResponseError({
-            error,
-            callback: () => {
-              toast.error(...getToastArguments(language.error.collectRecordValidationReset))
-            },
+            setIsFormDirty(true)
           })
-        })
+          .catch((error) => {
+            handleHttpResponseError({
+              error,
+              callback: () => {
+                toast.error(...getToastArguments(language.error.collectRecordValidationReset))
+              },
+            })
+          })
+      }
     },
     [
       collectRecordBeingEdited,
@@ -251,22 +253,7 @@ const useCollectRecordValidation = ({
     ],
   )
 
-  const setIgnoredItemsToBeRevalidated = ({
-    validationProperties,
-    validationPath,
-    inputName,
-  }) => {
-    const isInputDirty =
-      formikInstance.initialValues[inputName] === formikInstance.values[inputName]
-    const doesFieldHaveIgnoredValidation = validationProperties.validationType === 'ignore'
-
-    if (doesFieldHaveIgnoredValidation && isInputDirty) {
-      resetNonObservationFieldValidations({ validationPath })
-    }
-  }
-
   return {
-    setIgnoredItemsToBeRevalidated,
     handleScrollToObservation,
     handleValidate,
     ignoreNonObservationFieldValidations,

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -219,6 +219,9 @@ const FishBeltObservationTable = ({
           type: 'updateSize',
           payload: { newSize, observationId },
         })
+        resetObservationValidations({
+          observationId,
+        })
       }
 
       const handleUpdateSizeEvent = (event) => {
@@ -234,6 +237,9 @@ const FishBeltObservationTable = ({
         observationsDispatch({
           type: 'updateCount',
           payload: { newCount: event.target.value, observationId },
+        })
+        resetObservationValidations({
+          observationId,
         })
       }
 
@@ -286,6 +292,9 @@ const FishBeltObservationTable = ({
             observationId,
           },
         })
+        resetObservationValidations({
+          observationId,
+        })
       }
 
       const handleFishNameKeyDown = (event) => {
@@ -305,7 +314,6 @@ const FishBeltObservationTable = ({
         hasObservationIgnoredValidation,
         observationValidationMessages,
         observationValidationType,
-        hasObservationResetIgnoredValidation,
       } = getObservationValidationInfo({
         observationId,
         collectRecord,
@@ -370,7 +378,6 @@ const FishBeltObservationTable = ({
             <ObservationValidationInfo
               hasObservationErrorValidation={hasObservationErrorValidation}
               hasObservationIgnoredValidation={hasObservationIgnoredValidation}
-              hasObservationResetIgnoredValidation={hasObservationResetIgnoredValidation}
               hasObservationWarningValidation={hasObservationWarningValidation}
               ignoreObservationValidations={ignoreObservationValidations}
               isObservationValid={isObservationValid}

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
@@ -33,7 +33,6 @@ const FishBeltTransectInputs = ({
   areValidationsShowing,
   choices,
   formik,
-  setIgnoredItemsToBeRevalidated,
   ignoreNonObservationFieldValidations,
   onSizeBinChange,
   resetNonObservationFieldValidations,
@@ -119,109 +118,96 @@ const FishBeltTransectInputs = ({
 
   const handleTransectNumberChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'number',
-      validationProperties: transectNumberValidationProperties,
       validationPath: TRANSECT_NUMBER_VALIDATION_PATH,
     })
   }
 
   const handleLabelChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'label',
-      validationProperties: labelValidationProperties,
       validationPath: LABEL_VALIDATION_PATH,
     })
   }
 
   const handleLengthSurveyedChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'len_surveyed',
-      validationProperties: lengthSurveyedValidationProperties,
       validationPath: LENGHT_SURVEYED_VALIDATION_PATH,
     })
   }
   const handleWidthChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'width',
-      validationProperties: widthValidationProperties,
       validationPath: WIDTH_VALIDATION_PATH,
     })
   }
   const handleSizeBinChange = (event) => {
     onSizeBinChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'size_bin',
-      validationProperties: sizeBinValidationProperties,
       validationPath: SIZE_BIN_VALIDATION_PATH,
     })
   }
   const handleReefSlopeChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'reef_slope',
-      validationProperties: reefSlopeValidationProperties,
       validationPath: REEF_SLOPE_VALIDATION_PATH,
     })
   }
   const handleRelativeDepthChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'relative_depth',
-      validationProperties: relativeDepthValidationProperties,
       validationPath: RELATIVE_DEPTH_VALIDATION_PATH,
     })
   }
   const handleVisibilityChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'visibility',
-      validationProperties: visibilityValidationProperties,
       validationPath: VISIBILITY_VALIDATION_PATH,
     })
   }
   const handleCurrentChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'current',
-      validationProperties: currentValidationProperties,
       validationPath: CURRENT_VALIDATION_PATH,
     })
   }
   const handleTideChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'tide',
-      validationProperties: tideValidationProperties,
       validationPath: TIDE_VALIDATION_PATH,
     })
   }
   const handleNotesChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'notes',
-      validationProperties: notesValidationProperties,
       validationPath: NOTES_VALIDATION_PATH,
     })
   }
 
   const handleSampleTimeChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'sample_time',
-      validationProperties: sampleTimeValidationProperties,
       validationPath: SAMPLE_TIME_VALIDATION_PATH,
     })
   }
 
   const handleDepthChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'depth',
-      validationProperties: depthValidationProperties,
       validationPath: DEPTH_VALIDATION_PATH,
     })
   }
@@ -475,7 +461,6 @@ FishBeltTransectInputs.propTypes = {
   areValidationsShowing: PropTypes.bool.isRequired,
   choices: choicesPropType.isRequired,
   formik: formikPropType.isRequired,
-  setIgnoredItemsToBeRevalidated: PropTypes.func.isRequired,
   ignoreNonObservationFieldValidations: PropTypes.func.isRequired,
   onSizeBinChange: PropTypes.func.isRequired,
   resetNonObservationFieldValidations: PropTypes.func.isRequired,

--- a/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityObservationTable.js
@@ -114,7 +114,6 @@ const HabitatComplexityObservationsTable = ({
         hasObservationIgnoredValidation,
         observationValidationMessages,
         observationValidationType,
-        hasObservationResetIgnoredValidation,
       } = getObservationValidationInfo({
         observationId,
         collectRecord,
@@ -141,6 +140,9 @@ const HabitatComplexityObservationsTable = ({
             newValue,
             observationId,
           },
+        })
+        resetObservationValidations({
+          observationId,
         })
       }
 
@@ -176,7 +178,6 @@ const HabitatComplexityObservationsTable = ({
             <ObservationValidationInfo
               hasObservationErrorValidation={hasObservationErrorValidation}
               hasObservationIgnoredValidation={hasObservationIgnoredValidation}
-              hasObservationResetIgnoredValidation={hasObservationResetIgnoredValidation}
               hasObservationWarningValidation={hasObservationWarningValidation}
               ignoreObservationValidations={ignoreObservationValidations}
               isObservationValid={isObservationValid}

--- a/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityTransectInputs.js
@@ -31,7 +31,6 @@ const HabitatComplexityTransectInputs = ({
   areValidationsShowing,
   choices,
   formik,
-  setIgnoredItemsToBeRevalidated,
   ignoreNonObservationFieldValidations,
   resetNonObservationFieldValidations,
   validationsApiData,
@@ -103,104 +102,92 @@ const HabitatComplexityTransectInputs = ({
 
   const handleTransectNumberChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'number',
-      validationProperties: transectNumberValidationProperties,
       validationPath: TRANSECT_NUMBER_VALIDATION_PATH,
     })
   }
 
   const handleLabelChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'label',
-      validationProperties: labelValidationProperties,
       validationPath: LABEL_VALIDATION_PATH,
     })
   }
 
   const handleLengthSurveyedChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'len_surveyed',
-      validationProperties: lengthSurveyedValidationProperties,
       validationPath: LENGHT_SURVEYED_VALIDATION_PATH,
     })
   }
 
   const handleReefSlopeChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'reef_slope',
-      validationProperties: reefSlopeValidationProperties,
       validationPath: REEF_SLOPE_VALIDATION_PATH,
     })
   }
   const handleRelativeDepthChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'relative_depth',
-      validationProperties: relativeDepthValidationProperties,
       validationPath: RELATIVE_DEPTH_VALIDATION_PATH,
     })
   }
   const handleVisibilityChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'visibility',
-      validationProperties: visibilityValidationProperties,
       validationPath: VISIBILITY_VALIDATION_PATH,
     })
   }
   const handleCurrentChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'current',
-      validationProperties: currentValidationProperties,
       validationPath: CURRENT_VALIDATION_PATH,
     })
   }
 
   const handleNotesChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'notes',
-      validationProperties: notesValidationProperties,
       validationPath: NOTES_VALIDATION_PATH,
     })
   }
   const handleTideChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'tide',
-      validationProperties: tideValidationProperties,
       validationPath: TIDE_VALIDATION_PATH,
     })
   }
 
   const handleSampleTimeChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'sample_time',
-      validationProperties: sampleTimeValidationProperties,
       validationPath: SAMPLE_TIME_VALIDATION_PATH,
     })
   }
 
   const handleDepthChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'depth',
-      validationProperties: depthValidationProperties,
       validationPath: DEPTH_VALIDATION_PATH,
     })
   }
 
   const handleIntervalSizeChange = (event) => {
     formik.handleChange(event)
-    setIgnoredItemsToBeRevalidated({
+    resetNonObservationFieldValidations({
       inputName: 'interval_size',
-      validationProperties: intervalSizeValidationProperties,
       validationPath: INTERVAL_SIZE_VALIDATION_PATH,
     })
   }
@@ -438,7 +425,6 @@ HabitatComplexityTransectInputs.propTypes = {
   areValidationsShowing: PropTypes.bool.isRequired,
   choices: choicesPropType.isRequired,
   formik: formikPropType.isRequired,
-  setIgnoredItemsToBeRevalidated: PropTypes.func.isRequired,
   ignoreNonObservationFieldValidations: PropTypes.func.isRequired,
   resetNonObservationFieldValidations: PropTypes.func.isRequired,
   validationsApiData: habitatComplexityValidationPropType.isRequired,

--- a/src/components/pages/collectRecordFormPages/ObservationValidationInfo.js
+++ b/src/components/pages/collectRecordFormPages/ObservationValidationInfo.js
@@ -15,7 +15,6 @@ const ObservationValidationInfo = ({
   hasObservationIgnoredValidation,
   observationValidationMessages,
   observationValidationType,
-  hasObservationResetIgnoredValidation,
 }) => {
   const handleIgnoreWarningChange = async (event) => {
     const isIgnoreChecked = event.target.checked
@@ -35,9 +34,7 @@ const ObservationValidationInfo = ({
   return (
     <CellValidation>
       {isObservationValid ? <span aria-label="Passed Validation">&nbsp;</span> : null}
-      {hasObservationErrorValidation ||
-      hasObservationWarningValidation ||
-      hasObservationResetIgnoredValidation ? (
+      {hasObservationErrorValidation || hasObservationWarningValidation ? (
         <TableValidationList>
           {observationValidationMessages.map((validation) => (
             <li className={`${observationValidationType}-indicator`} key={validation.id}>
@@ -47,9 +44,7 @@ const ObservationValidationInfo = ({
         </TableValidationList>
       ) : null}
       {hasObservationIgnoredValidation ? <>Ignored</> : null}
-      {hasObservationWarningValidation ||
-      hasObservationIgnoredValidation ||
-      hasObservationResetIgnoredValidation ? (
+      {hasObservationWarningValidation || hasObservationIgnoredValidation ? (
         <InputIgnoreValidationWarningCheckboxWithLabel
           onChange={handleIgnoreWarningChange}
           checked={hasObservationIgnoredValidation}
@@ -69,7 +64,6 @@ ObservationValidationInfo.propTypes = {
   hasObservationIgnoredValidation: PropTypes.bool.isRequired,
   observationValidationMessages: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   observationValidationType: PropTypes.string.isRequired,
-  hasObservationResetIgnoredValidation: PropTypes.bool.isRequired,
 }
 
 export default ObservationValidationInfo

--- a/src/components/pages/collectRecordFormPages/ObserversInput/ObserversInput.js
+++ b/src/components/pages/collectRecordFormPages/ObserversInput/ObserversInput.js
@@ -17,7 +17,6 @@ const ObserversInput = ({
   formik,
   ignoreNonObservationFieldValidations,
   observers,
-  setIgnoredItemsToBeRevalidated,
   resetNonObservationFieldValidations,
   validationsApiData,
   validationPropertiesWithDirtyResetOnInputChange,
@@ -40,9 +39,7 @@ const ObserversInput = ({
     const selectedObservers = filterObserverProfiles(selectedItems)
 
     formik.setFieldValue('observers', selectedObservers)
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'observers',
-      validationProperties,
+    resetNonObservationFieldValidations({
       validationPath,
     })
   }
@@ -74,7 +71,6 @@ ObserversInput.propTypes = {
   formik: formikPropType.isRequired,
   ignoreNonObservationFieldValidations: PropTypes.func.isRequired,
   observers: observersPropType.isRequired,
-  setIgnoredItemsToBeRevalidated: PropTypes.func.isRequired,
   resetNonObservationFieldValidations: PropTypes.func.isRequired,
   validationsApiData: PropTypes.shape({ observers: observersValidationPropType }).isRequired,
   validationPropertiesWithDirtyResetOnInputChange: PropTypes.func.isRequired,

--- a/src/components/pages/collectRecordFormPages/SampleEventInputs/SampleEventInputs.js
+++ b/src/components/pages/collectRecordFormPages/SampleEventInputs/SampleEventInputs.js
@@ -26,7 +26,6 @@ const SampleEventInputs = ({
   handleManagementRegimesChange,
   sites,
   handleSitesChange,
-  setIgnoredItemsToBeRevalidated,
   ignoreNonObservationFieldValidations,
   resetNonObservationFieldValidations,
   validationPropertiesWithDirtyResetOnInputChange,
@@ -52,27 +51,21 @@ const SampleEventInputs = ({
   )
 
   const handleSiteChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'site',
-      validationProperties: siteValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: SITE_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
 
   const handleManagementChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'management',
-      validationProperties: managementValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: MANAGEMENT_VALIDATION_PATH,
     })
     formik.handleChange(event)
   }
 
   const handleSampleDateChange = (event) => {
-    setIgnoredItemsToBeRevalidated({
-      inputName: 'sample_date',
-      validationProperties: sampleDateValidationProperties,
+    resetNonObservationFieldValidations({
       validationPath: SAMPLE_DATE_VALIDATION_PATH,
     })
     formik.handleChange(event)
@@ -167,7 +160,6 @@ SampleEventInputs.propTypes = {
   handleManagementRegimesChange: PropTypes.func.isRequired,
   sites: PropTypes.arrayOf(sitePropType).isRequired,
   handleSitesChange: PropTypes.func.isRequired,
-  setIgnoredItemsToBeRevalidated: PropTypes.func.isRequired,
   ignoreNonObservationFieldValidations: PropTypes.func.isRequired,
   resetNonObservationFieldValidations: PropTypes.func.isRequired,
   validationPropertiesWithDirtyResetOnInputChange: PropTypes.func.isRequired,


### PR DESCRIPTION
Description:

when a user changes a collect record input or observation row input with any type of validation, the validation info clears, and the validation gets marked as 'reset' in browser storage (to update the api, which doesnt have its own logic for this yet)