### PR TITLE
feat: 828 (take 2) add drag site marker to readjust it for more precise site placement.

### DIFF
--- a/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
+++ b/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
@@ -31,6 +31,20 @@ const SingleSiteMap = ({
   const handleZoomDisplayHelpText = (displayValue) => setDisplayHelpText(displayValue)
 
   const _initializeMap = useEffect(() => {
+    const handleMarkerLocationChange = (lngLat) => {
+      // Adjust lng at international dateline
+      let adjustedLng = lngLat.lng
+
+      if (lngLat.lng < -180) {
+        adjustedLng = 360 + lngLat.lng
+      } else if (lngLat.lng > 180) {
+        adjustedLng = lngLat.lng - 360
+      }
+
+      handleLatitudeChange(lngLat.lat)
+      handleLongitudeChange(adjustedLng)
+    }
+
     const markerElement = document.createElement('div')
 
     markerElement.id = 'marker'
@@ -45,7 +59,7 @@ const SingleSiteMap = ({
       customAttribution: language.map.attribution,
     })
 
-    recordMarker.current = new maplibregl.Marker(markerElement)
+    recordMarker.current = new maplibregl.Marker(markerElement, { draggable: !isReadOnlyUser })
 
     addMapController(map.current)
 
@@ -60,18 +74,14 @@ const SingleSiteMap = ({
 
         recordMarker.current.setLngLat(lngLat)
 
-        // Adjust lng at international dateline
-        let adjustedLng = lngLat.lng
-
-        if (lngLat.lng < -180) {
-          adjustedLng = 360 + lngLat.lng
-        } else if (lngLat.lng > 180) {
-          adjustedLng = lngLat.lng - 360
-        }
-
-        handleLatitudeChange(lngLat.lat)
-        handleLongitudeChange(adjustedLng)
+        handleMarkerLocationChange(lngLat)
       }
+    })
+
+    recordMarker.current.on('dragend', () => {
+      const lngLat = recordMarker.current.getLngLat()
+
+      handleMarkerLocationChange(lngLat)
     })
 
     // clean up on unmount


### PR DESCRIPTION
As reported by Tiela, it was really hard to position the site map marker precisely. A for-now workaround is to allow the user to drag the marker after it is placed. 

Steps to test:

-create a new site
- to give the site a location, choose somewhere very zoomed in and specific and try to put the marker there with the click (its  hard and awkward, especially with the map auto centering and the hand being positioned in front of the place you want the marker to be). Click the marker to drag it to reposition. (it should  be draggable, and be able to reasonably be positionable where you want it)