### PR TITLE
Melissa/968 test speed

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -14,7 +14,6 @@ import { useOnlineStatus } from '../library/onlineStatusContext'
 import { useRoutes } from './useRoutes'
 import { useSyncStatus } from './mermaidData/syncApiDataIntoOfflineStorage/SyncStatusContext'
 import DatabaseSwitchboard from './mermaidData/databaseSwitchboard'
-import dexieInstancePropTypes from './dexieInstancePropTypes'
 import Footer from '../components/Footer'
 import GlobalStyle from '../library/styling/globalStyles'
 import Header from '../components/Header'
@@ -28,12 +27,14 @@ import useIsMounted from '../library/useIsMounted'
 import { useDexiePerUserDataInstance } from './dexiePerUserDataInstanceContext'
 import handleHttpResponseError from '../library/handleHttpResponseError'
 import ErrorBoundary from '../components/ErrorBoundary'
+import { useDexieCurrentUserInstance } from './dexieCurrentUserInstanceContext'
 
-function App({ dexieCurrentUserInstance }) {
+function App() {
   const { isAppOnline } = useOnlineStatus()
   const apiBaseUrl = process.env.REACT_APP_MERMAID_API
   const isMounted = useIsMounted()
   const { isOfflineStorageHydrated, syncErrors, isSyncInProgress } = useSyncStatus()
+  const dexieCurrentUserInstance = useDexieCurrentUserInstance()
 
   const { getAccessToken, isMermaidAuthenticated, logoutMermaid } = useAuthentication({
     dexieCurrentUserInstance,
@@ -188,10 +189,6 @@ function App({ dexieCurrentUserInstance }) {
       </DatabaseSwitchboardInstanceProvider>
     </ThemeProvider>
   )
-}
-
-App.propTypes = {
-  dexieCurrentUserInstance: dexieInstancePropTypes.isRequired,
 }
 
 export default App

--- a/src/App/dexieCurrentUserInstanceContext.js
+++ b/src/App/dexieCurrentUserInstanceContext.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types'
+import React, { createContext, useContext, useState } from 'react'
+
+import dexieInstancePropTypes from './dexieInstancePropTypes'
+import dexieCurrentUserInstance from './dexieCurrentUserInstance'
+
+const DexieCurrentUserInstanceContext = createContext()
+
+const DexieCurrentUserInstanceProvider = ({ children, value }) => {
+  const isTestEnvironment = process.env.NODE_ENV === 'test'
+  const currentUserInstanceToUse = isTestEnvironment ? value : dexieCurrentUserInstance
+
+  return (
+    <DexieCurrentUserInstanceContext.Provider value={currentUserInstanceToUse}>
+      {children}
+    </DexieCurrentUserInstanceContext.Provider>
+  )
+}
+
+const useDexieCurrentUserInstance = () => {
+  const context = useContext(DexieCurrentUserInstanceContext)
+
+  if (context === undefined) {
+    throw new Error(
+      'useDexieCurrentUserInstance must be used within a DexieCurrentUserInstanceProvider',
+    )
+  }
+
+  return context
+}
+
+DexieCurrentUserInstanceProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  value: PropTypes.shape({
+    dexieCurrentUserInstance: dexieInstancePropTypes,
+  }),
+}
+
+DexieCurrentUserInstanceProvider.defaultProps = { value: {} }
+
+export { DexieCurrentUserInstanceProvider, useDexieCurrentUserInstance }

--- a/src/App/dexieCurrentUserInstanceContext.js
+++ b/src/App/dexieCurrentUserInstanceContext.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { createContext, useContext, useState } from 'react'
+import React, { createContext, useContext } from 'react'
 
 import dexieInstancePropTypes from './dexieInstancePropTypes'
 import dexieCurrentUserInstance from './dexieCurrentUserInstance'

--- a/src/App/integrationTests/App.addSampleUnitRouting.test.js
+++ b/src/App/integrationTests/App.addSampleUnitRouting.test.js
@@ -14,7 +14,7 @@ import { getMockDexieInstancesAllSuccess } from '../../testUtilities/mockDexie'
 test('Clicking Add Sample Unit then click Fish Belt link expects to see New Fish Belt page.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -46,7 +46,7 @@ test('Clicking Add Sample Unit then click Fish Belt link expects to see New Fish
 test('Clicking Add Sample Unit then click Benthic Pit link expects to see New Benthic PIT page.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -78,7 +78,7 @@ test('Clicking Add Sample Unit then click Benthic Pit link expects to see New Be
 test('Clicking Add Sample Unit then click Habitat Complexity link expects to see New Habitat Complexity page.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -110,7 +110,7 @@ test('Clicking Add Sample Unit then click Habitat Complexity link expects to see
 test('Clicking Add Sample Unit then click Benthic LIT link expects to see New Benthic LIT page.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -142,7 +142,7 @@ test('Clicking Add Sample Unit then click Benthic LIT link expects to see New Be
 test('Clicking Add Sample Unit then click Bleaching link expects to see New Bleaching page.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/App.authentication1.test.js
+++ b/src/App/integrationTests/App.authentication1.test.js
@@ -16,7 +16,7 @@ import App from '../App'
 test('App renders the initial screen as expected for an online and authenticated user', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })
@@ -32,7 +32,7 @@ test('App renders the initial screen as expected for an online and authenticated
 test('App: an online and authenticated user can logout', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     dexieCurrentUserInstance,
     dexiePerUserDataInstance,
   })

--- a/src/App/integrationTests/App.authentication2.test.js
+++ b/src/App/integrationTests/App.authentication2.test.js
@@ -18,7 +18,7 @@ import App from '../App'
 test('App renders the initial screen as expected for an offline user who is authenticated when online', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     dexieCurrentUserInstance,
     dexiePerUserDataInstance,
   })
@@ -35,7 +35,7 @@ test('App renders the initial screen as expected for an offline user who is auth
 test('App renders the initial screen as expected for an online but not authenticated user', () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderUnauthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderUnauthenticatedOnline(<App />, {
     dexieCurrentUserInstance,
     dexiePerUserDataInstance,
   })
@@ -46,7 +46,7 @@ test('App renders the initial screen as expected for an online but not authentic
 test('App renders the initial screen as expected for an offline user who is not authenticated in an online environment', () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderUnauthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderUnauthenticatedOffline(<App />, {
     dexieCurrentUserInstance,
     dexiePerUserDataInstance,
   })

--- a/src/App/integrationTests/App.clickProjectOfflineReady.test.js
+++ b/src/App/integrationTests/App.clickProjectOfflineReady.test.js
@@ -52,7 +52,7 @@ beforeEach(() => {
 test('Sync: select project to be offline ready, shows toast, syncs and stores data, shows project as selected', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })
@@ -97,7 +97,7 @@ test('Sync: select project to be offline ready, shows toast, syncs and stores da
 test('Sync: select project to NOT be offline ready, shows toast, removes data, shows project as not selected', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })

--- a/src/App/integrationTests/App.dontshowOfflineDeleted.test.js
+++ b/src/App/integrationTests/App.dontshowOfflineDeleted.test.js
@@ -18,7 +18,7 @@ test('Collect page only shows records that arent marked to be deleted next sync'
     _deleted: true,
   })
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/collecting/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -43,7 +43,7 @@ test('Sites page only shows records that arent marked to be deleted next sync', 
     _deleted: true,
   })
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/sites/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -68,7 +68,7 @@ test('Management Regimes page only shows records that arent marked to be deleted
     _deleted: true,
   })
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/management-regimes/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/App.onlineStatusMessage.test.js
+++ b/src/App/integrationTests/App.onlineStatusMessage.test.js
@@ -16,7 +16,7 @@ test('Appropriate online status message shows when navigator is online', async (
 
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })
@@ -32,7 +32,7 @@ test('Appropriate online status message shows when navigator is offline', async 
   jest.spyOn(navigator, 'onLine', 'get').mockReturnValue(false)
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })
@@ -48,7 +48,7 @@ test('Appropriate online status message shows when navigator is offline', async 
 test('Appropriate online status message shows when server is reachable', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })
@@ -68,7 +68,7 @@ test('Appropriate online status message shows when server is unreachable', async
   )
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })

--- a/src/App/integrationTests/App.pageNotFound.test.js
+++ b/src/App/integrationTests/App.pageNotFound.test.js
@@ -10,7 +10,7 @@ test('App renders shows page not found when navigate to unknown path.', async ()
 
   renderAuthenticatedOnline(
     <Route>
-      <App dexieCurrentUserInstance={dexieCurrentUserInstance} />
+      <App />
     </Route>,
     { initialEntries: ['/thisRouteDoesNotExist'] },
     { dexiePerUserDataInstance, dexieCurrentUserInstance },

--- a/src/App/integrationTests/App.projects.test.js
+++ b/src/App/integrationTests/App.projects.test.js
@@ -11,7 +11,7 @@ test('Clicking anywhere on a project card navigates to the project collect page 
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })
@@ -35,7 +35,7 @@ test('Clicking anywhere on a project card navigates to the project collect page 
 // commented out for alpha, reactivate post alpha
 // test('Clicking anywhere on a project card navigates to the project health page when online', async () => {
 //   renderAuthenticatedOnline(
-//     <App dexieInstance={getMockDexieInstancesAllSuccess()} />,
+//     <App />,
 //   )
 
 //   expect(
@@ -61,7 +61,7 @@ test('Offline projects page only shows offline ready projects', async () => {
   // this includes marking one project as offline ready imperatively
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })

--- a/src/App/integrationTests/App.toggleOffline.test.js
+++ b/src/App/integrationTests/App.toggleOffline.test.js
@@ -21,7 +21,7 @@ test('Starting ONLINE - Toggle is checked and switched to OFFLINE, some navigati
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
   renderAuthenticated(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/'],
     },
@@ -64,7 +64,7 @@ test('Navigator online - Toggle switch is not checked, and is enabled', async ()
 
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })
@@ -80,7 +80,7 @@ test('Navigator offline - Toggle switch is checked and disabled', async () => {
 
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })
@@ -94,7 +94,7 @@ test('Navigator offline - Toggle switch is checked and disabled', async () => {
 test('Server is reachable - Toggle switch is not checked, and is enabled', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })
@@ -114,7 +114,7 @@ test('Server is unreachable - Toggle switch is not checked, and is enabled', asy
 
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })

--- a/src/App/integrationTests/App.useSyncApiDataIntoOfflineStorage.test.js
+++ b/src/App/integrationTests/App.useSyncApiDataIntoOfflineStorage.test.js
@@ -58,7 +58,7 @@ test('Sync: initial page load on non project page', async () => {
   expect((await dexiePerUserDataInstance.fish_species.toArray()).length).toEqual(0)
   expect((await dexiePerUserDataInstance.projects.toArray()).length).toEqual(0)
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })
@@ -98,7 +98,7 @@ test('Sync: initial page load on project page', async () => {
   expect((await dexiePerUserDataInstance.project_profiles.toArray()).length).toEqual(0)
   expect((await dexiePerUserDataInstance.project_sites.toArray()).length).toEqual(0)
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
     initialEntries: ['/projects/5/collecting/fishbelt/'],
@@ -142,7 +142,7 @@ test('Sync: initial page load on project page', async () => {
 test('Sync: initial page load already done, navigate to non project page', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })

--- a/src/App/integrationTests/App.userProfile.test.js
+++ b/src/App/integrationTests/App.userProfile.test.js
@@ -13,7 +13,7 @@ import App from '../App'
 test('App renders shows the users name from the API for an online and authenticated user', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })
@@ -29,7 +29,7 @@ test('App renders shows the users name from the API for an online and authentica
 test('App renders shows the users name from offline storage for an offline user who is authenticated when online', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
   })

--- a/src/App/integrationTests/collectRecords/benthicLit/App.ButtonGroupBenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.ButtonGroupBenthicLit.test.js
@@ -18,7 +18,7 @@ const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 test('Edit Benthic LIT - Save button starts with Saved status, make changes, Saved change to Saving, and finally to Saved. Validate button is disabled during saving', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit/70'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -49,7 +49,7 @@ test('Edit Benthic LIT - Save button starts with Saved status, make changes, Sav
 test('Validate Benthic LIT: fails to validate, shows button able to run validation again.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit/70'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -93,7 +93,7 @@ test('Validate Benthic LIT: fails to validate, shows button able to run validati
 test('Validate & submit Benthic LIT: validation passes, shows validate button disabled with proper text, submit is enabled. On submit, submit button is disabled and has "submitting" text', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit/70'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -164,7 +164,7 @@ test('Validate & submit Benthic LIT: validation passes, shows validate button di
 test('Initial load of successfully validated record', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit/70'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicLit/App.NewBenthicAttributeBenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.NewBenthicAttributeBenthicLit.test.js
@@ -17,7 +17,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Benthic LIT observations add new benthic attribute - filling out new attribute form adds a new attribute to dexie and the observation benthic attribute input', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit/70'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -128,7 +128,7 @@ test('Benthic LIT observations add new benthic attribute - filling out new attri
 test('Benthic LIT observations add new benthic attribute - proposing new attribute that already exists results in no added attribute, and a toast message warning.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit/70'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicLit/App.ObservationDuplicateRowsBenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.ObservationDuplicateRowsBenthicLit.test.js
@@ -14,7 +14,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Benthic LIT observations: tab in count input on last row duplicates row', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit/70'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -53,7 +53,7 @@ test('Benthic LIT observations: tab in count input on last row duplicates row', 
 test('Benthic LIT observations: enter key adds a new empty row below row where key pressed', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit/70'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicLit/App.createOfflineBenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.createOfflineBenthicLit.test.js
@@ -36,7 +36,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthiclit/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -73,7 +73,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthiclit/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -104,7 +104,7 @@ describe('Offline', () => {
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
     dexiePerUserDataInstance.collect_records.put = () => Promise.reject()
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthiclit/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicLit/App.createOnlineBenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.createOnlineBenthicLit.test.js
@@ -34,7 +34,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     renderAuthenticatedOnline(
-      <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+      <App />,
       {
         initialEntries: ['/projects/5/collecting/benthiclit'],
       },
@@ -73,7 +73,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     renderAuthenticatedOnline(
-      <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+      <App />,
       {
         initialEntries: ['/projects/5/collecting/benthiclit'],
       },
@@ -104,7 +104,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     dexiePerUserDataInstance.collect_records.put = () => Promise.reject()
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/collecting/benthiclit'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicLit/App.delete1BenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.delete1BenthicLit.test.js
@@ -17,7 +17,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicLit/App.delete2BenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.delete2BenthicLit.test.js
@@ -16,7 +16,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicLit/App.dirtyBenthicLitFormPersistence.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.dirtyBenthicLitFormPersistence.test.js
@@ -13,7 +13,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Unsaved NEW benthic LIT form edits clear when the user navigates away and back', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -54,7 +54,7 @@ test('Unsaved NEW benthic LIT form edits clear when the user navigates away and 
 test('Unsaved EDIT benthic LIT form edits clear when the user navigates away and back', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit/70'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -95,7 +95,7 @@ test('Unsaved EDIT benthic LIT form edits clear when the user navigates away and
 test('Unsaved NEW benthic LIT form edits persist through change in online/offline status', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -123,7 +123,7 @@ test('Unsaved NEW benthic LIT form edits persist through change in online/offlin
 test('Unsaved EDIT benthic LIT form edits persist through change in online/offline status', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit/70'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicLit/App.submitBenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.submitBenthicLit.test.js
@@ -19,7 +19,7 @@ const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 test('Submit Benthic LIT success shows toast message and redirects to collect record list page', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit/70'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -86,7 +86,7 @@ test('Submit Benthic LIT success shows toast message and redirects to collect re
 test('Submit Benthic LIT failure shows toast message and an enabled submit button', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthiclit/70'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicLit/App.updateBenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.updateBenthicLit.test.js
@@ -18,7 +18,7 @@ describe('Offline', () => {
     // make sure there is a collect record to edit in dexie
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -60,7 +60,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -123,7 +123,7 @@ describe('Offline', () => {
     // make sure the next save will fail
     dexiePerUserDataInstance.collect_records.put = jest.fn().mockRejectedValueOnce()
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -151,7 +151,7 @@ describe('Offline', () => {
     // make sure there is a collect record to edit in dexie
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicLit/App.validationDisplay1BenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.validationDisplay1BenthicLit.test.js
@@ -90,7 +90,7 @@ test('Benthic LIT validations will show the all warnings when there are multiple
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
     },
@@ -189,7 +189,7 @@ test('Validating an empty collect record, and then editing an input with errors 
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
     },
@@ -352,7 +352,7 @@ test('Benthic LIT validations will show passed input validations', async () => {
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
     },

--- a/src/App/integrationTests/collectRecords/benthicLit/App.validationDisplay2BenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.validationDisplay2BenthicLit.test.js
@@ -48,7 +48,7 @@ test('Validating an empty benthic LIT collect record shows validations (proof of
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
     },
@@ -211,7 +211,7 @@ test('benthic LIT validations will show only the first error when there are mult
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
     },

--- a/src/App/integrationTests/collectRecords/benthicLit/App.validationIgnoring1BenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.validationIgnoring1BenthicLit.test.js
@@ -240,7 +240,7 @@ test('Benthic LIT validation: user can dismiss non-observations input warnings '
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
     },
@@ -473,7 +473,7 @@ test('Benthic LIT validation: user can dismiss record-level warnings ', async ()
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
     },
@@ -585,7 +585,7 @@ test('Benthic LIT validation: user can dismiss observation warnings ', async () 
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
     },
@@ -841,7 +841,7 @@ test('Benthic LIT validation: user can reset dismissed non-observation input war
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
     },

--- a/src/App/integrationTests/collectRecords/benthicLit/App.validationIgnoring1BenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.validationIgnoring1BenthicLit.test.js
@@ -618,7 +618,7 @@ test('Benthic LIT validation: user can dismiss observation warnings ', async () 
 }, 60000)
 
 test('Benthic LIT validation: user can reset dismissed non-observation input warnings', async () => {
-  const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
+  const { dexiePerUserDataInstance } = getMockDexieInstancesAllSuccess()
 
   mockMermaidApiAllSuccessful.use(
     rest.post(`${apiBaseUrl}/projects/5/collectrecords/validate/`, (req, res, ctx) => {

--- a/src/App/integrationTests/collectRecords/benthicLit/App.validationIgnoring2BenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.validationIgnoring2BenthicLit.test.js
@@ -90,7 +90,7 @@ test('Benthic LIT validation: user can reset ignored observation warnings ', asy
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
     },
@@ -172,7 +172,7 @@ test('user can reset dismissed record-level warnings', async () => {
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
     },
@@ -376,7 +376,7 @@ test('Benthic LIT validation: user edits non-observation input with ignored vali
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthiclit/70'],
     },

--- a/src/App/integrationTests/collectRecords/benthicPhotoQuadrat/App.validationIgnoring1BenthicPhotoQuadrat.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPhotoQuadrat/App.validationIgnoring1BenthicPhotoQuadrat.test.js
@@ -696,7 +696,7 @@ test('Benthic Photo Quadrat validation: user can dismiss observation warnings ',
 }, 60000)
 
 test('Benthic Photo Quadrat validation: user can reset dismissed non-observation input warnings', async () => {
-  const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
+  const { dexiePerUserDataInstance } = getMockDexieInstancesAllSuccess()
 
   mockMermaidApiAllSuccessful.use(
     rest.post(`${apiBaseUrl}/projects/5/collectrecords/validate/`, (req, res, ctx) => {

--- a/src/App/integrationTests/collectRecords/benthicPhotoQuadrat/App.validationIgnoring1BenthicPhotoQuadrat.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPhotoQuadrat/App.validationIgnoring1BenthicPhotoQuadrat.test.js
@@ -275,7 +275,7 @@ test('Benthic Photo Quadrat validation: user can dismiss non-observations input 
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpqt/90'],
     },
@@ -549,7 +549,7 @@ test('Benthic Photo Quadrat validation: user can dismiss record-level warnings '
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpqt/90'],
     },
@@ -661,7 +661,7 @@ test('Benthic Photo Quadrat validation: user can dismiss observation warnings ',
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpqt/90'],
     },
@@ -955,7 +955,7 @@ test('Benthic Photo Quadrat validation: user can reset dismissed non-observation
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpqt/90'],
     },

--- a/src/App/integrationTests/collectRecords/benthicPhotoQuadrat/App.validationIgnoring2BenthicPhotoQuadrat.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPhotoQuadrat/App.validationIgnoring2BenthicPhotoQuadrat.test.js
@@ -90,7 +90,7 @@ test('Benthic photo quadrat validation: user can reset ignored observation warni
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpqt/90'],
     },
@@ -172,7 +172,7 @@ test('user can reset dismissed record-level warnings', async () => {
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpqt/90'],
     },
@@ -460,7 +460,7 @@ test('Benthic photo quadrat validation: user edits non-observation input with ig
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpqt/90'],
     },

--- a/src/App/integrationTests/collectRecords/benthicPit/App.ButtonGroupBenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.ButtonGroupBenthicPit.test.js
@@ -18,7 +18,7 @@ const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 test('Edit Benthic PIT - Save button starts with Saved status, make changes, Saved change to Saving, and finally to Saved. Validate button is disabled during saving', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicPit/50'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -49,7 +49,7 @@ test('Edit Benthic PIT - Save button starts with Saved status, make changes, Sav
 test('Validate Benthic PIT: fails to validate, shows button able to run validation again.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/50'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -93,7 +93,7 @@ test('Validate Benthic PIT: fails to validate, shows button able to run validati
 test('Validate & submit Benthic PIT: validation passes, shows validate button disabled with proper text, submit is enabled. On submit, submit button is disabled and has "submitting" text', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/50'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -164,7 +164,7 @@ test('Validate & submit Benthic PIT: validation passes, shows validate button di
 test('Initial load of successfully validated record', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/50'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicPit/App.NewBenthicAttributeBenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.NewBenthicAttributeBenthicPit.test.js
@@ -17,7 +17,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Benthic PIT observations add new benthic attribute - filling out new attribute form adds a new attribute to dexie and the observation benthic attribute input', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/50'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -128,7 +128,7 @@ test('Benthic PIT observations add new benthic attribute - filling out new attri
 test('Benthic PIT observations add new benthic attribute - proposing new attribute that already exists results in no added attribute, and a toast message warning.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/50'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicPit/App.ObservationDuplicateRowsBenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.ObservationDuplicateRowsBenthicPit.test.js
@@ -14,7 +14,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Benthic Pit observations: tab in count input on last row duplicates row', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/50'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -53,7 +53,7 @@ test('Benthic Pit observations: tab in count input on last row duplicates row', 
 test('Benthic Pit observations: enter key adds a new empty row below row where key pressed', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/50'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicPit/App.ObservationIntervalBenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.ObservationIntervalBenthicPit.test.js
@@ -15,7 +15,7 @@ import App from '../../../App'
 test('Benthic Pit observations: intervals are derived from interval start and interval size fields', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -79,7 +79,7 @@ test('Benthic Pit observations: intervals are derived from interval start and in
 test('Benthic PIT observations: intervals recalculate when user deletes an observation', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -131,7 +131,7 @@ test('Benthic PIT observations: intervals recalculate when user deletes an obser
 test('Benthic Pit observations: intervals reclaculate when a user inserts a row using the enter key', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicPit/App.benthicPitCreateOffline.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.benthicPitCreateOffline.test.js
@@ -36,7 +36,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthicpit/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -73,7 +73,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthicpit/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -104,7 +104,7 @@ describe('Offline', () => {
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
     dexiePerUserDataInstance.collect_records.put = () => Promise.reject()
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthicpit/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicPit/App.benthicPitCreateOnline.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.benthicPitCreateOnline.test.js
@@ -34,7 +34,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     renderAuthenticatedOnline(
-      <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+      <App />,
       {
         initialEntries: ['/projects/5/collecting/benthicpit/'],
       },
@@ -73,7 +73,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     renderAuthenticatedOnline(
-      <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+      <App />,
       {
         initialEntries: ['/projects/5/collecting/benthicpit/'],
       },
@@ -104,7 +104,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     dexiePerUserDataInstance.collect_records.put = () => Promise.reject()
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/collecting/benthicpit/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicPit/App.benthicPitDelete1.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.benthicPitDelete1.test.js
@@ -17,7 +17,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicPit/App.benthicPitDelete2.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.benthicPitDelete2.test.js
@@ -16,7 +16,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicPit/App.dirtyBenthicPitFormPersistence.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.dirtyBenthicPitFormPersistence.test.js
@@ -13,7 +13,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Unsaved NEW benthic pit form edits clear when the user navigates away and back', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -54,7 +54,7 @@ test('Unsaved NEW benthic pit form edits clear when the user navigates away and 
 test('Unsaved EDIT benthic pit form edits clear when the user navigates away and back', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/50'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -95,7 +95,7 @@ test('Unsaved EDIT benthic pit form edits clear when the user navigates away and
 test('Unsaved NEW benthic pit form edits persist through change in online/offline status', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -123,7 +123,7 @@ test('Unsaved NEW benthic pit form edits persist through change in online/offlin
 test('Unsaved EDIT benthic pit form edits persist through change in online/offline status', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/50'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicPit/App.submitBenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.submitBenthicPit.test.js
@@ -19,7 +19,7 @@ const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 test('Submit Benthic PIT success shows toast message and redirects to collect record list page', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/50'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -86,7 +86,7 @@ test('Submit Benthic PIT success shows toast message and redirects to collect re
 test('Submit Benthic PIT failure shows toast message and an enabled submit button', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/benthicpit/50'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicPit/App.updateBenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.updateBenthicPit.test.js
@@ -18,7 +18,7 @@ describe('Offline', () => {
     // make sure there is a collect record to edit in dexie
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -60,7 +60,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -120,7 +120,7 @@ describe('Offline', () => {
     // make sure the next save will fail
     dexiePerUserDataInstance.collect_records.put = jest.fn().mockRejectedValueOnce()
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -148,7 +148,7 @@ describe('Offline', () => {
     // make sure there is a collect record to edit in dexie
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/benthicPit/App.validationDisplay1BenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.validationDisplay1BenthicPit.test.js
@@ -90,7 +90,7 @@ test('Benthic PIT validations will show the all warnings when there are multiple
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
     },
@@ -189,7 +189,7 @@ test('Validating an empty collect record, and then editing an input with errors 
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
     },
@@ -354,7 +354,7 @@ test('Benthic PIT validations will show passed input validations', async () => {
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
     },

--- a/src/App/integrationTests/collectRecords/benthicPit/App.validationDisplay2BenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.validationDisplay2BenthicPit.test.js
@@ -48,7 +48,7 @@ test('Validating an empty benthic PIT collect record shows validations (proof of
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
     },
@@ -213,7 +213,7 @@ test('Benthic PIT validations will show only the first error when there are mult
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
     },

--- a/src/App/integrationTests/collectRecords/benthicPit/App.validationIgnoring1BenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.validationIgnoring1BenthicPit.test.js
@@ -263,7 +263,7 @@ test('Benthic PIT validation: user can dismiss non-observations input warnings '
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
     },
@@ -522,7 +522,7 @@ test('Benthic PIT validation: user can dismiss record-level warnings ', async ()
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
     },
@@ -634,7 +634,7 @@ test('Benthic PIT validation: user can dismiss observation warnings ', async () 
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
     },
@@ -914,7 +914,7 @@ test('Benthic PIT validation: user can reset dismissed non-observation input war
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
     },

--- a/src/App/integrationTests/collectRecords/benthicPit/App.validationIgnoring1BenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.validationIgnoring1BenthicPit.test.js
@@ -667,7 +667,7 @@ test('Benthic PIT validation: user can dismiss observation warnings ', async () 
 }, 60000)
 
 test('Benthic PIT validation: user can reset dismissed non-observation input warnings', async () => {
-  const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
+  const { dexiePerUserDataInstance } = getMockDexieInstancesAllSuccess()
 
   mockMermaidApiAllSuccessful.use(
     rest.post(`${apiBaseUrl}/projects/5/collectrecords/validate/`, (req, res, ctx) => {

--- a/src/App/integrationTests/collectRecords/benthicPit/App.validationIgnoring2BenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.validationIgnoring2BenthicPit.test.js
@@ -90,7 +90,7 @@ test('Benthic PIT validation: user can reset ignored observation warnings ', asy
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
     },
@@ -172,7 +172,7 @@ test('user can reset dismissed record-level warnings', async () => {
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
     },
@@ -400,7 +400,7 @@ test('Benthic PIT validation: user edits non-observation input with ignored vali
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/benthicpit/50'],
     },

--- a/src/App/integrationTests/collectRecords/bleaching/App.ButtonGroupBleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.ButtonGroupBleaching.test.js
@@ -18,7 +18,7 @@ const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 test('Edit Bleaching collect record - Save button starts with Saved status, make changes, Saved change to Saving, and finally to Saved. Validate button is disabled during saving', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -49,7 +49,7 @@ test('Edit Bleaching collect record - Save button starts with Saved status, make
 test('Validate Bleaching collect record: fails to validate, shows button able to run validation again.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -93,7 +93,7 @@ test('Validate Bleaching collect record: fails to validate, shows button able to
 test('Validate & submit Bleaching collect record: validation passes, shows validate button disabled with proper text, submit is enabled. On submit, submit button is disabled and has "submitting" text', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -164,7 +164,7 @@ test('Validate & submit Bleaching collect record: validation passes, shows valid
 test('Initial load of successfully validated record', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/bleaching/App.NewBenthicAttributeBleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.NewBenthicAttributeBleaching.test.js
@@ -17,7 +17,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Bleaching collect record observations add new benthic attribute - filling out new attribute form adds a new attribute to dexie and the observation benthic attribute input', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -128,7 +128,7 @@ test('Bleaching collect record observations add new benthic attribute - filling 
 test('Bleaching collect record observations add new benthic attribute - proposing new attribute that already exists results in no added attribute, and a toast message warning.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/bleaching/App.ObservationColoniesBleachedDuplicateRowsBleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.ObservationColoniesBleachedDuplicateRowsBleaching.test.js
@@ -14,7 +14,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Bleaching colonies bleached observations: tab in count input on last row duplicates row', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -53,7 +53,7 @@ test('Bleaching colonies bleached observations: tab in count input on last row d
 test('Bleaching colonies bleached observations: enter key adds a new empty row below row where key pressed', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/bleaching/App.ObservationPercentCoverDuplicateRowsBleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.ObservationPercentCoverDuplicateRowsBleaching.test.js
@@ -14,7 +14,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Bleaching percent cover observations: tab in count input on last row duplicates row', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -59,7 +59,7 @@ test('Bleaching percent cover observations: tab in count input on last row dupli
 test('Bleaching percent cover observations: enter key adds a new empty row below row where key pressed', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/bleaching/App.createOfflineBleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.createOfflineBleaching.test.js
@@ -33,7 +33,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/bleachingqc/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -68,7 +68,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/bleachingqc/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -99,7 +99,7 @@ describe('Offline', () => {
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
     dexiePerUserDataInstance.collect_records.put = () => Promise.reject()
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/bleachingqc/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/bleaching/App.createOnlineBleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.createOnlineBleaching.test.js
@@ -31,7 +31,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     renderAuthenticatedOnline(
-      <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+      <App />,
       {
         initialEntries: ['/projects/5/collecting/bleachingqc'],
       },
@@ -68,7 +68,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     renderAuthenticatedOnline(
-      <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+      <App />,
       {
         initialEntries: ['/projects/5/collecting/bleachingqc'],
       },
@@ -99,7 +99,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     dexiePerUserDataInstance.collect_records.put = () => Promise.reject()
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/collecting/bleachingqc'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/bleaching/App.delete1Bleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.delete1Bleaching.test.js
@@ -17,7 +17,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/bleaching/App.delete2Bleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.delete2Bleaching.test.js
@@ -16,7 +16,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/bleaching/App.dirtyFormPersistenceBleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.dirtyFormPersistenceBleaching.test.js
@@ -13,7 +13,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Unsaved NEW bleaching form edits clear when the user navigates away and back', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -54,7 +54,7 @@ test('Unsaved NEW bleaching form edits clear when the user navigates away and ba
 test('Unsaved EDIT bleaching form edits clear when the user navigates away and back', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -95,7 +95,7 @@ test('Unsaved EDIT bleaching form edits clear when the user navigates away and b
 test('Unsaved NEW bleaching form edits persist through change in online/offline status', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -123,7 +123,7 @@ test('Unsaved NEW bleaching form edits persist through change in online/offline 
 test('Unsaved EDIT bleaching form edits persist through change in online/offline status', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/bleaching/App.submitBleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.submitBleaching.test.js
@@ -19,7 +19,7 @@ const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 test('Submit Bleaching collect record success shows toast message and redirects to collect record list page', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -86,7 +86,7 @@ test('Submit Bleaching collect record success shows toast message and redirects 
 test('Submit Benthic PIT failure shows toast message and an enabled submit button', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/bleaching/App.updateBleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.updateBleaching.test.js
@@ -18,7 +18,7 @@ describe('Offline', () => {
     // make sure there is a collect record to edit in dexie
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -58,7 +58,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -147,7 +147,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -202,7 +202,7 @@ describe('Offline', () => {
     // make sure the next save will fail
     dexiePerUserDataInstance.collect_records.put = jest.fn().mockRejectedValueOnce()
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -230,7 +230,7 @@ describe('Offline', () => {
     // make sure there is a collect record to edit in dexie
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/bleaching/App.validationDisplay1Bleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.validationDisplay1Bleaching.test.js
@@ -93,7 +93,7 @@ test('Bleaching collect record validations will show the all warnings when there
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },
@@ -223,7 +223,7 @@ test('Validating an empty collect record, and then editing an input with errors 
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },
@@ -393,7 +393,7 @@ test('Bleaching collect record validations will show passed input validations', 
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },

--- a/src/App/integrationTests/collectRecords/bleaching/App.validationDisplay2Bleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.validationDisplay2Bleaching.test.js
@@ -48,7 +48,7 @@ test('Validating an empty bleaching collect record collect record shows validati
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },
@@ -229,7 +229,7 @@ test('bleaching collect record validations will show only the first error when t
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },

--- a/src/App/integrationTests/collectRecords/bleaching/App.validationIgnoring1Bleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.validationIgnoring1Bleaching.test.js
@@ -691,7 +691,7 @@ test('Bleaching collect record validation: user can dismiss percent cover observ
 }, 60000)
 
 test('Bleaching collect record validation: user can reset dismissed non-observation input warnings', async () => {
-  const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
+  const { dexiePerUserDataInstance } = getMockDexieInstancesAllSuccess()
 
   mockMermaidApiAllSuccessful.use(
     rest.post(`${apiBaseUrl}/projects/5/collectrecords/validate/`, (req, res, ctx) => {

--- a/src/App/integrationTests/collectRecords/bleaching/App.validationIgnoring1Bleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.validationIgnoring1Bleaching.test.js
@@ -217,7 +217,7 @@ test('Bleaching collect record validation: user can dismiss non-observations inp
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },
@@ -424,7 +424,7 @@ test('Bleaching collect record validation: user can dismiss record-level warning
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },
@@ -536,7 +536,7 @@ test('Bleaching collect record validation: user can dismiss colonies bleached ob
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },
@@ -652,7 +652,7 @@ test('Bleaching collect record validation: user can dismiss percent cover observ
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },
@@ -926,7 +926,7 @@ test('Bleaching collect record validation: user can reset dismissed non-observat
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },

--- a/src/App/integrationTests/collectRecords/bleaching/App.validationIgnoring2Bleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.validationIgnoring2Bleaching.test.js
@@ -92,7 +92,7 @@ test('Bleaching validation: user can reset ignored observation warnings (colonie
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },
@@ -221,7 +221,7 @@ test('Bleaching validation: user can reset ignored observation warnings (percent
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },
@@ -311,7 +311,7 @@ test('user can reset dismissed record-level warnings', async () => {
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },
@@ -503,7 +503,7 @@ test('Bleaching validation: user edits non-observation input with ignored valida
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/bleachingqc/60'],
     },

--- a/src/App/integrationTests/collectRecords/fishBelt/App.dirtyFishbeltFormPersistence.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.dirtyFishbeltFormPersistence.test.js
@@ -13,7 +13,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Unsaved NEW fishbelt form edits clear when the user navigates away and back', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -54,7 +54,7 @@ test('Unsaved NEW fishbelt form edits clear when the user navigates away and bac
 test('Unsaved EDIT fishbelt form edits clear when the user navigates away and back', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/2'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -95,7 +95,7 @@ test('Unsaved EDIT fishbelt form edits clear when the user navigates away and ba
 test('Unsaved NEW fishbelt form edits persist through change in online/offline status', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -123,7 +123,7 @@ test('Unsaved NEW fishbelt form edits persist through change in online/offline s
 test('Unsaved EDIT fishbelt form edits persist through change in online/offline status', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/2'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltButtonGroup.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltButtonGroup.test.js
@@ -17,7 +17,7 @@ const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 test('Edit Fishbelt - Save button starts with Saved status, make changes, Saved change to Saving, and finally to Saved. Validate button is disabled during saving', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/2'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -48,7 +48,7 @@ test('Edit Fishbelt - Save button starts with Saved status, make changes, Saved 
 test('Validate fishbelt: fails to validate, shows button able to run validation again.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/1'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -92,7 +92,7 @@ test('Validate fishbelt: fails to validate, shows button able to run validation 
 test('Validate & submit fishbelt: validation passes, shows validate button disabled with proper text, submit is enabled. On submit, submit button is disabled and has "submitting" text', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/1'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -163,7 +163,7 @@ test('Validate & submit fishbelt: validation passes, shows validate button disab
 test('Initial load of successfully validated record', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/1'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltCreateOffline.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltCreateOffline.test.js
@@ -38,7 +38,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/fishbelt/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -75,7 +75,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/fishbelt/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -107,7 +107,7 @@ describe('Offline', () => {
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
     dexiePerUserDataInstance.collect_records.put = () => Promise.reject()
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/fishbelt/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltCreateOnline.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltCreateOnline.test.js
@@ -36,7 +36,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     renderAuthenticatedOnline(
-      <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+      <App />,
       {
         initialEntries: ['/projects/5/collecting/fishbelt/'],
       },
@@ -74,7 +74,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     renderAuthenticatedOnline(
-      <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+      <App />,
       {
         initialEntries: ['/projects/5/collecting/fishbelt/'],
       },
@@ -106,7 +106,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     dexiePerUserDataInstance.collect_records.put = () => Promise.reject()
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/collecting/fishbelt/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltDelete1.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltDelete1.test.js
@@ -17,7 +17,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/fishbelt/2'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltDelete2.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltDelete2.test.js
@@ -16,7 +16,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/fishbelt/2'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltNewSpecies.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltNewSpecies.test.js
@@ -17,7 +17,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Fishbelt observations add new species - filling out new species form adds a new species to dexie and the observation fish name input', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/2'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -129,7 +129,7 @@ test('Fishbelt observations add new species - filling out new species form adds 
 test('Fishbelt observations add new species - proposing new species that already exists results in no added species, and a toast message warning.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/2'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltObservationDuplicateRows.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltObservationDuplicateRows.test.js
@@ -14,7 +14,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Fishbelt observations: tab in count input on last row duplicates row', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/2'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -53,7 +53,7 @@ test('Fishbelt observations: tab in count input on last row duplicates row', asy
 test('Fishbelt observations: enter key adds a new empty row below row where key pressed', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/2'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltSubmit.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltSubmit.test.js
@@ -18,7 +18,7 @@ const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 test('Submit fishbelt success shows toast message and redirects to collect record list page', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/1'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -85,7 +85,7 @@ test('Submit fishbelt success shows toast message and redirects to collect recor
 test('Submit fishbelt failure shows toast message and an enabled submit button', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/1'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltUpdate.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltUpdate.test.js
@@ -18,7 +18,7 @@ describe('Offline', () => {
     // make sure there is a collect record to edit in dexie
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/fishbelt/2'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -62,7 +62,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/fishbelt/2'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -123,7 +123,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/fishbelt/2'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -177,7 +177,7 @@ describe('Offline', () => {
     // make sure the next save will fail
     dexiePerUserDataInstance.collect_records.put = jest.fn().mockRejectedValueOnce()
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/fishbelt/2'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -205,7 +205,7 @@ describe('Offline', () => {
     // make sure there is a collect record to edit in dexie
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/fishbelt/2'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltValidationDisplay1.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltValidationDisplay1.test.js
@@ -89,7 +89,7 @@ test('Fishbelt validations will show the all warnings when there are multiple wa
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/fishbelt/1'],
     },
@@ -188,7 +188,7 @@ test('Validating an empty collect record, and then editing an input with errors 
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/fishbelt/1'],
     },
@@ -357,7 +357,7 @@ test('Fishbelt validations will show passed input validations', async () => {
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/fishbelt/1'],
     },

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltValidationDisplay2.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltValidationDisplay2.test.js
@@ -47,7 +47,7 @@ test('Validating an empty collect record shows validations (proof of wire-up)', 
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/fishbelt/1'],
     },
@@ -213,7 +213,7 @@ test('Fishbelt validations will show only the first error when there are multipl
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/fishbelt/1'],
     },

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltValidationIgnoring1.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltValidationIgnoring1.test.js
@@ -661,7 +661,7 @@ test('Fishbelt Validation: user can dismiss observation warnings ', async () => 
 }, 60000)
 
 test('Fishbelt validation: user can reset dismissed non-observation input warnings', async () => {
-  const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
+  const { dexiePerUserDataInstance } = getMockDexieInstancesAllSuccess()
 
   mockMermaidApiAllSuccessful.use(
     rest.post(`${apiBaseUrl}/projects/5/collectrecords/validate/`, (req, res, ctx) => {

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltValidationIgnoring1.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltValidationIgnoring1.test.js
@@ -261,7 +261,7 @@ test('Fishbelt Validation: user can dismiss non-observations input warnings ', a
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/fishbelt/1'],
     },
@@ -516,7 +516,7 @@ test('Fishbelt Validation: user can dismiss record-level warnings ', async () =>
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/fishbelt/1'],
     },
@@ -628,7 +628,7 @@ test('Fishbelt Validation: user can dismiss observation warnings ', async () => 
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/fishbelt/1'],
     },
@@ -908,7 +908,7 @@ test('Fishbelt validation: user can reset dismissed non-observation input warnin
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/fishbelt/1'],
     },

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltValidationIgnoring2.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltValidationIgnoring2.test.js
@@ -89,7 +89,7 @@ test('Validation: user can reset ignored observation warnings ', async () => {
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/fishbelt/1'],
     },
@@ -171,7 +171,7 @@ test('user can reset dismissed record-level warnings', async () => {
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/fishbelt/1'],
     },
@@ -399,7 +399,7 @@ test('Validation: user edits non-observation input with ignored validation reset
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/fishbelt/1'],
     },

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltValidationPassingInputs.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltValidationPassingInputs.test.js
@@ -61,7 +61,7 @@ test('Fishbelt validations show check for valid inputs', async () => {
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/fishbelt/1'],
     },

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.ButtonGroupHabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.ButtonGroupHabitatComplexity.test.js
@@ -18,7 +18,7 @@ const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 test('Edit Habitat Complexity - Save button starts with Saved status, make changes, Saved change to Saving, and finally to Saved. Validate button is disabled during saving', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -49,7 +49,7 @@ test('Edit Habitat Complexity - Save button starts with Saved status, make chang
 test('Validate Habitat Complexity: fails to validate, shows button able to run validation again.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -93,7 +93,7 @@ test('Validate Habitat Complexity: fails to validate, shows button able to run v
 test('Validate & submit Habitat Complexity: validation passes, shows validate button disabled with proper text, submit is enabled. On submit, submit button is disabled and has "submitting" text', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -164,7 +164,7 @@ test('Validate & submit Habitat Complexity: validation passes, shows validate bu
 test('Initial load of successfully validated record', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.Delete1HabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.Delete1HabitatComplexity.test.js
@@ -17,7 +17,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.ObservationDuplicateRowsHabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.ObservationDuplicateRowsHabitatComplexity.test.js
@@ -14,7 +14,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Habitat Complexity observations: tab in count input on last row duplicates row', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -61,7 +61,7 @@ test('Habitat Complexity observations: tab in count input on last row duplicates
 test('Habitat Complexity observations: enter key adds a new empty row below row where key pressed', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.ObservationIntervalHabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.ObservationIntervalHabitatComplexity.test.js
@@ -15,7 +15,7 @@ import App from '../../../App'
 test('Habitat Complexity observations: intervals are derived from interval size fields', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -61,7 +61,7 @@ test('Habitat Complexity observations: intervals are derived from interval size 
 test('Habitat Complexity observations: intervals recalculate when user deletes an observation', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -109,7 +109,7 @@ test('Habitat Complexity observations: intervals recalculate when user deletes a
 test('Habitat Complexity observations: intervals reclaculate when a user inserts a row using the enter key', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.createOfflineHabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.createOfflineHabitatComplexity.test.js
@@ -37,7 +37,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -75,7 +75,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -108,7 +108,7 @@ describe('Offline', () => {
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
     dexiePerUserDataInstance.collect_records.put = () => Promise.reject()
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.createOnlineHabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.createOnlineHabitatComplexity.test.js
@@ -35,7 +35,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     renderAuthenticatedOnline(
-      <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+      <App />,
       {
         initialEntries: ['/projects/5/collecting/habitatcomplexity/'],
       },
@@ -75,7 +75,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     renderAuthenticatedOnline(
-      <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+      <App />,
       {
         initialEntries: ['/projects/5/collecting/habitatcomplexity/'],
       },
@@ -108,7 +108,7 @@ describe('Online', () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
     dexiePerUserDataInstance.collect_records.put = () => Promise.reject()
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.delete2HabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.delete2HabitatComplexity.test.js
@@ -16,7 +16,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.dirtyHabitatComplexityFormPersistence.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.dirtyHabitatComplexityFormPersistence.test.js
@@ -13,7 +13,7 @@ import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockD
 test('Unsaved NEW Habitat Complexity form edits clear when the user navigates away and back', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -54,7 +54,7 @@ test('Unsaved NEW Habitat Complexity form edits clear when the user navigates aw
 test('Unsaved EDIT Habitat Complexity form edits clear when the user navigates away and back', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -95,7 +95,7 @@ test('Unsaved EDIT Habitat Complexity form edits clear when the user navigates a
 test('Unsaved NEW Habitat Complexity form edits persist through change in online/offline status', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -123,7 +123,7 @@ test('Unsaved NEW Habitat Complexity form edits persist through change in online
 test('Unsaved EDIT Habitat Complexity form edits persist through change in online/offline status', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticated(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticated(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.submitHabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.submitHabitatComplexity.test.js
@@ -19,7 +19,7 @@ const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 test('Submit Habitat Complexity success shows toast message and redirects to collect record list page', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -86,7 +86,7 @@ test('Submit Habitat Complexity success shows toast message and redirects to col
 test('Submit Habitat Complexity failure shows toast message and an enabled submit button', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.updateHabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.updateHabitatComplexity.test.js
@@ -1,6 +1,8 @@
 import '@testing-library/jest-dom/extend-expect'
 import React from 'react'
 import userEvent from '@testing-library/user-event'
+import { Route } from 'react-router-dom'
+
 import {
   screen,
   renderAuthenticatedOffline,
@@ -9,7 +11,7 @@ import {
 } from '../../../../testUtilities/testingLibraryWithHelpers'
 import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockDexie'
 import { initiallyHydrateOfflineStorageWithMockData } from '../../../../testUtilities/initiallyHydrateOfflineStorageWithMockData'
-import App from '../../../App'
+import HabitatComplexityForm from '../../../../components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm'
 
 describe('Offline', () => {
   test('Edit Habitat Complexity save success shows toast message and proper record information', async () => {
@@ -18,11 +20,17 @@ describe('Offline', () => {
     // make sure there is a collect record to edit in dexie
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App />, {
-      initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
-      dexiePerUserDataInstance,
-      dexieCurrentUserInstance,
-    })
+    renderAuthenticatedOffline(
+      <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+        <HabitatComplexityForm isNewRecord={false} />
+      </Route>,
+      {
+        initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+        dexiePerUserDataInstance,
+        dexieCurrentUserInstance,
+        isSyncInProgressOverride: true,
+      },
+    )
 
     // make a change
 
@@ -61,11 +69,17 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App />, {
-      initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
-      dexiePerUserDataInstance,
-      dexieCurrentUserInstance,
-    })
+    renderAuthenticatedOffline(
+      <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+        <HabitatComplexityForm isNewRecord={false} />
+      </Route>,
+      {
+        initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+        dexiePerUserDataInstance,
+        dexieCurrentUserInstance,
+        isSyncInProgressOverride: true,
+      },
+    )
 
     // test all observers format too
     const addObservationButton = await screen.findByRole('button', {
@@ -112,11 +126,17 @@ describe('Offline', () => {
     // make sure the next save will fail
     dexiePerUserDataInstance.collect_records.put = jest.fn().mockRejectedValueOnce()
 
-    renderAuthenticatedOffline(<App />, {
-      initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
-      dexiePerUserDataInstance,
-      dexieCurrentUserInstance,
-    })
+    renderAuthenticatedOffline(
+      <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+        <HabitatComplexityForm isNewRecord={false} />
+      </Route>,
+      {
+        initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+        dexiePerUserDataInstance,
+        dexieCurrentUserInstance,
+        isSyncInProgressOverride: true,
+      },
+    )
 
     // make an unsaved change
     const depthInput = await screen.findByLabelText('Depth')
@@ -140,11 +160,17 @@ describe('Offline', () => {
     // make sure there is a collect record to edit in dexie
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App />, {
-      initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
-      dexiePerUserDataInstance,
-      dexieCurrentUserInstance,
-    })
+    renderAuthenticatedOffline(
+      <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+        <HabitatComplexityForm isNewRecord={false} />
+      </Route>,
+      {
+        initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+        dexiePerUserDataInstance,
+        dexieCurrentUserInstance,
+        isSyncInProgressOverride: true,
+      },
+    )
 
     await screen.findByLabelText('project pages loading indicator')
     await waitForElementToBeRemoved(() =>

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.updateHabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.updateHabitatComplexity.test.js
@@ -18,7 +18,7 @@ describe('Offline', () => {
     // make sure there is a collect record to edit in dexie
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -61,7 +61,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -112,7 +112,7 @@ describe('Offline', () => {
     // make sure the next save will fail
     dexiePerUserDataInstance.collect_records.put = jest.fn().mockRejectedValueOnce()
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -140,7 +140,7 @@ describe('Offline', () => {
     // make sure there is a collect record to edit in dexie
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.validationDisplay1HabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.validationDisplay1HabitatComplexity.test.js
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/extend-expect'
 import React from 'react'
 import userEvent from '@testing-library/user-event'
 import { rest } from 'msw'
+import { Route } from 'react-router-dom'
 import {
   mockMermaidApiAllSuccessful,
   renderAuthenticatedOnline,
@@ -11,8 +12,9 @@ import {
 import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockDexie'
 import { mockHabitatComplexityCollectRecords } from '../../../../testUtilities/mockCollectRecords/mockHabitatComplexityCollectRecords'
 import { mockHabitatComplexityValidationsObject } from '../../../../testUtilities/mockCollectRecords/mockHabitatComplexityValidationsObject'
-import App from '../../../App'
 import mockMermaidData from '../../../../testUtilities/mockMermaidData'
+import HabitatComplexityForm from '../../../../components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm'
+import { initiallyHydrateOfflineStorageWithMockData } from '../../../../testUtilities/initiallyHydrateOfflineStorageWithMockData'
 
 const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 
@@ -89,13 +91,19 @@ test('Habitat Complexity validations will show the all warnings when there are m
     }),
   )
 
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
   renderAuthenticatedOnline(
-    <App />,
+    <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+      <HabitatComplexityForm isNewRecord={false} />
+    </Route>,
+
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+      isSyncInProgressOverride: true,
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
     },
-    dexiePerUserDataInstance,
-    dexieCurrentUserInstance,
   )
 
   userEvent.click(
@@ -188,13 +196,19 @@ test('Validating an empty collect record, and then editing an input with errors 
     }),
   )
 
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
   renderAuthenticatedOnline(
-    <App />,
+    <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+      <HabitatComplexityForm isNewRecord={false} />
+    </Route>,
+
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+      isSyncInProgressOverride: true,
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
     },
-    dexiePerUserDataInstance,
-    dexieCurrentUserInstance,
   )
 
   userEvent.click(
@@ -357,13 +371,19 @@ test('Habitat Complexity validations will show passed input validations', async 
     }),
   )
 
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
   renderAuthenticatedOnline(
-    <App />,
+    <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+      <HabitatComplexityForm isNewRecord={false} />
+    </Route>,
+
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+      isSyncInProgressOverride: true,
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
     },
-    dexiePerUserDataInstance,
-    dexieCurrentUserInstance,
   )
 
   userEvent.click(

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.validationDisplay1HabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.validationDisplay1HabitatComplexity.test.js
@@ -90,7 +90,7 @@ test('Habitat Complexity validations will show the all warnings when there are m
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     },
@@ -189,7 +189,7 @@ test('Validating an empty collect record, and then editing an input with errors 
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     },
@@ -358,7 +358,7 @@ test('Habitat Complexity validations will show passed input validations', async 
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     },

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.validationDisplay2HabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.validationDisplay2HabitatComplexity.test.js
@@ -48,7 +48,7 @@ test('Validating an empty Habitat Complexity collect record shows validations (p
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     },
@@ -212,7 +212,7 @@ test('Habitat Complexity validations will show only the first error when there a
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     },

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.validationDisplay2HabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.validationDisplay2HabitatComplexity.test.js
@@ -2,17 +2,21 @@ import '@testing-library/jest-dom/extend-expect'
 import React from 'react'
 import userEvent from '@testing-library/user-event'
 import { rest } from 'msw'
+import { Route } from 'react-router-dom'
+
 import {
   mockMermaidApiAllSuccessful,
   renderAuthenticatedOnline,
   screen,
   within,
 } from '../../../../testUtilities/testingLibraryWithHelpers'
-import App from '../../../App'
 import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockDexie'
 import mockMermaidData from '../../../../testUtilities/mockMermaidData'
 import { mockHabitatComplexityValidationsObject } from '../../../../testUtilities/mockCollectRecords/mockHabitatComplexityValidationsObject'
 import { mockHabitatComplexityCollectRecords } from '../../../../testUtilities/mockCollectRecords/mockHabitatComplexityCollectRecords'
+import { initiallyHydrateOfflineStorageWithMockData } from '../../../../testUtilities/initiallyHydrateOfflineStorageWithMockData'
+
+import HabitatComplexityForm from '../../../../components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm'
 
 const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 
@@ -47,13 +51,19 @@ test('Validating an empty Habitat Complexity collect record shows validations (p
     }),
   )
 
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
   renderAuthenticatedOnline(
-    <App />,
+    <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+      <HabitatComplexityForm isNewRecord={false} />
+    </Route>,
+
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+      isSyncInProgressOverride: true,
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
     },
-    dexiePerUserDataInstance,
-    dexieCurrentUserInstance,
   )
 
   userEvent.click(
@@ -211,13 +221,19 @@ test('Habitat Complexity validations will show only the first error when there a
     }),
   )
 
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
   renderAuthenticatedOnline(
-    <App />,
+    <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+      <HabitatComplexityForm isNewRecord={false} />
+    </Route>,
+
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+      isSyncInProgressOverride: true,
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
     },
-    dexiePerUserDataInstance,
-    dexieCurrentUserInstance,
   )
 
   userEvent.click(

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.validationIgnoring1HabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.validationIgnoring1HabitatComplexity.test.js
@@ -2,6 +2,8 @@ import '@testing-library/jest-dom/extend-expect'
 import React from 'react'
 import userEvent from '@testing-library/user-event'
 import { rest } from 'msw'
+import { Route } from 'react-router-dom'
+
 import {
   mockMermaidApiAllSuccessful,
   renderAuthenticatedOnline,
@@ -9,10 +11,12 @@ import {
   waitFor,
   within,
 } from '../../../../testUtilities/testingLibraryWithHelpers'
-import App from '../../../App'
 import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockDexie'
 import mockMermaidData from '../../../../testUtilities/mockMermaidData'
 import { mockHabitatComplexityCollectRecords } from '../../../../testUtilities/mockCollectRecords/mockHabitatComplexityCollectRecords'
+import { initiallyHydrateOfflineStorageWithMockData } from '../../../../testUtilities/initiallyHydrateOfflineStorageWithMockData'
+
+import HabitatComplexityForm from '../../../../components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm'
 
 const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 
@@ -250,13 +254,19 @@ test('Habitat Complexity validation: user can dismiss non-observations input war
     }),
   )
 
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
   renderAuthenticatedOnline(
-    <App />,
+    <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+      <HabitatComplexityForm isNewRecord={false} />
+    </Route>,
+
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+      isSyncInProgressOverride: true,
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
     },
-    dexiePerUserDataInstance,
-    dexieCurrentUserInstance,
   )
 
   userEvent.click(await screen.findByRole('button', { name: 'Validate' }, { timeout: 10000 }))
@@ -500,13 +510,19 @@ test('Habitat Complexity validation: user can dismiss record-level warnings ', a
     }),
   )
 
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
   renderAuthenticatedOnline(
-    <App />,
+    <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+      <HabitatComplexityForm isNewRecord={false} />
+    </Route>,
+
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+      isSyncInProgressOverride: true,
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
     },
-    dexiePerUserDataInstance,
-    dexieCurrentUserInstance,
   )
 
   userEvent.click(await screen.findByRole('button', { name: 'Validate' }, { timeout: 10000 }))
@@ -612,13 +628,19 @@ test('Habitat Complexity validation: user can dismiss observation warnings ', as
     }),
   )
 
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
   renderAuthenticatedOnline(
-    <App />,
+    <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+      <HabitatComplexityForm isNewRecord={false} />
+    </Route>,
+
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+      isSyncInProgressOverride: true,
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
     },
-    dexiePerUserDataInstance,
-    dexieCurrentUserInstance,
   )
 
   userEvent.click(await screen.findByRole('button', { name: 'Validate' }, { timeout: 10000 }))
@@ -880,12 +902,19 @@ test('Habitat Complexity validation: user can reset dismissed non-observation in
     }),
   )
 
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
   renderAuthenticatedOnline(
-    <App />,
+    <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+      <HabitatComplexityForm isNewRecord={false} />
+    </Route>,
+
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+      isSyncInProgressOverride: true,
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
     },
-    dexiePerUserDataInstance,
   )
 
   userEvent.click(await screen.findByRole('button', { name: 'Validate' }, { timeout: 10000 }))

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.validationIgnoring1HabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.validationIgnoring1HabitatComplexity.test.js
@@ -251,7 +251,7 @@ test('Habitat Complexity validation: user can dismiss non-observations input war
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     },
@@ -501,7 +501,7 @@ test('Habitat Complexity validation: user can dismiss record-level warnings ', a
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     },
@@ -613,7 +613,7 @@ test('Habitat Complexity validation: user can dismiss observation warnings ', as
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     },
@@ -881,7 +881,7 @@ test('Habitat Complexity validation: user can reset dismissed non-observation in
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     },

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.validationIgnoring2HabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.validationIgnoring2HabitatComplexity.test.js
@@ -1,7 +1,9 @@
 import '@testing-library/jest-dom/extend-expect'
+import { rest } from 'msw'
+import { Route } from 'react-router-dom'
 import React from 'react'
 import userEvent from '@testing-library/user-event'
-import { rest } from 'msw'
+
 import {
   mockMermaidApiAllSuccessful,
   renderAuthenticatedOnline,
@@ -9,10 +11,11 @@ import {
   waitFor,
   within,
 } from '../../../../testUtilities/testingLibraryWithHelpers'
-import App from '../../../App'
 import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockDexie'
 import mockMermaidData from '../../../../testUtilities/mockMermaidData'
 import { mockHabitatComplexityCollectRecords } from '../../../../testUtilities/mockCollectRecords/mockHabitatComplexityCollectRecords'
+import HabitatComplexityForm from '../../../../components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm'
+import { initiallyHydrateOfflineStorageWithMockData } from '../../../../testUtilities/initiallyHydrateOfflineStorageWithMockData'
 
 const apiBaseUrl = process.env.REACT_APP_MERMAID_API
 
@@ -88,14 +91,19 @@ test('Habitat Complexity validation: user can reset ignored observation warnings
       return res(ctx.json(response))
     }),
   )
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
   renderAuthenticatedOnline(
-    <App />,
+    <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+      <HabitatComplexityForm isNewRecord={false} />
+    </Route>,
+
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+      isSyncInProgressOverride: true,
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
     },
-    dexiePerUserDataInstance,
-    dexieCurrentUserInstance,
   )
 
   userEvent.click(await screen.findByRole('button', { name: 'Validate' }, { timeout: 10000 }))
@@ -171,13 +179,19 @@ test('user can reset dismissed record-level warnings', async () => {
     }),
   )
 
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
   renderAuthenticatedOnline(
-    <App />,
+    <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+      <HabitatComplexityForm isNewRecord={false} />
+    </Route>,
+
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+      isSyncInProgressOverride: true,
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
     },
-    dexiePerUserDataInstance,
-    dexieCurrentUserInstance,
   )
 
   userEvent.click(await screen.findByRole('button', { name: 'Validate' }, { timeout: 10000 }))
@@ -387,13 +401,19 @@ test('Habitat Complexity validation: user edits non-observation input with ignor
     }),
   )
 
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
   renderAuthenticatedOnline(
-    <App />,
+    <Route path="/projects/:projectId/collecting/habitatcomplexity/:recordId">
+      <HabitatComplexityForm isNewRecord={false} />
+    </Route>,
+
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
+      isSyncInProgressOverride: true,
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
     },
-    dexiePerUserDataInstance,
-    dexieCurrentUserInstance,
   )
 
   userEvent.click(await screen.findByRole('button', { name: 'Validate' }, { timeout: 10000 }))

--- a/src/App/integrationTests/collectRecords/habitatComplexity/App.validationIgnoring2HabitatComplexity.test.js
+++ b/src/App/integrationTests/collectRecords/habitatComplexity/App.validationIgnoring2HabitatComplexity.test.js
@@ -90,7 +90,7 @@ test('Habitat Complexity validation: user can reset ignored observation warnings
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     },
@@ -172,7 +172,7 @@ test('user can reset dismissed record-level warnings', async () => {
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     },
@@ -388,7 +388,7 @@ test('Habitat Complexity validation: user edits non-observation input with ignor
   )
 
   renderAuthenticatedOnline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     {
       initialEntries: ['/projects/5/collecting/habitatcomplexity/80'],
     },

--- a/src/App/integrationTests/managementRegime/App.managementRegimeCreateOffline.test.js
+++ b/src/App/integrationTests/managementRegime/App.managementRegimeCreateOffline.test.js
@@ -31,7 +31,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/management-regimes/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -79,7 +79,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/management-regimes/new'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -111,7 +111,7 @@ describe('Offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/management-regimes/new'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -151,7 +151,7 @@ describe('Offline', () => {
 
     dexiePerUserDataInstance.project_managements.put = () => Promise.reject(dexieError)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/management-regimes/new'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/managementRegime/App.managementRegimeCreateOnline.test.js
+++ b/src/App/integrationTests/managementRegime/App.managementRegimeCreateOnline.test.js
@@ -36,7 +36,7 @@ describe('Online', () => {
   test('New MR button navigates to new MR form properly', async () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/management-regimes/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -82,7 +82,7 @@ describe('Online', () => {
   test('New MR save success shows saved inputs, toast, and navigates to the edit MR page for the newly created MR', async () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/management-regimes/new'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -112,7 +112,7 @@ describe('Online', () => {
   test('New MR save success show new record in MR table', async () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/management-regimes/new'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -151,7 +151,7 @@ describe('Online', () => {
       }),
     )
 
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/management-regimes/new'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -197,7 +197,7 @@ describe('Online', () => {
     )
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/management-regimes/new'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/noInfoAssociatedWithId/App.CollectNoRecord.test.js
+++ b/src/App/integrationTests/noInfoAssociatedWithId/App.CollectNoRecord.test.js
@@ -14,7 +14,7 @@ test('Offline collect records list shows no info associated with projectId view 
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/collecting/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -26,7 +26,7 @@ test('Offline collect records list shows no info associated with projectId view 
 test('Online collect records list shows no info associated with projectId view ', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/collecting/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/noInfoAssociatedWithId/App.ManagementRegimeListNoRecord.test.js
+++ b/src/App/integrationTests/noInfoAssociatedWithId/App.ManagementRegimeListNoRecord.test.js
@@ -14,7 +14,7 @@ test('Offline management regimes (plural) shows no info associated with project 
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/management-regimes/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -26,7 +26,7 @@ test('Offline management regimes (plural) shows no info associated with project 
 test('Online management regimes (plural) shows no info associated with project id view ', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/management-regimes/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/noInfoAssociatedWithId/App.ManagementRegimeNoRecord.test.js
+++ b/src/App/integrationTests/noInfoAssociatedWithId/App.ManagementRegimeNoRecord.test.js
@@ -14,7 +14,7 @@ test('Offline management regime shows no info associated with MANAGEMENT REGIME 
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/management-regimes/nonExistantMrId'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -26,7 +26,7 @@ test('Offline management regime shows no info associated with MANAGEMENT REGIME 
 test('Online management regime shows no info associated with MANAGEMENT REGIME id view ', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/management-regimes/nonExistantMrId'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -40,7 +40,7 @@ test('Offline management regime shows no info associated with PROJECT id view ',
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/management-regimes/1'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -52,7 +52,7 @@ test('Offline management regime shows no info associated with PROJECT id view ',
 test('Online management regime shows no info associated with PROJECT id view ', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/management-regimes/1'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -66,7 +66,7 @@ test('Offline management regime shows no info associated with PROJECT or MANAGEM
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/management-regimes/nonExistantMrId'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -82,7 +82,7 @@ test('Offline management regime shows no info associated with PROJECT or MANAGEM
 test('Online management regime shows no info associated with PROJECT or MANAGEMENT REGIME id view ', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/management-regimes/nonExistantMrId'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/noInfoAssociatedWithId/App.SitesListNoRecord.test.js
+++ b/src/App/integrationTests/noInfoAssociatedWithId/App.SitesListNoRecord.test.js
@@ -14,7 +14,7 @@ test('Offline sites list shows no info associated with projectId view ', async (
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/sites/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -26,7 +26,7 @@ test('Offline sites list shows no info associated with projectId view ', async (
 test('Online sites list shows no info associated with projectId view ', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/sites/'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/noInfoAssociatedWithId/App.SitesNoRecord.test.js
+++ b/src/App/integrationTests/noInfoAssociatedWithId/App.SitesNoRecord.test.js
@@ -14,7 +14,7 @@ test('Offline site shows no info associated with SITE id view ', async () => {
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/sites/nonExistantSiteId'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -26,7 +26,7 @@ test('Offline site shows no info associated with SITE id view ', async () => {
 test('Online site shows no info associated with SITE id view ', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/sites/nonExistantSiteId'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -40,7 +40,7 @@ test('Offline site shows no info associated with PROJECT id view ', async () => 
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/sites/1'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -52,7 +52,7 @@ test('Offline site shows no info associated with PROJECT id view ', async () => 
 test('Online site shows no info associated with PROJECT id view ', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/sites/1'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -66,7 +66,7 @@ test('Offline site shows no info associated with PROJECT or SITE id view ', asyn
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/sites/nonExistantSiteId'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -82,7 +82,7 @@ test('Offline site shows no info associated with PROJECT or SITE id view ', asyn
 test('Online site shows no info associated with PROJECT or SITE id view ', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/sites/nonExistantSiteId'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/noInfoAssociatedWithId/App.fishBeltNoRecord.test.js
+++ b/src/App/integrationTests/noInfoAssociatedWithId/App.fishBeltNoRecord.test.js
@@ -14,7 +14,7 @@ test('Offline fish belt collect shows no info associated with RECORD id view ', 
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/nonExistantRecordId'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -26,7 +26,7 @@ test('Offline fish belt collect shows no info associated with RECORD id view ', 
 test('Online fish belt collect shows no info associated with RECORD id view ', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/collecting/fishbelt/nonExistantRecordId'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -40,7 +40,7 @@ test('Offline fish belt collect shows no info associated with PROJECT id view ',
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/collecting/fishbelt/5'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -52,7 +52,7 @@ test('Offline fish belt collect shows no info associated with PROJECT id view ',
 test('Online fish belt collect shows no info associated with PROJECT id view ', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/nonExistantProjectId/collecting/fishbelt/5'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/site/App.siteEdit.test.js
+++ b/src/App/integrationTests/site/App.siteEdit.test.js
@@ -17,7 +17,7 @@ test('Offline: Edit Site shows toast and edited record info', async () => {
   // make sure there is a site to edit in dexie
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/sites/1'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -46,7 +46,7 @@ test('Offline: Edit Site shows toast and edited record info', async () => {
 test('Online: Edit Site shows toast and edited record info', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/sites/1'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -79,7 +79,7 @@ test('Offline: edit site save stored site in dexie', async () => {
   // make sure there is a site to edit in dexie
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/sites/1'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -122,7 +122,7 @@ test('Offline: Edit site  save failure shows toast message with new edits persis
   // make sure there is a site to edit in dexie
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/sites/1'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/sites/App.siteCreateOffline.test.js
+++ b/src/App/integrationTests/sites/App.siteCreateOffline.test.js
@@ -35,7 +35,7 @@ describe('offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/sites/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -81,7 +81,7 @@ describe('offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/sites/new'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -116,7 +116,7 @@ describe('offline', () => {
 
     await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/sites/new'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -155,7 +155,7 @@ describe('offline', () => {
 
     dexiePerUserDataInstance.project_sites.put = () => Promise.reject(dexieError)
 
-    renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOffline(<App />, {
       initialEntries: ['/projects/5/sites/new'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,

--- a/src/App/integrationTests/sites/App.siteCreateOnline.test.js
+++ b/src/App/integrationTests/sites/App.siteCreateOnline.test.js
@@ -40,7 +40,7 @@ describe('Online', () => {
   test('new site button navigates to new site form properly', async () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/sites/'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -84,7 +84,7 @@ describe('Online', () => {
   test('new site save success shows saved inputs, toast, and navigates to the edit site page for the newly created site', async () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/sites/new'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -117,7 +117,7 @@ describe('Online', () => {
   test('new site save success show new record in site table', async () => {
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/sites/new'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -157,7 +157,7 @@ describe('Online', () => {
     )
     const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-    renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    renderAuthenticatedOnline(<App />, {
       initialEntries: ['/projects/5/sites/new'],
       dexiePerUserDataInstance,
       dexieCurrentUserInstance,
@@ -203,7 +203,7 @@ test('New MR save will handle 500 push status codes with a generic message and s
   )
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOnline(<App />, {
     initialEntries: ['/projects/5/sites/new'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/unavailablePages/App.pageUnavailableOffline1.test.js
+++ b/src/App/integrationTests/unavailablePages/App.pageUnavailableOffline1.test.js
@@ -12,7 +12,7 @@ import App from '../../App'
 test('App renders show page unavailable offline when navigate to Project Health page while offline.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/observers-and-transects'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -24,7 +24,7 @@ test('App renders show page unavailable offline when navigate to Project Health 
 test('App renders show page unavailable offline when navigate to Submitted page while offline.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/submitted'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -35,7 +35,7 @@ test('App renders show page unavailable offline when navigate to Submitted page 
 test('App renders show page unavailable offline when navigate to Graphs and Maps page while offline.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/graphs-and-maps'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -47,7 +47,7 @@ test('App renders show page unavailable offline when navigate to Graphs and Maps
 test('App renders show page unavailable offline when navigate to Project Info page while offline.', async () => {
   const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/project-info'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/App/integrationTests/unavailablePages/App.pageUnavailableOffline2.test.js
+++ b/src/App/integrationTests/unavailablePages/App.pageUnavailableOffline2.test.js
@@ -15,7 +15,7 @@ test('App renders show page unavailable offline when navigate to Project Info pa
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/project-info'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -29,7 +29,7 @@ test('App renders show page unavailable offline when navigate to Users page whil
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/users'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -43,7 +43,7 @@ test('App renders show page unavailable offline when navigate to Fish Families p
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
-  renderAuthenticatedOffline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+  renderAuthenticatedOffline(<App />, {
     initialEntries: ['/projects/5/fish-families'],
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,
@@ -58,7 +58,7 @@ test('App renders show page unavailable offline when navigate to Data Sharing pa
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
 
   renderAuthenticatedOffline(
-    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    <App />,
     { initialEntries: ['/projects/5/data-sharing'] },
     dexiePerUserDataInstance,
     dexieCurrentUserInstance,

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,8 @@ import reportWebVitals from './reportWebVitals'
 import { App } from './App'
 import { OnlineStatusProvider } from './library/onlineStatusContext'
 import { SyncStatusProvider } from './App/mermaidData/syncApiDataIntoOfflineStorage/SyncStatusContext'
-import dexieCurrentUserInstance from './App/dexieCurrentUserInstance'
 import { DexiePerUserDataInstanceProvider } from './App/dexiePerUserDataInstanceContext'
+import { DexieCurrentUserInstanceProvider } from './App/dexieCurrentUserInstanceContext'
 
 ReactDOM.render(
   <React.StrictMode>
@@ -34,7 +34,9 @@ ReactDOM.render(
         <OnlineStatusProvider>
           <SyncStatusProvider>
             <DexiePerUserDataInstanceProvider>
-              <App dexieCurrentUserInstance={dexieCurrentUserInstance} />
+              <DexieCurrentUserInstanceProvider>
+                <App />
+              </DexieCurrentUserInstanceProvider>
             </DexiePerUserDataInstanceProvider>
           </SyncStatusProvider>
         </OnlineStatusProvider>

--- a/src/testUtilities/testingLibraryWithHelpers.js
+++ b/src/testUtilities/testingLibraryWithHelpers.js
@@ -20,6 +20,9 @@ import { getMockDexieInstancesAllSuccess } from './mockDexie'
 import { DexiePerUserDataInstanceProvider } from '../App/dexiePerUserDataInstanceContext'
 import { BellNotificationProvider } from '../App/BellNotificationContext'
 import mockMermaidData from './mockMermaidData'
+import { DexieCurrentUserInstanceProvider } from '../App/dexieCurrentUserInstanceContext'
+import { CustomToastContainer } from '../components/generic/toast'
+import handleHttpResponseError from '../library/handleHttpResponseError'
 
 const fakeCurrentUser = {
   id: 'fake-id',
@@ -40,9 +43,14 @@ const AuthenticatedProviders = ({ children, initialEntries, isSyncInProgressOver
   >
     <MemoryRouter initialEntries={initialEntries}>
       <ThemeProvider theme={theme}>
+        <CustomToastContainer limit={5} />
         <SyncStatusProvider value={isSyncInProgressOverride ? { isSyncInProgress: false } : {}}>
           <CurrentUserProvider value={{ currentUser: fakeCurrentUser }}>
-            <HttpResponseErrorHandlerProvider value={() => {}}>
+            <HttpResponseErrorHandlerProvider
+              value={({ error, callback }) =>
+                handleHttpResponseError({ error, callback, logoutMermaid: () => {} })
+              }
+            >
               <BellNotificationProvider
                 value={{
                   notifications: mockMermaidData.notifications,
@@ -69,9 +77,14 @@ const UnauthenticatedProviders = ({ children, initialEntries }) => (
   >
     <MemoryRouter initialEntries={initialEntries}>
       <ThemeProvider theme={theme}>
+        <CustomToastContainer limit={5} />
         <SyncStatusProvider>
           <CurrentUserProvider value={undefined}>
-            <HttpResponseErrorHandlerProvider value={() => {}}>
+            <HttpResponseErrorHandlerProvider
+              value={({ error, callback }) =>
+                handleHttpResponseError({ error, callback, logoutMermaid: () => {} })
+              }
+            >
               <BellNotificationProvider value={undefined}>{children}</BellNotificationProvider>
             </HttpResponseErrorHandlerProvider>
           </CurrentUserProvider>
@@ -99,12 +112,21 @@ UnauthenticatedProviders.defaultProps = {
 }
 const renderAuthenticated = (
   ui,
-  { renderOptions, initialEntries, dexiePerUserDataInstance, isSyncInProgressOverride } = {},
+  {
+    dexieCurrentUserInstance,
+    dexiePerUserDataInstance,
+    initialEntries,
+    isSyncInProgressOverride,
+    renderOptions,
+  } = {},
 ) => {
-  const { dexiePerUserDataInstance: defaultDexieUserDataDatabaseInstance } =
-    getMockDexieInstancesAllSuccess()
+  const {
+    dexiePerUserDataInstance: defaultDexieUserDataDatabaseInstance,
+    dexieCurrentUserInstance: defaultDexieCurrentUserInstance,
+  } = getMockDexieInstancesAllSuccess()
   const dexieUserDataDatabaseInstanceToUse =
     dexiePerUserDataInstance ?? defaultDexieUserDataDatabaseInstance
+  const dexieCurrentUserInstanceToUse = dexieCurrentUserInstance ?? defaultDexieCurrentUserInstance
   const wrapper = ({ children }) => {
     return (
       <AuthenticatedProviders
@@ -120,7 +142,9 @@ const renderAuthenticated = (
             <DexiePerUserDataInstanceProvider
               value={{ dexiePerUserDataInstance: dexieUserDataDatabaseInstanceToUse }}
             >
-              {children}
+              <DexieCurrentUserInstanceProvider value={dexieCurrentUserInstanceToUse}>
+                {children}
+              </DexieCurrentUserInstanceProvider>
             </DexiePerUserDataInstanceProvider>
           </OnlineStatusProvider>
         </DatabaseSwitchboardInstanceProvider>
@@ -136,12 +160,22 @@ const renderAuthenticated = (
 
 const renderAuthenticatedOnline = (
   ui,
-  { renderOptions, initialEntries, dexiePerUserDataInstance, isSyncInProgressOverride } = {},
+  {
+    dexieCurrentUserInstance,
+    dexiePerUserDataInstance,
+    initialEntries,
+    isSyncInProgressOverride,
+    renderOptions,
+  } = {},
 ) => {
-  const { dexiePerUserDataInstance: defaultDexieUserDataDatabaseInstance } =
-    getMockDexieInstancesAllSuccess()
+  const {
+    dexiePerUserDataInstance: defaultDexieUserDataDatabaseInstance,
+    dexieCurrentUserInstance: defaultDexieCurrentUserInstance,
+  } = getMockDexieInstancesAllSuccess()
   const dexieUserDataDatabaseInstanceToUse =
     dexiePerUserDataInstance ?? defaultDexieUserDataDatabaseInstance
+  const dexieCurrentUserInstanceToUse = dexieCurrentUserInstance ?? defaultDexieCurrentUserInstance
+
   const wrapper = ({ children }) => {
     return (
       <AuthenticatedProviders
@@ -157,7 +191,9 @@ const renderAuthenticatedOnline = (
             <DexiePerUserDataInstanceProvider
               value={{ dexiePerUserDataInstance: dexieUserDataDatabaseInstanceToUse }}
             >
-              {children}
+              <DexieCurrentUserInstanceProvider value={dexieCurrentUserInstanceToUse}>
+                {children}
+              </DexieCurrentUserInstanceProvider>
             </DexiePerUserDataInstanceProvider>
           </OnlineStatusProvider>
         </DatabaseSwitchboardInstanceProvider>
@@ -173,12 +209,16 @@ const renderAuthenticatedOnline = (
 
 const renderUnauthenticatedOnline = (
   ui,
-  { renderOptions, initialEntries, dexiePerUserDataInstance } = {},
+  { renderOptions, initialEntries, dexiePerUserDataInstance, dexieCurrentUserInstance } = {},
 ) => {
-  const { dexiePerUserDataInstance: defaultDexieUserDataDatabaseInstance } =
-    getMockDexieInstancesAllSuccess()
+  const {
+    dexiePerUserDataInstance: defaultDexieUserDataDatabaseInstance,
+    dexieCurrentUserInstance: defaultDexieCurrentUserInstance,
+  } = getMockDexieInstancesAllSuccess()
   const dexieUserDataDatabaseInstanceToUse =
     dexiePerUserDataInstance ?? defaultDexieUserDataDatabaseInstance
+  const dexieCurrentUserInstanceToUse = dexieCurrentUserInstance ?? defaultDexieCurrentUserInstance
+
   const wrapper = ({ children }) => {
     return (
       <UnauthenticatedProviders initialEntries={initialEntries}>
@@ -186,7 +226,9 @@ const renderUnauthenticatedOnline = (
           <DexiePerUserDataInstanceProvider
             value={{ dexiePerUserDataInstance: dexieUserDataDatabaseInstanceToUse }}
           >
-            {children}
+            <DexieCurrentUserInstanceProvider value={dexieCurrentUserInstanceToUse}>
+              {children}
+            </DexieCurrentUserInstanceProvider>
           </DexiePerUserDataInstanceProvider>
         </OnlineStatusProvider>
       </UnauthenticatedProviders>
@@ -198,12 +240,22 @@ const renderUnauthenticatedOnline = (
 
 const renderAuthenticatedOffline = (
   ui,
-  { renderOptions, initialEntries, dexiePerUserDataInstance, isSyncInProgressOverride } = {},
+  {
+    renderOptions,
+    initialEntries,
+    dexiePerUserDataInstance,
+    isSyncInProgressOverride,
+    dexieCurrentUserInstance,
+  } = {},
 ) => {
-  const { dexiePerUserDataInstance: defaultDexieUserDataDatabaseInstance } =
-    getMockDexieInstancesAllSuccess()
+  const {
+    dexiePerUserDataInstance: defaultDexieUserDataDatabaseInstance,
+    dexieCurrentUserInstance: defaultDexieCurrentUserInstance,
+  } = getMockDexieInstancesAllSuccess()
   const dexieUserDataDatabaseInstanceToUse =
     dexiePerUserDataInstance ?? defaultDexieUserDataDatabaseInstance
+  const dexieCurrentUserInstanceToUse = dexieCurrentUserInstance ?? defaultDexieCurrentUserInstance
+
   const wrapper = ({ children }) => {
     return (
       <AuthenticatedProviders
@@ -219,7 +271,9 @@ const renderAuthenticatedOffline = (
             <DexiePerUserDataInstanceProvider
               value={{ dexiePerUserDataInstance: dexieUserDataDatabaseInstanceToUse }}
             >
-              {children}
+              <DexieCurrentUserInstanceProvider value={dexieCurrentUserInstanceToUse}>
+                {children}
+              </DexieCurrentUserInstanceProvider>
             </DexiePerUserDataInstanceProvider>
           </OnlineStatusProvider>
         </DatabaseSwitchboardInstanceProvider>
@@ -235,12 +289,15 @@ const renderAuthenticatedOffline = (
 
 const renderUnauthenticatedOffline = (
   ui,
-  { renderOptions, initialEntries, dexiePerUserDataInstance } = {},
+  { renderOptions, initialEntries, dexiePerUserDataInstance, dexieCurrentUserInstance } = {},
 ) => {
-  const { dexiePerUserDataInstance: defaultDexieUserDataDatabaseInstance } =
-    getMockDexieInstancesAllSuccess()
+  const {
+    dexiePerUserDataInstance: defaultDexieUserDataDatabaseInstance,
+    dexieCurrentUserInstance: defaultDexieCurrentUserInstance,
+  } = getMockDexieInstancesAllSuccess()
   const dexieUserDataDatabaseInstanceToUse =
     dexiePerUserDataInstance ?? defaultDexieUserDataDatabaseInstance
+  const dexieCurrentUserInstanceToUse = dexieCurrentUserInstance ?? defaultDexieCurrentUserInstance
   const wrapper = ({ children }) => {
     return (
       <UnauthenticatedProviders initialEntries={initialEntries}>
@@ -248,7 +305,9 @@ const renderUnauthenticatedOffline = (
           <DexiePerUserDataInstanceProvider
             value={{ dexiePerUserDataInstance: dexieUserDataDatabaseInstanceToUse }}
           >
-            {children}
+            <DexieCurrentUserInstanceProvider value={dexieCurrentUserInstanceToUse}>
+              {children}
+            </DexieCurrentUserInstanceProvider>
           </DexiePerUserDataInstanceProvider>
         </OnlineStatusProvider>
       </UnauthenticatedProviders>


### PR DESCRIPTION
Ticket: https://trello.com/c/tgDctEzq/968-research-making-tests-faster-timebox-4-hours

This change involves two steps. 
The first is changing how state is fed into the app to allow easier mocking and rendering of isolated component free of them being wrapped in the app state (which is mocked by test renderer functions instead)
The second involves selecting a sample of integration tests and replacing them rendering the whole app, and rendering the page component instead in an attempt to speed up the test suite

Results running the sample tests all together:
This branch:         
11.6 seconds average
Develop:
21.7 seconds average


Thats almost twice as fast!

However the tradeoffs are that we are relying more on mocks to make tests run. This isnt great ideally, but its better to have tests that are twice as fast which makes them more useful and also able to run in CI.

Another tradeoff that is more meaningful IMO is that writing tests this new way and relying on the render mocks more makes the test suite even more complicated to understand and maintain. Check out some of the new tests and let me know what you think. Maybe its the same complexity/confusingness? 

Note: I have broken some of the untouched tests with this change, but am pushing this PR for conversation purposes. If you want to run the sample tests use `yarn test src/App/integrationTests/collectRecords/habitatComplexity/App.updateHabitatComplexity.test.js src/App/integrationTests/collectRecords/habitatComplexity/App.validationDisplay1HabitatComplexity.test.js src/App/integrationTests/collectRecords/habitatComplexity/App.validationDisplay2HabitatComplexity.test.js src/App/integrationTests/collectRecords/habitatComplexity/App.validationIgnoring1HabitatComplexity.test.js src/App/integrationTests/collectRecords/habitatComplexity/App.validationIgnoring2HabitatComplexity.test.js `

