### PR TITLE
fix: M971 misleading site save messaging when offline

### DIFF
--- a/src/App/integrationTests/managementRegime/App.managementRegimeCreateOffline.test.js
+++ b/src/App/integrationTests/managementRegime/App.managementRegimeCreateOffline.test.js
@@ -87,11 +87,7 @@ describe('Offline', () => {
 
     await saveMR()
 
-    expect(
-      await screen.findByText(
-        'The management regime has been saved on your computer and in the MERMAID online system.',
-      ),
-    )
+    expect(await screen.findByText('The management regime has been saved on your computer.'))
 
     // ensure the new form is now the edit form
     expect(await screen.findByTestId('edit-management-regime-form-title'))
@@ -119,11 +115,7 @@ describe('Offline', () => {
 
     await saveMR()
 
-    expect(
-      await screen.findByText(
-        'The management regime has been saved on your computer and in the MERMAID online system.',
-      ),
-    )
+    expect(await screen.findByText('The management regime has been saved on your computer.'))
 
     const sideNav = await screen.findByTestId('content-page-side-nav')
 

--- a/src/App/integrationTests/site/App.siteEdit.test.js
+++ b/src/App/integrationTests/site/App.siteEdit.test.js
@@ -34,11 +34,7 @@ test('Offline: Edit Site shows toast and edited record info', async () => {
     }),
   )
 
-  expect(
-    await screen.findByText(
-      'The site has been saved on your computer and in the MERMAID online system.',
-    ),
-  )
+  expect(await screen.findByText('The site has been saved on your computer.'))
 
   expect(siteNameInput).toHaveValue('OOF')
 })
@@ -96,11 +92,7 @@ test('Offline: edit site save stored site in dexie', async () => {
     }),
   )
 
-  expect(
-    await screen.findByText(
-      'The site has been saved on your computer and in the MERMAID online system.',
-    ),
-  )
+  expect(await screen.findByText('The site has been saved on your computer.'))
 
   const savedSites = await dexiePerUserDataInstance.project_sites.toArray()
 

--- a/src/App/integrationTests/sites/App.siteCreateOffline.test.js
+++ b/src/App/integrationTests/sites/App.siteCreateOffline.test.js
@@ -89,11 +89,7 @@ describe('offline', () => {
 
     await saveSite()
 
-    expect(
-      await screen.findByText(
-        'The site has been saved on your computer and in the MERMAID online system.',
-      ),
-    )
+    expect(await screen.findByText('The site has been saved on your computer.'))
 
     // ensure the new form is now the edit form
     expect(
@@ -124,11 +120,7 @@ describe('offline', () => {
 
     await saveSite()
 
-    expect(
-      await screen.findByText(
-        'The site has been saved on your computer and in the MERMAID online system.',
-      ),
-    )
+    expect(await screen.findByText('The site has been saved on your computer.'))
 
     const sideNav = await screen.findByTestId('content-page-side-nav')
 

--- a/src/components/pages/ManagementRegime/ManagementRegime.js
+++ b/src/components/pages/ManagementRegime/ManagementRegime.js
@@ -324,7 +324,12 @@ const ManagementRegime = ({ isNewManagementRegime }) => {
       databaseSwitchboardInstance
         .saveManagementRegime({ managementRegime: formattedManagementRegimeForApi, projectId })
         .then((response) => {
-          toast.success(language.success.getMermaidDataSaveSuccess('management regime'))
+          toast.success(
+            language.success.getMermaidDataSaveSuccess({
+              mermaidDataTypeLabel: 'management regime',
+              isAppOnline,
+            }),
+          )
           clearPersistedUnsavedFormikData()
           setSaveButtonState(buttonGroupStates.saved)
           setIsFormDirty(false)

--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -326,7 +326,14 @@ const Site = ({ isNewSite }) => {
       databaseSwitchboardInstance
         .saveSite({ site: formattedSiteForApi, projectId })
         .then((response) => {
-          toast.success(...getToastArguments(language.success.getMermaidDataSaveSuccess('site')))
+          toast.success(
+            ...getToastArguments(
+              language.success.getMermaidDataSaveSuccess({
+                mermaidDataTypeLabel: 'site',
+                isAppOnline,
+              }),
+            ),
+          )
           clearPersistedUnsavedFormikData()
           setSaveButtonState(buttonGroupStates.saved)
           setIsFormDirty(false)

--- a/src/language.js
+++ b/src/language.js
@@ -127,8 +127,10 @@ const success = {
   projectSave: 'Project saved',
   projectCopied: 'Project copied',
   projectCreated: 'Project created',
-  getMermaidDataSaveSuccess: (mermaidDataTypeLabel) =>
-    `The ${mermaidDataTypeLabel} has been saved on your computer and in the MERMAID online system.`,
+  getMermaidDataSaveSuccess: ({ mermaidDataTypeLabel, isAppOnline }) =>
+    isAppOnline
+      ? `The ${mermaidDataTypeLabel} has been saved on your computer and in the MERMAID online system.`
+      : `The ${mermaidDataTypeLabel} has been saved on your computer.`,
   getMermaidDataDeleteSuccess: (mermaidDataTypeLabel) =>
     `The ${mermaidDataTypeLabel} has been deleted from your computer and the MERMAID online system.`,
 


### PR DESCRIPTION
Steps to test:
- create a new site while offline. 
- click save

Expected results
- a toast with "The site has been saved on your computer." shows

Do the same when online: Expect the toast to say "The site has been saved on your computer and in the MERMAID online system."

Repeat (online and off) for saving an MR