### PR TITLE
feat: enable auto complete inputs in observation tables to select the value by using the tab key

### DIFF
--- a/src/components/ObservationAutocomplete/ObservationAutocomplete.js
+++ b/src/components/ObservationAutocomplete/ObservationAutocomplete.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import styled from 'styled-components'
+import InputAutocomplete from '../generic/InputAutocomplete'
+
+export const StyledInputAutocomplete = styled(InputAutocomplete)`
+  & input {
+    border: none;
+  }
+  width: 100%;
+  text-align: inherit;
+  padding: 0;
+`
+
+const ObservationAutocomplete = (props) => {
+  return <StyledInputAutocomplete {...props} isTabUsedToSelectHighlighted={true} />
+}
+
+export default ObservationAutocomplete

--- a/src/components/ObservationAutocomplete/index.js
+++ b/src/components/ObservationAutocomplete/index.js
@@ -1,0 +1,3 @@
+import ObservationAutocomplete from './ObservationAutocomplete'
+
+export default ObservationAutocomplete

--- a/src/components/generic/InputAutocomplete/InputAutocomplete.js
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.js
@@ -35,14 +35,15 @@ const NoResultSection = styled.div`
 
 const InputAutocomplete = ({
   className,
-  noResultsText,
-  noResultsAction,
-  id,
   helperText,
+  id,
+  noResultsAction,
+  noResultsText,
   onChange,
-  options,
-  value,
   onKeyDown,
+  options,
+  isTabUsedToSelectHighlighted,
+  value,
   ...restOfProps
 }) => {
   const optionMatchingValueProp = useMemo(
@@ -58,6 +59,22 @@ const InputAutocomplete = ({
     setIsMenuOpen(false)
     setSelectedValue(optionMatchingValueProp)
   }, [optionMatchingValueProp])
+
+  const stateReducer = (state, changes) => {
+    switch (changes.type) {
+      case Downshift.stateChangeTypes.blurInput: {
+        // This causes the tab key to behave like the enter
+        // key and select the item associated with the key press
+        // blurInput = tab or shift+tab for Downshift
+        return {
+          ...changes,
+          selectedItem: isTabUsedToSelectHighlighted ? menuItems[state.highlightedIndex] : null,
+        }
+      }
+      default:
+        return changes
+    }
+  }
 
   const handleStateChange = useCallback(
     (changes) => {
@@ -123,6 +140,7 @@ const InputAutocomplete = ({
       onStateChange={handleStateChange}
       onInputValueChange={handleInputValueChange}
       itemToString={(item) => (item ? item.label : '')}
+      stateReducer={stateReducer}
     >
       {(downshiftObject) => {
         const { getRootProps, getInputProps, getMenuProps } = downshiftObject
@@ -168,6 +186,7 @@ InputAutocomplete.propTypes = {
   onChange: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func,
   options: inputOptionsPropTypes.isRequired,
+  isTabUsedToSelectHighlighted: PropTypes.bool,
   value: PropTypes.string,
 }
 
@@ -177,6 +196,7 @@ InputAutocomplete.defaultProps = {
   noResultsAction: undefined,
   noResultsText: undefined,
   onKeyDown: undefined,
+  isTabUsedToSelectHighlighted: false,
   value: '',
 }
 

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -5,7 +5,6 @@ import styled from 'styled-components'
 import {
   InputAutocompleteContainer,
   NewOptionButton,
-  ObservationAutocomplete,
   ObservationTr,
   StyledLinkThatLooksLikeButtonToReference,
   StyledOverflowWrapper,
@@ -31,6 +30,7 @@ import getObservationValidationInfo from '../CollectRecordFormPageAlternative/ge
 import InputNumberNoScrollWithUnit from '../../../generic/InputNumberNoScrollWithUnit'
 import language from '../../../../language'
 import ObservationValidationInfo from '../ObservationValidationInfo'
+import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
 
 const StyledColgroup = styled('colgroup')`
   col {

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -6,7 +6,6 @@ import {
   ButtonRemoveRow,
   InputAutocompleteContainer,
   NewOptionButton,
-  ObservationAutocomplete,
   ObservationsSummaryStats,
   ObservationTr,
   StyledLinkThatLooksLikeButtonToReference,
@@ -33,6 +32,7 @@ import getObservationValidationInfo from '../CollectRecordFormPageAlternative/ge
 import InputNumberNoScroll from '../../../generic/InputNumberNoScroll/InputNumberNoScroll'
 import language from '../../../../language'
 import ObservationValidationInfo from '../ObservationValidationInfo'
+import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
 
 const StyledColgroup = styled('colgroup')`
   col {

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
@@ -5,7 +5,6 @@ import styled from 'styled-components'
 import {
   InputAutocompleteContainer,
   NewOptionButton,
-  ObservationAutocomplete,
   ObservationTr,
   StyledLinkThatLooksLikeButtonToReference,
   StyledOverflowWrapper,
@@ -30,6 +29,7 @@ import language from '../../../../language'
 import BenthicPitLitObservationSummaryStats from '../../../BenthicPitLitObservationSummaryStats/BenthicPitLitObservationSummaryStats'
 import { getObservationsPropertyNames } from '../../../../App/mermaidData/recordProtocolHelpers'
 import ObservationValidationInfo from '../ObservationValidationInfo'
+import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
 
 const StyledColgroup = styled('colgroup')`
   col {

--- a/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
@@ -5,7 +5,6 @@ import styled from 'styled-components'
 import {
   InputAutocompleteContainer,
   NewOptionButton,
-  ObservationAutocomplete,
   ObservationTr,
   StyledLinkThatLooksLikeButtonToReference,
   StyledOverflowWrapper,
@@ -31,6 +30,7 @@ import getObservationValidationInfo from '../CollectRecordFormPageAlternative/ge
 import InputNumberNoScroll from '../../../generic/InputNumberNoScroll/InputNumberNoScroll'
 import language from '../../../../language'
 import ObservationValidationInfo from '../ObservationValidationInfo'
+import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
 
 const mermaidReferenceLink = process.env.REACT_APP_MERMAID_REFERENCE_LINK
 

--- a/src/components/pages/collectRecordFormPages/CollectingFormPage.Styles.js
+++ b/src/components/pages/collectRecordFormPages/CollectingFormPage.Styles.js
@@ -3,7 +3,6 @@ import theme from '../../../theme'
 import { hoverState, mediaQueryTabletLandscapeOnly } from '../../../library/styling/mediaQueries'
 import { ButtonCaution, ButtonThatLooksLikeLink, ButtonSecondary } from '../../generic/buttons'
 import { Table, TableOverflowWrapper, Tr, Td, GenericStickyTable } from '../../generic/Table/table'
-import InputAutocomplete from '../../generic/InputAutocomplete'
 import { inputTextareaSelectStyles } from '../../generic/form'
 import { LinkThatLooksLikeButton } from '../../generic/links'
 
@@ -18,15 +17,6 @@ export const ObservationTr = styled(Tr)`
   border-width: 0 0 0 ${theme.spacing.xsmall};
   border-style: solid;
   border-color: ${(props) => theme.color.getBorderColor(props.messageType)};
-`
-
-export const ObservationAutocomplete = styled(InputAutocomplete)`
-  & input {
-    border: none;
-  }
-  width: 100%;
-  text-align: inherit;
-  padding: 0;
 `
 
 export const InputAutocompleteContainer = styled.div`

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -28,7 +28,6 @@ import {
   ButtonRemoveRow,
   InputAutocompleteContainer,
   NewOptionButton,
-  ObservationAutocomplete,
   ObservationsSummaryStats,
   ObservationTr,
   StyledLinkThatLooksLikeButtonToReference,
@@ -40,6 +39,7 @@ import { fishReferenceEndpoint } from '../../../../App/mermaidData/fishNameHelpe
 import { getObservationsPropertyNames } from '../../../../App/mermaidData/recordProtocolHelpers'
 import getObservationValidationInfo from '../CollectRecordFormPageAlternative/getObservationValidationInfo'
 import ObservationValidationInfo from '../ObservationValidationInfo'
+import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
 
 const StyledColgroup = styled('colgroup')`
   col {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5873,9 +5873,9 @@ compression@^1.7.4:
     vary "~1.1.2"
 
 compute-scroll-into-view@^1.0.17:
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz#6a88f18acd9d42e9cf4baa6bec7e0522607ab7ab"
-  integrity sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz#1768b5522d1172754f5d0c9b02de3af6be506a43"
+  integrity sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -6918,9 +6918,9 @@ dotenv@^8.0.0:
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
 downshift@^6.1.3:
-  version "6.1.11"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-6.1.11.tgz#bb570448c26e67df9d15da6ed4e3b0af6a44ddd5"
-  integrity sha512-pBI5zYIv5o2zzjfcQZV8R2LDwOowopuRoNXrXfVMHP79l64JZQ3kCW4EDwaFk8abV6QnlZ9GwNnE3rDQ8d440Q==
+  version "6.1.12"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-6.1.12.tgz#f14476b41a6f6fd080c340bad1ddf449f7143f6f"
+  integrity sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==
   dependencies:
     "@babel/runtime" "^7.14.8"
     compute-scroll-into-view "^1.0.17"


### PR DESCRIPTION
[trello card](https://trello.com/c/sXNQFAmD/904-cannot-select-highlighted-option-using-the-tab-button-while-adding-observations)

To test:
- visit each of the observation tables that have autocomplete inputs (benthic attribute or fish name)
- type in the autocomplete to get a list of options
- use arrow keys to highlight an option
- press the tab key

Expected result:
The options menu should close and the selected value should be the one chosen (with the tab key press). The cursor should be in the next input.

Protocols with observation auto complete inputs: 
- fish belt
- benthic LIT
- Benthic photo quadrat
- benthic pit
- bleaching