### PR TITLE
fix: observation input behaviour with enter key

### DIFF
--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -72,7 +72,7 @@ const BenthicLitObservationsTable = ({
     const mermaidReferenceLink = process.env.REACT_APP_MERMAID_REFERENCE_LINK
     const growthFormSelectOptions = getOptions(choices.growthforms)
 
-    const handleKeyDown = ({ event, index, observation, isLastCell, isBenthicAttribute }) => {
+    const handleKeyDown = ({ event, index, observation, isLastCell }) => {
       const isTabKey = event.code === 'Tab' && !event.shiftKey
       const isEnterKey = event.code === 'Enter'
       const isLastRow = index === observationsState.length - 1
@@ -87,7 +87,7 @@ const BenthicLitObservationsTable = ({
         setAreObservationsInputsDirty(true)
       }
 
-      if (isEnterKey && !isBenthicAttribute) {
+      if (isEnterKey) {
         event.preventDefault()
         setAutoFocusAllowed(true)
         observationsDispatch({
@@ -166,14 +166,6 @@ const BenthicLitObservationsTable = ({
         })
       }
 
-      const handleBenthicAttributeKeyDown = (event) => {
-        handleKeyDown({ event, index, observation, isBenthicAttribute: true })
-      }
-
-      const handleLastCellKeyDown = (event) => {
-        handleKeyDown({ event, index, observation, isLastCell: true })
-      }
-
       const handleIgnoreObservationValidations = () => {
         ignoreObservationValidations({
           observationId,
@@ -218,6 +210,10 @@ const BenthicLitObservationsTable = ({
         setIsNewBenthicAttributeModalOpen(true)
       }
 
+      const handleObservationKeyDown = (event) => {
+        handleKeyDown({ event, index, observation })
+      }
+
       return (
         <ObservationTr key={observationId}>
           <Td align="center">{rowNumber}</Td>
@@ -231,7 +227,6 @@ const BenthicLitObservationsTable = ({
                   aria-labelledby="benthic-attribute-label"
                   options={benthicAttributeSelectOptions}
                   onChange={handleBenthicAttributeChange}
-                  onKeyDown={handleBenthicAttributeKeyDown}
                   value={attribute}
                   noResultsText={language.autocomplete.noResultsDefault}
                   noResultsAction={
@@ -258,6 +253,7 @@ const BenthicLitObservationsTable = ({
               onChange={handleGrowthFormChange}
               value={growth_form}
               aria-labelledby="growth-form-label"
+              onKeyDown={handleObservationKeyDown}
             >
               <option value=""> </option>
               {growthFormSelectOptions.map((item) => (
@@ -273,7 +269,7 @@ const BenthicLitObservationsTable = ({
               unit="m"
               aria-labelledby="length-label"
               onChange={handleLengthChange}
-              onKeyDown={handleLastCellKeyDown}
+              onKeyDown={(event) => handleKeyDown({ event, index, observation, isLastCell: true })}
             />
           </Td>
 

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -170,7 +170,7 @@ const BenthicPhotoQuadratObservationTable = ({
     const mermaidReferenceLink = process.env.REACT_APP_MERMAID_REFERENCE_LINK
     const growthFormOptions = getOptions(choices.growthforms)
 
-    const handleKeyDown = ({ event, index, observation, isBenthicAttribute, isNumberOfPoints }) => {
+    const handleKeyDown = ({ event, index, observation, isNumberOfPoints }) => {
       const isTabKey = event.code === 'Tab' && !event.shiftKey
       const isEnterKey = event.code === 'Enter'
       const isLastRow = index === observationsState.length - 1
@@ -184,7 +184,7 @@ const BenthicPhotoQuadratObservationTable = ({
         })
       }
 
-      if (isEnterKey && !isBenthicAttribute) {
+      if (isEnterKey) {
         event.preventDefault()
         setAutoFocusAllowed(true)
         observationsDispatch({
@@ -270,22 +270,6 @@ const BenthicPhotoQuadratObservationTable = ({
         })
       }
 
-      const handleBenthicAttributeKeyDown = (event) => {
-        handleKeyDown({ event, index, observation, isBenthicAttribute: true })
-      }
-
-      const handleQuadratNumberKeyDown = (event) => {
-        handleKeyDown({ event, index, observation })
-      }
-
-      const handleGrowthFormKeyDown = (event) => {
-        handleKeyDown({ event, index, observation })
-      }
-
-      const handleNumberOfPointsKeyDown = (event) => {
-        handleKeyDown({ event, index, observation, isNumberOfPoints: true })
-      }
-
       const handleIgnoreObservationValidations = () => {
         ignoreObservationValidations({
           observationId,
@@ -327,6 +311,10 @@ const BenthicPhotoQuadratObservationTable = ({
       )
       const proposeNewBenthicAttributeClick = () => openNewObservationModal(observationId)
 
+      const handleObservationKeyDown = (event) => {
+        handleKeyDown({ event, index, observation })
+      }
+
       return (
         <ObservationTr key={observationId}>
           <Td align="center">{rowNumber}</Td>
@@ -339,7 +327,7 @@ const BenthicPhotoQuadratObservationTable = ({
               step="any"
               aria-labelledby="quadrat-number-label"
               onChange={handleQuadratNumberChange}
-              onKeyDown={handleQuadratNumberKeyDown}
+              onKeyDown={handleObservationKeyDown}
             />
           </Td>
           <Td align="left">
@@ -350,7 +338,6 @@ const BenthicPhotoQuadratObservationTable = ({
                   aria-labelledby="benthic-attribute-label"
                   options={benthicAttributeOptions}
                   onChange={handleBenthicAttributeChange}
-                  onKeyDown={handleBenthicAttributeKeyDown}
                   value={attribute}
                   noResultsText={language.autocomplete.noResultsDefault}
                   noResultsAction={
@@ -375,7 +362,7 @@ const BenthicPhotoQuadratObservationTable = ({
           <Td align="right">
             <Select
               onChange={handleGrowthFormChange}
-              onKeyDown={handleGrowthFormKeyDown}
+              onKeyDown={handleObservationKeyDown}
               value={growthFormOrEmptyStringToAvoidInputValueErrors}
               aria-labelledby="growth-form-label"
             >
@@ -395,7 +382,9 @@ const BenthicPhotoQuadratObservationTable = ({
               step="any"
               aria-labelledby="number-of-points-label"
               onChange={handleNumberOfPointsChange}
-              onKeyDown={handleNumberOfPointsKeyDown}
+              onKeyDown={(event) => {
+                handleKeyDown({ event, index, observation, isNumberOfPoints: true })
+              }}
             />
           </Td>
           {areValidationsShowing ? validationsMarkup : null}

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
@@ -96,7 +96,7 @@ const BenthicPitObservationsTable = ({
     const mermaidReferenceLink = process.env.REACT_APP_MERMAID_REFERENCE_LINK
     const growthFormSelectOptions = getOptions(choices.growthforms)
 
-    const handleKeyDown = ({ event, index, observation, isGrowthForm, isBenthicAttribute }) => {
+    const handleKeyDown = ({ event, index, observation, isGrowthForm }) => {
       const isTabKey = event.code === 'Tab' && !event.shiftKey
       const isEnterKey = event.code === 'Enter'
       const isLastRow = index === observationsState.length - 1
@@ -111,7 +111,7 @@ const BenthicPitObservationsTable = ({
         setAreObservationsInputsDirty(true)
       }
 
-      if (isEnterKey && !isBenthicAttribute) {
+      if (isEnterKey) {
         event.preventDefault()
         setAutoFocusAllowed(true)
         observationsDispatch({
@@ -179,14 +179,6 @@ const BenthicPitObservationsTable = ({
         })
       }
 
-      const handleBenthicAttributeKeyDown = (event) => {
-        handleKeyDown({ event, index, observation, isBenthicAttribute: true })
-      }
-
-      const handleGrowthFormKeyDown = (event) => {
-        handleKeyDown({ event, index, observation, isGrowthForm: true })
-      }
-
       const handleIgnoreObservationValidations = () => {
         ignoreObservationValidations({
           observationId,
@@ -246,7 +238,6 @@ const BenthicPitObservationsTable = ({
                   aria-labelledby="benthic-attribute-label"
                   options={benthicAttributeSelectOptions}
                   onChange={handleBenthicAttributeChange}
-                  onKeyDown={handleBenthicAttributeKeyDown}
                   value={attribute}
                   noResultsText={language.autocomplete.noResultsDefault}
                   noResultsAction={
@@ -271,7 +262,9 @@ const BenthicPitObservationsTable = ({
           <Td align="right">
             <Select
               onChange={handleGrowthFormChange}
-              onKeyDown={handleGrowthFormKeyDown}
+              onKeyDown={(event) => {
+                handleKeyDown({ event, index, observation, isGrowthForm: true })
+              }}
               value={growth_form}
               aria-labelledby="growth-form-label"
             >

--- a/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
@@ -79,7 +79,7 @@ const ColoniesBleachedObservationTable = ({
   const observationRows = useMemo(() => {
     const growthFormSelectOptions = getOptions(choices.growthforms)
 
-    const handleKeyDown = ({ event, index, observation, isLastCell, isBenthicAttribute }) => {
+    const handleKeyDown = ({ event, index, observation, isLastCell }) => {
       const isTabKey = event.code === 'Tab' && !event.shiftKey
       const isEnterKey = event.code === 'Enter'
       const isLastRow = index === observationsState.length - 1
@@ -94,7 +94,7 @@ const ColoniesBleachedObservationTable = ({
         setAreObservationsInputsDirty(true)
       }
 
-      if (isEnterKey && !isBenthicAttribute) {
+      if (isEnterKey) {
         event.preventDefault()
         setAutoFocusAllowed(true)
         observationsDispatch({
@@ -184,14 +184,6 @@ const ColoniesBleachedObservationTable = ({
         })
       }
 
-      const handleBenthicAttributeKeyDown = (event) => {
-        handleKeyDown({ event, index, observation, isBenthicAttribute: true })
-      }
-
-      const handleLastCellKeyDown = (event) => {
-        handleKeyDown({ event, index, observation, isLastCell: true })
-      }
-
       const handleIgnoreObservationValidations = () => {
         ignoreObservationValidations({
           observationId,
@@ -235,6 +227,9 @@ const ColoniesBleachedObservationTable = ({
         setObservationIdToAddNewBenthicAttributeTo(observationId)
         setIsNewBenthicAttributeModalOpen(true)
       }
+      const handleObservationKeyDown = (event) => {
+        handleKeyDown({ event, index, observation })
+      }
 
       return (
         <ObservationTr key={observationId}>
@@ -249,7 +244,6 @@ const ColoniesBleachedObservationTable = ({
                   aria-labelledby="benthic-attribute-label"
                   options={benthicAttributeSelectOptions}
                   onChange={handleBenthicAttributeChange}
-                  onKeyDown={handleBenthicAttributeKeyDown}
                   value={attribute}
                   noResultsText={language.autocomplete.noResultsDefault}
                   noResultsAction={
@@ -276,6 +270,7 @@ const ColoniesBleachedObservationTable = ({
               onChange={handleGrowthFormChange}
               value={growth_form}
               aria-labelledby="growth-form-label"
+              onKeyDown={handleObservationKeyDown}
             >
               <option value=""> </option>
               {growthFormSelectOptions.map((item) => (
@@ -294,6 +289,7 @@ const ColoniesBleachedObservationTable = ({
               onChange={(event) => {
                 handleObservationInputChange({ event, dispatchType: 'updateNormal' })
               }}
+              onKeyDown={handleObservationKeyDown}
             />
           </Td>
           <Td align="right">
@@ -305,6 +301,7 @@ const ColoniesBleachedObservationTable = ({
               onChange={(event) => {
                 handleObservationInputChange({ event, dispatchType: 'updatePale' })
               }}
+              onKeyDown={handleObservationKeyDown}
             />
           </Td>
           <Td align="right">
@@ -316,6 +313,7 @@ const ColoniesBleachedObservationTable = ({
               onChange={(event) => {
                 handleObservationInputChange({ event, dispatchType: 'update20Bleached' })
               }}
+              onKeyDown={handleObservationKeyDown}
             />
           </Td>
           <Td align="right">
@@ -327,6 +325,7 @@ const ColoniesBleachedObservationTable = ({
               onChange={(event) => {
                 handleObservationInputChange({ event, dispatchType: 'update50Bleached' })
               }}
+              onKeyDown={handleObservationKeyDown}
             />
           </Td>
           <Td align="right">
@@ -338,6 +337,7 @@ const ColoniesBleachedObservationTable = ({
               onChange={(event) => {
                 handleObservationInputChange({ event, dispatchType: 'update80Bleached' })
               }}
+              onKeyDown={handleObservationKeyDown}
             />
           </Td>
           <Td align="right">
@@ -349,6 +349,7 @@ const ColoniesBleachedObservationTable = ({
               onChange={(event) => {
                 handleObservationInputChange({ event, dispatchType: 'update100Bleached' })
               }}
+              onKeyDown={handleObservationKeyDown}
             />
           </Td>
           <Td align="right">
@@ -360,7 +361,9 @@ const ColoniesBleachedObservationTable = ({
               onChange={(event) => {
                 handleObservationInputChange({ event, dispatchType: 'updateRecentlyDead' })
               }}
-              onKeyDown={handleLastCellKeyDown}
+              onKeyDown={(event) => {
+                handleKeyDown({ event, index, observation, isLastCell: true })
+              }}
             />
           </Td>
 

--- a/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
@@ -137,10 +137,6 @@ const PercentCoverObservationTable = ({
         })
       }
 
-      const handleLastCellKeyDown = (event) => {
-        handleKeyDown({ event, index, observation, isLastCell: true })
-      }
-
       const handleIgnoreObservationValidations = () => {
         ignoreObservationValidations({
           observationId,
@@ -180,6 +176,10 @@ const PercentCoverObservationTable = ({
         </CellValidation>
       )
 
+      const handleObservationKeyDown = (event) => {
+        handleKeyDown({ event, index, observation })
+      }
+
       return (
         <ObservationTr key={observationId}>
           <Td align="center">{rowNumber}</Td>
@@ -195,6 +195,7 @@ const PercentCoverObservationTable = ({
                 handleObservationInputChange({ event, dispatchType: 'updateHardCoralPercent' })
               }}
               autoFocus={autoFocusAllowed}
+              onKeyDown={handleObservationKeyDown}
             />
           </Td>
           <Td align="right">
@@ -206,6 +207,7 @@ const PercentCoverObservationTable = ({
               onChange={(event) => {
                 handleObservationInputChange({ event, dispatchType: 'updateSoftCoralPercent' })
               }}
+              onKeyDown={handleObservationKeyDown}
             />
           </Td>
           <Td align="right">
@@ -217,7 +219,9 @@ const PercentCoverObservationTable = ({
               onChange={(event) => {
                 handleObservationInputChange({ event, dispatchType: 'updateAlgaePercent' })
               }}
-              onKeyDown={handleLastCellKeyDown}
+              onKeyDown={(event) => {
+                handleKeyDown({ event, index, observation, isLastCell: true })
+              }}
             />
           </Td>
 

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -167,7 +167,7 @@ const FishBeltObservationTable = ({
   const observationsRows = useMemo(() => {
     const mermaidReferenceLink = process.env.REACT_APP_MERMAID_REFERENCE_LINK
 
-    const handleKeyDown = ({ event, index, observation, isCount, isFishName }) => {
+    const handleKeyDown = ({ event, index, observation, isCount }) => {
       const isTabKey = event.code === 'Tab' && !event.shiftKey
       const isEnterKey = event.code === 'Enter'
       const isLastRow = index === observationsState.length - 1
@@ -181,7 +181,7 @@ const FishBeltObservationTable = ({
         })
       }
 
-      if (isEnterKey && !isFishName) {
+      if (isEnterKey) {
         event.preventDefault()
         setAutoFocusAllowed(true)
         observationsDispatch({
@@ -334,14 +334,6 @@ const FishBeltObservationTable = ({
         })
       }
 
-      const handleFishNameKeyDown = (event) => {
-        handleKeyDown({ event, index, observation, isFishName: true })
-      }
-
-      const handleCountKeyDown = (event) => {
-        handleKeyDown({ event, index, observation, isCount: true })
-      }
-
       const proposeNewSpeciesClick = () => openNewObservationModal(observationId)
 
       return (
@@ -362,7 +354,6 @@ const FishBeltObservationTable = ({
                   aria-labelledby="fish-name-label"
                   options={fishNameOptions}
                   onChange={handleFishNameChange}
-                  onKeyDown={handleFishNameKeyDown}
                   value={fish_attribute}
                   noResultsText={language.autocomplete.noResultsDefault}
                   noResultsAction={
@@ -393,7 +384,9 @@ const FishBeltObservationTable = ({
               step="any"
               aria-labelledby="fish-count-label"
               onChange={handleUpdateCount}
-              onKeyDown={handleCountKeyDown}
+              onKeyDown={(event) => {
+                handleKeyDown({ event, index, observation, isCount: true })
+              }}
             />
           </Td>
           <Td align="right">{observationBiomass ?? <> - </>}</Td>

--- a/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityObservationTable.js
@@ -146,10 +146,6 @@ const HabitatComplexityObservationsTable = ({
         })
       }
 
-      const handleHabitatComplexityScoreKeydown = (event) => {
-        handleKeyDown({ event, index, observation, isLastCell: true })
-      }
-
       const handleIgnoreObservationValidations = () => {
         ignoreObservationValidations({
           observationId,
@@ -199,7 +195,9 @@ const HabitatComplexityObservationsTable = ({
           <Td align="center">
             <Select
               onChange={handleHabitatComplexityScoreChange}
-              onKeyDown={handleHabitatComplexityScoreKeydown}
+              onKeyDown={(event) => {
+                handleKeyDown({ event, index, observation, isLastCell: true })
+              }}
               value={habitatComplexityScore}
               aria-labelledby="habitat-complexity-score-label"
               autoFocus={autoFocusAllowed}


### PR DESCRIPTION
To test:

- go to a protocol's observation table(s)
- focus the cursor on the first input and press return/enter

Do the same for all other inputs except autocomplete inputs and all the other protocols

Expected results:
- a new empty row should be created for each input's enter keypress (unless an autocomplete field is used)
