### PR TITLE
Bleached summary stats: number of genera should remain at 0 until something is entered in the row

### DIFF
--- a/src/components/BleachingColoniesBleachedSummaryStats/BleachingColoniesBleachedSummaryStats.js
+++ b/src/components/BleachingColoniesBleachedSummaryStats/BleachingColoniesBleachedSummaryStats.js
@@ -21,7 +21,7 @@ const BleachincColoniesBleachedSummaryStats = ({ observationsColoniesBleached })
   }
 
   const getTotalOfCoralGenera = () => {
-    const attributeIds = observationsColoniesBleached.map((item) => item.attribute)
+    const attributeIds = observationsColoniesBleached.filter((item) => item.attribute)
     const uniqueAttributeIds = [...new Set(attributeIds)]
 
     return uniqueAttributeIds.length


### PR DESCRIPTION
Switched map to filter for `getTotalOfCoralGenera ` so we don't get an array with an empty string, which was being counted for 1 item
