### PR TITLE
fix: 951 fishbelt observation input onchange produced error

### DIFF
--- a/src/App/mermaidData/databaseSwitchboard/CollectRecordsMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/CollectRecordsMixin.js
@@ -595,6 +595,12 @@ const CollectRecordsMixin = (Base) =>
         recordId,
       )
 
+      const areThereValidationsToReset = !!unmodifiedCollectRecord?.validations
+
+      if (!areThereValidationsToReset) {
+        return unmodifiedCollectRecord
+      }
+
       const observationTableNames = getObservationsPropertyNames(unmodifiedCollectRecord)
 
       let modifiedCollectRecordWithResetObservationValidations = { ...unmodifiedCollectRecord }

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -27,7 +27,7 @@ import { InputWrapper, RequiredIndicator, Select } from '../../../generic/form'
 import { Tr, Td, Th } from '../../../generic/Table/table'
 import BenthicPitLitObservationSummaryStats from '../../../BenthicPitLitObservationSummaryStats/BenthicPitLitObservationSummaryStats'
 import getObservationValidationInfo from '../CollectRecordFormPageAlternative/getObservationValidationInfo'
-import InputNumberNoScrollWithUnit from '../../../generic/InputNumberNoScrollWithUnit'
+import InputNumberNoScroll from '../../../generic/InputNumberNoScroll'
 import language from '../../../../language'
 import ObservationValidationInfo from '../ObservationValidationInfo'
 import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
@@ -232,7 +232,7 @@ const BenthicLitObservationsTable = ({
             </Select>
           </Td>
           <Td align="right">
-            <InputNumberNoScrollWithUnit
+            <InputNumberNoScroll
               value={length}
               aria-labelledby="length-label"
               onChange={handleLengthChange}

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -22,7 +22,6 @@ import { summarizeArrayObjectValuesByProperty } from '../../../../library/summar
 import { Tr, Td, Th } from '../../../generic/Table/table'
 import getValidationPropertiesForInput from '../getValidationPropertiesForInput'
 import InputNumberNoScroll from '../../../generic/InputNumberNoScroll/InputNumberNoScroll'
-import InputNumberNoScrollWithUnit from '../../../generic/InputNumberNoScrollWithUnit/InputNumberNoScrollWithUnit'
 import language from '../../../../language'
 import {
   ButtonRemoveRow,
@@ -256,7 +255,7 @@ const FishBeltObservationTable = ({
       ) : null
 
       const sizeInput = showNumericSizeInput ? (
-        <InputNumberNoScrollWithUnit
+        <InputNumberNoScroll
           type="number"
           min="0"
           value={sizeOrEmptyStringToAvoidInputValueErrors}


### PR DESCRIPTION

  
  Steps to test

- Make a new fishbelt, 
- edit the site, save (do NOT click validate)
- make a new observation row
- enter in one of the observation input values

Expected results:
- the new value is entered with no fuss


Test for all protocols