### PR TITLE
fix: make fishbelt/benthic pqt form dirty when new observation added by enter or tab key

### DIFF
--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -182,6 +182,7 @@ const BenthicPhotoQuadratObservationTable = ({
           type: 'duplicateLastObservation',
           payload: { referenceObservation: observation },
         })
+        setAreObservationsInputsDirty(true)
       }
 
       if (isEnterKey && !isBenthicAttribute) {
@@ -193,6 +194,7 @@ const BenthicPhotoQuadratObservationTable = ({
             referenceObservationIndex: index,
           },
         })
+        setAreObservationsInputsDirty(true)
       }
     }
 

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -179,6 +179,7 @@ const FishBeltObservationTable = ({
           type: 'duplicateLastObservation',
           payload: { referenceObservation: observation },
         })
+        setAreObservationsInputsDirty(true)
       }
 
       if (isEnterKey && !isFishName) {
@@ -190,6 +191,7 @@ const FishBeltObservationTable = ({
             referenceObservationIndex: index,
           },
         })
+        setAreObservationsInputsDirty(true)
       }
     }
 


### PR DESCRIPTION

To test:

- go to a fishbelt or benthic photo quadrat collect record with an existing filled out observation table.
- go to the last input in the last row, and hit tab to create a new row

Expected result:
- the user is able to save the change


Do the same but using the enter key to create a new observation/row. 
- on any row, in the the last input cell, hit enter

Expected result:
- the user is able to save the change