### PR TITLE
fix: 963 added trailing slash to project summary endpoint to avoid 301 responses

### DIFF
--- a/src/App/mermaidData/databaseSwitchboard/ProjectHealthMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/ProjectHealthMixin.js
@@ -436,7 +436,7 @@ const ProjectHealthMixin = (Base) =>
       return this._isOnlineAuthenticatedAndReady
         ? axios
             .get(
-              `${this._apiBaseUrl}/projects/${projectId}/summary`,
+              `${this._apiBaseUrl}/projects/${projectId}/summary/`,
               await getAuthorizationHeaders(this._getAccessToken),
             )
             .then((apiResults) => apiResults.data)

--- a/src/testUtilities/mockMermaidApiAllSuccessful.js
+++ b/src/testUtilities/mockMermaidApiAllSuccessful.js
@@ -87,7 +87,7 @@ const mockMermaidApiAllSuccessful = setupServer(
   rest.post(`${apiBaseUrl}/projects/5/collectrecords/submit/`, (req, res, ctx) => {
     return res(ctx.status(200))
   }),
-  rest.get(`${apiBaseUrl}/projects/5/summary`, (req, res, ctx) => {
+  rest.get(`${apiBaseUrl}/projects/5/summary/`, (req, res, ctx) => {
     return res(ctx.status(200))
   }),
   rest.get(`${apiBaseUrl}/sites/`, (req, res, ctx) => {


### PR DESCRIPTION
Id save testing for @alanjleonard 

 (I couldnt reproduce this on the newly downloaded FF dev edition. Perhaps they fixed the bug? I added the trailing slach as @saanobhaai mentioned in the ticket regardless)

See ticket for more info if you want: https://trello.com/c/gbfLStlT/963-send-token-with-redirected-requests