### PR TITLE
fix: 949 allow zeros in site latitude and longitude inputs

### DIFF
--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -360,7 +360,7 @@ const Site = ({ isNewSite }) => {
         errors.country = [{ code: language.error.formValidation.required, id: 'Required' }]
       }
 
-      if (!values.latitude) {
+      if (!values.latitude && values.latitude !== 0) {
         errors.latitude = [{ code: language.error.formValidation.required, id: 'Required' }]
       }
 
@@ -368,7 +368,7 @@ const Site = ({ isNewSite }) => {
         errors.latitude = [{ code: language.error.formValidation.latitude, id: 'Invalid Latitude' }]
       }
 
-      if (!values.longitude) {
+      if (!values.longitude && values.latitude !== 0) {
         errors.longitude = [{ code: language.error.formValidation.required, id: 'Required' }]
       }
 


### PR DESCRIPTION
steps to test:

- Make a new site
- enter 0 into the latitude input
- enter 0 into the longitude input

Expected results: there should be no validation errors