### PR TITLE
Fix: missing column sort indicator

### DIFF
--- a/src/components/pages/Collect/Collect.js
+++ b/src/components/pages/Collect/Collect.js
@@ -272,7 +272,7 @@ const Collect = () => {
                       sortedIndex={column.sortedIndex}
                       isMultiSortColumn={isMultiSortColumn}
                     >
-                      {column.render('Header')}
+                      <span>{column.render('Header')}</span>
                     </Th>
                   ))}
                 </Tr>

--- a/src/components/pages/ManagementRegimes/ManagementRegimes.js
+++ b/src/components/pages/ManagementRegimes/ManagementRegimes.js
@@ -359,7 +359,7 @@ const ManagementRegimes = () => {
                       sortedIndex={column.sortedIndex}
                       isMultiSortColumn={isMultiSortColumn}
                     >
-                      {column.render('Header')}
+                      <span>{column.render('Header')}</span>
                     </Th>
                   ))}
                 </Tr>

--- a/src/components/pages/Sites/Sites.js
+++ b/src/components/pages/Sites/Sites.js
@@ -313,6 +313,7 @@ const Sites = () => {
                   const isMultiSortColumn = headerGroup.headers.some(
                     (header) => header.sortedIndex > 0,
                   )
+                  const ThClassName = column.parent ? column.parent.id : undefined
 
                   return (
                     <Th
@@ -320,8 +321,9 @@ const Sites = () => {
                       isSortedDescending={column.isSortedDesc}
                       sortedIndex={column.sortedIndex}
                       isMultiSortColumn={isMultiSortColumn}
+                      className={ThClassName}
                     >
-                      {column.render('Header')}
+                      <span>{column.render('Header')}</span>
                     </Th>
                   )
                 })}

--- a/src/components/pages/Submitted/Submitted.js
+++ b/src/components/pages/Submitted/Submitted.js
@@ -267,7 +267,7 @@ const Submitted = () => {
                       sortedIndex={column.sortedIndex}
                       isMultiSortColumn={isMultiSortColumn}
                     >
-                      {column.render('Header')}
+                      <span>{column.render('Header')}</span>
                     </Th>
                   ))}
                 </Tr>

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -709,7 +709,7 @@ const Users = () => {
                       isSortingEnabled={!column.disableSortBy}
                       disabledHover={column.disableSortBy}
                     >
-                      {column.render('Header')}
+                      <span>{column.render('Header')}</span>
                     </Th>
                   )
                 })}

--- a/src/components/pages/UsersAndTransects/UsersAndTransects.js
+++ b/src/components/pages/UsersAndTransects/UsersAndTransects.js
@@ -421,7 +421,7 @@ const UsersAndTransects = () => {
                       align={headerAlignment}
                       className={ThClassName}
                     >
-                      {column.render('Header')}
+                      <span> {column.render('Header')}</span>
                     </OverviewTh>
                   )
                 })}


### PR DESCRIPTION
Added missing spans

[Trello card](https://trello.com/c/VVpgHBme/896-column-sort-indicator-is-missing)

To test:
1. go to table sort item page (users, sites, management regimes ...etc)
2. click header to sort
3. ensure arrow and number appear
