### PR TITLE
fix/feat: handle status_code errors from sync/push 

### DIFF
--- a/src/App/integrationTests/managementRegime/App.managementRegimeCreateOffline.test.js
+++ b/src/App/integrationTests/managementRegime/App.managementRegimeCreateOffline.test.js
@@ -87,7 +87,11 @@ describe('Offline', () => {
 
     await saveMR()
 
-    expect(await screen.findByText('Management Regime saved.'))
+    expect(
+      await screen.findByText(
+        'The management regime has been saved on your computer and in the MERMAID online system.',
+      ),
+    )
 
     // ensure the new form is now the edit form
     expect(await screen.findByTestId('edit-management-regime-form-title'))
@@ -115,7 +119,11 @@ describe('Offline', () => {
 
     await saveMR()
 
-    expect(await screen.findByText('Management Regime saved.'))
+    expect(
+      await screen.findByText(
+        'The management regime has been saved on your computer and in the MERMAID online system.',
+      ),
+    )
 
     const sideNav = await screen.findByTestId('content-page-side-nav')
 
@@ -135,14 +143,10 @@ describe('Offline', () => {
   test('New MR save failure shows toast message with edits persisting', async () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-    const mockManagementRegimeErrorData = {
-      name: 'This field may not be blank.',
-    }
-
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
     dexiePerUserDataInstance.project_managements.put = () =>
-      Promise.reject(mockManagementRegimeErrorData)
+      Promise.reject(new Error('this is a dexie error'))
 
     renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
       initialEntries: ['/projects/5/management-regimes/new'],
@@ -153,7 +157,10 @@ describe('Offline', () => {
     await saveMR()
 
     expect(await screen.findByTestId('management-regime-toast-error')).toHaveTextContent(
-      `The management regime has not been saved. name: This field may not be blank.`,
+      'The management regime failed to save both on your computer and in the MERMAID online system.',
+    )
+    expect(await screen.findByTestId('management-regime-toast-error')).toHaveTextContent(
+      'this is a dexie error',
     )
 
     // ensure the were not in edit mode, but new management regime mode

--- a/src/App/integrationTests/managementRegime/App.managementRegimeCreateOnline.test.js
+++ b/src/App/integrationTests/managementRegime/App.managementRegimeCreateOnline.test.js
@@ -1,13 +1,21 @@
+import { rest } from 'msw'
 import React from 'react'
 import userEvent from '@testing-library/user-event'
 
 import { getMockDexieInstancesAllSuccess } from '../../../testUtilities/mockDexie'
 import {
+  mockMermaidApiAllSuccessful,
   renderAuthenticatedOnline,
   screen,
   within,
 } from '../../../testUtilities/testingLibraryWithHelpers'
 import App from '../../App'
+import {
+  mock400StatusCodeForAllDataTypesPush,
+  mock500StatusCodeForAllDataTypesPush,
+} from '../../../testUtilities/mockPushStatusCodes'
+
+const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 
 const saveMR = async () => {
   userEvent.type(await screen.findByLabelText('Name'), 'Rebecca')
@@ -82,7 +90,11 @@ describe('Online', () => {
 
     await saveMR()
 
-    expect(await screen.findByText('Management Regime saved.'))
+    expect(
+      await screen.findByText(
+        'The management regime has been saved on your computer and in the MERMAID online system.',
+      ),
+    )
 
     // ensure the new form is now the edit form
     expect(await screen.findByTestId('edit-management-regime-form-title'))
@@ -108,7 +120,11 @@ describe('Online', () => {
 
     await saveMR()
 
-    expect(await screen.findByText('Management Regime saved.'))
+    expect(
+      await screen.findByText(
+        'The management regime has been saved on your computer and in the MERMAID online system.',
+      ),
+    )
 
     const sideNav = await screen.findByTestId('content-page-side-nav')
 
@@ -125,15 +141,15 @@ describe('Online', () => {
 
     expect(await within(table).findByText('Rebecca'))
   })
-  test('New MR save failure shows toast message with edits persisting', async () => {
+  test('New MR save will handle 400 push status codes by passing on reasoning to the user. Edits persist', async () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-    const mockManagementRegimeErrorData = {
-      name: 'This field may not be blank.',
-    }
-
-    dexiePerUserDataInstance.project_managements.put = () =>
-      Promise.reject(mockManagementRegimeErrorData)
+    mockMermaidApiAllSuccessful.use(
+      // append the validated data on the pull response, because that is what the UI uses to update itself
+      rest.post(`${apiBaseUrl}/push/`, (_req, res, ctx) => {
+        return res(ctx.json(mock400StatusCodeForAllDataTypesPush))
+      }),
+    )
 
     renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
       initialEntries: ['/projects/5/management-regimes/new'],
@@ -144,7 +160,62 @@ describe('Online', () => {
     await saveMR()
 
     expect(await screen.findByTestId('management-regime-toast-error')).toHaveTextContent(
-      `The management regime has not been saved. name: This field may not be blank.`,
+      'The management regime has been saved on your computer, but not in the MERMAID online system.',
+    )
+    expect(await screen.findByTestId('management-regime-toast-error')).toHaveTextContent(
+      'an error message from api',
+    )
+    expect(await screen.findByTestId('management-regime-toast-error')).toHaveTextContent(
+      'another error message from api',
+    )
+
+    // ensure the were not in edit mode, but new management regime mode
+    expect(
+      screen.getByText('Management Regime', {
+        selector: 'h2',
+      }),
+    )
+
+    // edits persisted
+    expect(screen.getByLabelText('Name')).toHaveValue('Rebecca')
+    expect(screen.getByLabelText('Secondary Name')).toHaveValue('Becca')
+    expect(screen.getByLabelText('Year Established')).toHaveValue(1980)
+    expect(screen.getByLabelText('Area')).toHaveValue(40)
+    expect(within(screen.getByLabelText('Parties')).getByLabelText('NGO')).toBeChecked()
+    expect(
+      within(screen.getByLabelText('Rules')).getByLabelText('Open Access', { exact: false }),
+    ).toBeChecked()
+    expect(within(screen.getByLabelText('Compliance')).getByLabelText('somewhat')).toBeChecked()
+  })
+
+  test('New MR save will handle 500 push status codes with a generic message and spare the user any api generated error details. Edits persist', async () => {
+    mockMermaidApiAllSuccessful.use(
+      // append the validated data on the pull response, because that is what the UI uses to update itself
+      rest.post(`${apiBaseUrl}/push/`, (_req, res, ctx) => {
+        return res(ctx.json(mock500StatusCodeForAllDataTypesPush))
+      }),
+    )
+    const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
+
+    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+      initialEntries: ['/projects/5/management-regimes/new'],
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
+    })
+
+    await saveMR()
+
+    expect(await screen.findByTestId('management-regime-toast-error')).toHaveTextContent(
+      'The management regime has been saved on your computer, but not in the MERMAID online system.',
+    )
+    expect(await screen.findByTestId('management-regime-toast-error')).toHaveTextContent(
+      'Server error: please contact support@datamermaid.org',
+    )
+    expect(await screen.findByTestId('management-regime-toast-error')).not.toHaveTextContent(
+      'an error message from api',
+    )
+    expect(await screen.findByTestId('management-regime-toast-error')).not.toHaveTextContent(
+      'another error message from api',
     )
 
     // ensure the were not in edit mode, but new management regime mode

--- a/src/App/integrationTests/site/App.siteEdit.test.js
+++ b/src/App/integrationTests/site/App.siteEdit.test.js
@@ -34,7 +34,11 @@ test('Offline: Edit Site shows toast and edited record info', async () => {
     }),
   )
 
-  expect(await screen.findByText('Site saved.'))
+  expect(
+    await screen.findByText(
+      'The site has been saved on your computer and in the MERMAID online system.',
+    ),
+  )
 
   expect(siteNameInput).toHaveValue('OOF')
 })
@@ -59,7 +63,11 @@ test('Online: Edit Site shows toast and edited record info', async () => {
     }),
   )
 
-  expect(await screen.findByText('Site saved.'))
+  expect(
+    await screen.findByText(
+      'The site has been saved on your computer and in the MERMAID online system.',
+    ),
+  )
 
   expect(siteNameInput).toHaveValue('OOF')
 })
@@ -88,7 +96,11 @@ test('Offline: edit site save stored site in dexie', async () => {
     }),
   )
 
-  expect(await screen.findByText('Site saved.'))
+  expect(
+    await screen.findByText(
+      'The site has been saved on your computer and in the MERMAID online system.',
+    ),
+  )
 
   const savedSites = await dexiePerUserDataInstance.project_sites.toArray()
 
@@ -99,15 +111,12 @@ test('Offline: edit site save stored site in dexie', async () => {
 test('Offline: Edit site  save failure shows toast message with new edits persisting', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  const mockSiteErrorData = {
-    name: 'This field may not be blank.',
-    country: 'This field is required.',
-  }
-
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
   // make sure the next save will fail
-  dexiePerUserDataInstance.project_sites.put = jest.fn().mockRejectedValueOnce(mockSiteErrorData)
+  dexiePerUserDataInstance.project_sites.put = jest
+    .fn()
+    .mockRejectedValueOnce(new Error('this is a dexie error'))
 
   // make sure there is a site to edit in dexie
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
@@ -130,8 +139,9 @@ test('Offline: Edit site  save failure shows toast message with new edits persis
   )
 
   expect(await screen.findByTestId('site-toast-error')).toHaveTextContent(
-    `The site has not been saved. name: This field may not be blank. country: This field is required.`,
+    `The site failed to save both on your computer and in the MERMAID online system.`,
   )
+  expect(await screen.findByTestId('site-toast-error')).toHaveTextContent(`this is a dexie error`)
 
   expect(siteNameInput).toHaveValue('OOF')
 })

--- a/src/App/integrationTests/sites/App.siteCreateOffline.test.js
+++ b/src/App/integrationTests/sites/App.siteCreateOffline.test.js
@@ -89,7 +89,11 @@ describe('offline', () => {
 
     await saveSite()
 
-    expect(await screen.findByText('Site saved.'))
+    expect(
+      await screen.findByText(
+        'The site has been saved on your computer and in the MERMAID online system.',
+      ),
+    )
 
     // ensure the new form is now the edit form
     expect(
@@ -120,7 +124,11 @@ describe('offline', () => {
 
     await saveSite()
 
-    expect(await screen.findByText('Site saved.'))
+    expect(
+      await screen.findByText(
+        'The site has been saved on your computer and in the MERMAID online system.',
+      ),
+    )
 
     const sideNav = await screen.findByTestId('content-page-side-nav')
 
@@ -140,14 +148,10 @@ describe('offline', () => {
   test('new site save failure shows toast message with edits persisting', async () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-    const mockSiteErrorData = {
-      name: 'This field may not be blank.',
-      country: 'This field is required.',
-    }
-
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    dexiePerUserDataInstance.project_sites.put = () => Promise.reject(mockSiteErrorData)
+    dexiePerUserDataInstance.project_sites.put = () =>
+      Promise.reject(new Error('this is a dexie error'))
 
     renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
       initialEntries: ['/projects/5/sites/new'],
@@ -158,8 +162,9 @@ describe('offline', () => {
     await saveSite()
 
     expect(await screen.findByTestId('site-toast-error')).toHaveTextContent(
-      `The site has not been saved. name: This field may not be blank. country: This field is required.`,
+      `The site failed to save both on your computer and in the MERMAID online system.`,
     )
+    expect(await screen.findByTestId('site-toast-error')).toHaveTextContent(`this is a dexie error`)
 
     // ensure the were not in edit mode, but new site mode
     expect(

--- a/src/App/mermaidData/databaseSwitchboard/DatabaseSwitchboardState.js
+++ b/src/App/mermaidData/databaseSwitchboard/DatabaseSwitchboardState.js
@@ -1,4 +1,5 @@
 import language from '../../../language'
+import { getSampleUnitLabel as getAssociatedSubmittedSampleUnitObjectsIncludingUiLabel } from '../getSampleUnitLabel'
 
 const DatabaseSwitchboardState = class {
   _apiBaseUrl
@@ -17,6 +18,76 @@ const DatabaseSwitchboardState = class {
 
   _isStatusCodeSuccessful = function _isStatusCodeSuccessful(statusValue) {
     return statusValue >= 200 && statusValue < 300
+  }
+
+  _getMermaidDataPushSyncStatusCodeError = function _getMermaidDataPushSyncStatusCodeError({
+    mermaidDataTypeName,
+    pushResponse,
+  }) {
+    // The api and code has evolved to have various 'error' info formats.
+    // If there is no special error format from the API, we stick to a standard JS error instance.
+    // For 500 and 40x, there is an error object with isSyncError and
+    // isDeleteRejectedError booleans. isSyncError helps the component differentiate
+    // between an http errsor and a nested error from a push. isDeleteRejectedError
+    //  helps the DatabaseSwitchboard know it should rollback the _deleted
+    // and uiState_pushToApi property in
+    // browser storage so that the UI doesnt keep trying to push a record that
+    // has been rejected from being deleted because of association conflicts.
+    // A 409 error object will include an associatedSampleUnits property containing
+    // an array of associated submitted records that are connected to the thing
+    // attempting to be deleted. Its array format pre-existed this work and the UI
+    // component is already set up to list the associated sample units to the user with it.
+    // Other 400 status codes will have a property, statusCodeReasons, whose value is an object.
+    // as of this comment writing, any key values pairs will be listed out to the user.
+    // This format also has preexisting component code that already works with it
+    // and at the time of this function's creation, creating a common format and
+    // refactoring was out of reasonable scope of this work.
+    const itemReturnedFromApiPush = pushResponse.data[mermaidDataTypeName][0]
+    const statusCode = itemReturnedFromApiPush.status_code
+
+    // if 500 we spare the user from all the tech reasons things went wrong, and just return standard error with text
+    // Other 50X wont occur with status_code.
+    // status_code errors from a push response are NOT related to HTTP.
+    // Their values are just borrowing meaning from HTTP)
+    // project synonyms for push status code errors are 'nested errors', or 'push sub-node errors'
+    if (statusCode === 500) {
+      const error = new Error(language.error[statusCode])
+
+      error.isSyncError = true
+
+      return error
+    }
+
+    // if 40X, we return the api error object
+    if (statusCode >= 400 && statusCode < 500 && statusCode !== 409) {
+      // The data property on the returned project management
+      // item is an object with properties that are assumed to be error messages.
+      // They will be converted into a list of error messages for the user in the UI
+
+      const error = {
+        statusCodeReasons: pushResponse.data[mermaidDataTypeName][0].data,
+        isSyncError: true,
+      }
+
+      return error
+    }
+
+    if (statusCode === 409) {
+      const { sampleevent, ...sampleUnitProtocols } = itemReturnedFromApiPush.data // eslint-disable-line no-unused-vars
+      const sampleUnitProtocolValues = Object.values(sampleUnitProtocols).flat()
+      const associatedSampleUnits =
+        getAssociatedSubmittedSampleUnitObjectsIncludingUiLabel(sampleUnitProtocolValues)
+
+      const error = {
+        isSyncError: true,
+        isDeleteRejectedError: true,
+        associatedSampleUnits,
+      }
+
+      return error
+    }
+
+    return undefined
   }
 
   _notAuthenticatedAndReadyError = new Error(language.error.appNotAuthenticatedOrReady)

--- a/src/components/generic/toast.js
+++ b/src/components/generic/toast.js
@@ -34,6 +34,9 @@ export const CustomToastContainer = styled(ToastContainer).attrs({
     }
   }
   .Toastify__toast--warning {
+    border-left-color: ${theme.color.warningColor};
+  }
+  .Toastify__toast--error {
     border-left-color: ${theme.color.cautionColor};
   }
   .Toastify__toast--default {

--- a/src/language.js
+++ b/src/language.js
@@ -14,9 +14,9 @@ const inlineMessage = {
 
 const error = {
   403: 'The current user does not have sufficient permission to do that.',
-  500: 'Something went wrong with the server.',
-  502: 'Something went wrong with the server.',
-  503: 'Something went wrong with the server.',
+  500: 'Server error: please contact support@datamermaid.org',
+  502: 'Server error: please contact support@datamermaid.org',
+  503: 'Server error: please contact support@datamermaid.org',
   apiDataSync: 'The app was not able to sync data with the API. Please try again.',
   appNotAuthenticatedOrReady: 'Initialization error. Try reloading or reauthenticating.',
   collectRecordChoicesUnavailable:
@@ -50,13 +50,20 @@ const error = {
   },
   generaUnavailable: 'Fish genera data is currently unavailable. Please try again.',
   generic: 'Something went wrong.',
+  getSaveOnlineSyncErrorTitle: (mermaidDataTypeLabel) =>
+    `The ${mermaidDataTypeLabel} has been saved on your computer, but not in the MERMAID online system.`,
+  getDeleteOnlineSyncErrorTitle: (mermaidDataTypeLabel) =>
+    `The ${mermaidDataTypeLabel} has not been deleted from your computer or the MERMAID online system.`,
+  getSaveOfflineErrorTitle: (mermaidDataTypeLabel) =>
+    `The ${mermaidDataTypeLabel} failed to save both on your computer and in the MERMAID online system.`,
+  getDeleteOfflineErrorTitle: (mermaidDataTypeLabel) =>
+    `The ${mermaidDataTypeLabel} has failed to delete from your computer or the MERMAID online system.`,
   idNotFoundUserAction: "Please check the URL in your browser's address bar.",
   invalidEmailAdd: 'Invalid email address.',
   managementRegimeRecordsUnavailable:
     'Management Regime records data is currently unavailable. Please try again.',
   managementRegimeRecordUnavailable:
     'Management Regime record data is currently unavailable. Please try again.',
-  managementRegimeSave: 'Something went wrong. The management regime has not been saved.',
   notificationsUnavailable: 'Notifications are unavailable.',
   notificationNotDeleted: 'Notification could not be removed.',
   projectSave: 'Something went wrong. The project has not been saved.',
@@ -64,7 +71,6 @@ const error = {
   projectWithSameName: 'A project with the same name already exists.',
   siteRecordsUnavailable: 'Site records data is currently unavailable. Please try again.',
   siteRecordUnavailable: 'Site record data is currently unavailable. Please try again.',
-  siteSave: 'Something went wrong. The site has not been saved.',
   submittedRecordsUnavailable: 'Submitted records data is currently unavailable. Please try again',
   submittedRecordUnavailable: 'Submitted record data is currently unavailable. Please try again',
   submittedRecordMoveToCollect:
@@ -123,8 +129,11 @@ const success = {
   projectSave: 'Project saved',
   projectCopied: 'Project copied',
   projectCreated: 'Project created',
-  siteSave: 'Site saved.',
-  managementRegimeSave: 'Management Regime saved.',
+  getMermaidDataSaveSuccess: (mermaidDataTypeLabel) =>
+    `The ${mermaidDataTypeLabel} has been saved on your computer and in the MERMAID online system.`,
+  getMermaidDataDeleteSuccess: (mermaidDataTypeLabel) =>
+    `The ${mermaidDataTypeLabel} has been deleted from your computer and the MERMAID online system.`,
+
   submittedRecordMoveToCollect: 'The submitted record has been moved to collecting.',
   projectStatusSaved: `Test project selection saved.`,
   getDataSharingPolicyChangeSuccess: (method, policy_code) => {
@@ -396,6 +405,7 @@ const getValidationMessage = (validation, projectId = '') => {
     invalid_sample_date: () => 'Invalid date',
     invalid_score: () => `Invalid score`,
     invalid_total_percent: () => `Sum of percents must not be less than 0 or greater than 100`,
+    large_num_quadrats: () => 'Number of quadrats is too large',
     len_surveyed_not_positive: () => 'Transect length must be a non-negative number',
     len_surveyed_out_of_range: () =>
       `Transect length surveyed value outside range of ${context?.len_surveyed_range[0]} and ${context?.len_surveyed_range[1]}`,
@@ -429,21 +439,12 @@ const getValidationMessage = (validation, projectId = '') => {
   return (validationMessages[code] || validationMessages.default)()
 }
 
-const getErrorTitle = (page) => `The ${page} has not been saved. `
-
-const getErrorMessages = (pageError) => {
-  return Object.entries(pageError)
-    .map(([key, value]) => `${key}: ${value}`)
-    .join('\n')
-}
-
 export default {
   autocomplete,
   createNewOptionModal,
   deleteRecord,
   error,
-  getErrorMessages,
-  getErrorTitle,
+  getResolveModalLanguage,
   getValidationMessage,
   header,
   inlineMessage,
@@ -457,5 +458,4 @@ export default {
   success,
   table,
   title,
-  getResolveModalLanguage,
 }

--- a/src/library/getErrorMessageHtmlListThatMayHaveSyncStatusCodeErrors.js
+++ b/src/library/getErrorMessageHtmlListThatMayHaveSyncStatusCodeErrors.js
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import language from '../language'
+
+export const getErrorMessageHtmlListThatMayHaveSyncStatusCodeErrors = (error) => {
+  // we want to handle actual error objects as that is useful and conventional
+  if (error instanceof Error) {
+    return (
+      <ul>
+        <li>{error.message}</li>
+      </ul>
+    )
+  }
+
+  // If the error has some other type,
+  // its probably an object with a bunch of properties with values as errors
+  // (which the api returns sync error info with for 40x status_codes specifically, but not other status codes)
+  try {
+    const errorMessageListItems = Object.entries(error.statusCodeReasons).map(([key, value]) => (
+      <li key={key}>{`${key}: ${value}`}</li>
+    ))
+
+    return <ul>{errorMessageListItems}</ul>
+  } catch {
+    return (
+      <ul>
+        <li>{language.error.generic}</li>
+      </ul>
+    )
+  }
+}

--- a/src/library/handleHttpResponseError.test.js
+++ b/src/library/handleHttpResponseError.test.js
@@ -36,8 +36,8 @@ test('handleHttpResponseError produces the appropriate toast message if the stat
 
   handleHttpResponseError({ error: { response: { status: 500 } }, callback, logoutMermaid })
 
-  expect(toastSpy).toHaveBeenCalledWith('Something went wrong with the server.', {
-    toastId: 'Something went wrong with the server.',
+  expect(toastSpy).toHaveBeenCalledWith('Server error: please contact support@datamermaid.org', {
+    toastId: 'Server error: please contact support@datamermaid.org',
     transition: Slide,
   })
 
@@ -51,8 +51,8 @@ test('handleHttpResponseError produces the appropriate toast message if the stat
 
   handleHttpResponseError({ error: { response: { status: 502 } }, callback, logoutMermaid })
 
-  expect(toastSpy).toHaveBeenCalledWith('Something went wrong with the server.', {
-    toastId: 'Something went wrong with the server.',
+  expect(toastSpy).toHaveBeenCalledWith('Server error: please contact support@datamermaid.org', {
+    toastId: 'Server error: please contact support@datamermaid.org',
     transition: Slide,
   })
 
@@ -66,8 +66,8 @@ test('handleHttpResponseError produces the appropriate toast message if the stat
 
   handleHttpResponseError({ error: { response: { status: 503 } }, callback, logoutMermaid })
 
-  expect(toastSpy).toHaveBeenCalledWith('Something went wrong with the server.', {
-    toastId: 'Something went wrong with the server.',
+  expect(toastSpy).toHaveBeenCalledWith('Server error: please contact support@datamermaid.org', {
+    toastId: 'Server error: please contact support@datamermaid.org',
     transition: Slide,
   })
 

--- a/src/library/showSyncToastError.js
+++ b/src/library/showSyncToastError.js
@@ -1,0 +1,19 @@
+import { toast } from 'react-toastify'
+import React from 'react'
+
+import { getErrorMessageHtmlListThatMayHaveSyncStatusCodeErrors } from './getErrorMessageHtmlListThatMayHaveSyncStatusCodeErrors'
+import { getToastArguments } from './getToastArguments'
+
+export const showSyncToastError = ({ error, toastTitle, testId }) => {
+  const errorLang = getErrorMessageHtmlListThatMayHaveSyncStatusCodeErrors(error)
+
+  toast.error(
+    ...getToastArguments(
+      <div data-testid={testId}>
+        {toastTitle}
+        <br />
+        {errorLang}
+      </div>,
+    ),
+  )
+}

--- a/src/testUtilities/mockPushStatusCodes.js
+++ b/src/testUtilities/mockPushStatusCodes.js
@@ -1,0 +1,119 @@
+export const mock400StatusCodeForAllDataTypesPush = {
+  benthic_attributes: [
+    {
+      status_code: 400,
+      data: { name: 'an error message from api', other: 'another error message from api' },
+    },
+  ],
+  collect_records: [
+    {
+      status_code: 400,
+      data: { name: 'an error message from api', other: 'another error message from api' },
+    },
+  ],
+  fish_species: [
+    {
+      status_code: 400,
+      data: {
+        name: 'an error message from api',
+        other: 'another error message from api',
+      },
+    },
+  ],
+  project_managements: [
+    {
+      status_code: 400,
+      data: {
+        name: 'an error message from api',
+        other: 'another error message from api',
+      },
+    },
+  ],
+  project_profiles: [
+    {
+      status_code: 400,
+      data: {
+        name: 'an error message from api',
+        other: 'another error message from api',
+      },
+    },
+  ],
+  project_sites: [
+    {
+      status_code: 400,
+      data: {
+        name: 'an error message from api',
+        other: 'another error message from api',
+      },
+    },
+  ],
+  projects: [
+    {
+      status_code: 400,
+      data: {
+        name: 'an error message from api',
+        other: 'another error message from api',
+      },
+    },
+  ],
+}
+
+export const mock500StatusCodeForAllDataTypesPush = {
+  benthic_attributes: [
+    {
+      status_code: 500,
+      data: { name: 'an error message from api', other: 'another error message from api' },
+    },
+  ],
+  collect_records: [
+    {
+      status_code: 500,
+      data: { name: 'an error message from api', other: 'another error message from api' },
+    },
+  ],
+  fish_species: [
+    {
+      status_code: 500,
+      data: {
+        name: 'an error message from api',
+        other: 'another error message from api',
+      },
+    },
+  ],
+  project_managements: [
+    {
+      status_code: 500,
+      data: {
+        name: 'an error message from api',
+        other: 'another error message from api',
+      },
+    },
+  ],
+  project_profiles: [
+    {
+      status_code: 500,
+      data: {
+        name: 'an error message from api',
+        other: 'another error message from api',
+      },
+    },
+  ],
+  project_sites: [
+    {
+      status_code: 500,
+      data: {
+        name: 'an error message from api',
+        other: 'another error message from api',
+      },
+    },
+  ],
+  projects: [
+    {
+      status_code: 500,
+      data: {
+        name: 'an error message from api',
+        other: 'another error message from api',
+      },
+    },
+  ],
+}


### PR DESCRIPTION
* fix utility that generates messaging for sync errors so that it can handle a null error
* format 40x sync errors for the user so that they use the api custom error object that displays user messages as appropriate
* handle a possible Error instance for all other errors that could occur from a push.
* add some new human friendly validation text
* ensure save and delete site and MR incorporate all the error types (fallback, http, sync, sync specific to entity associated with others/delete rejected)
* fix toast.error styling to ensure its error coloured.
* M931 ensure when MR or site delete is rejected, we unmark it as deleted in the front end



Testing this is complicated, I would leave it for @saanobhaai 