### PR TITLE
fix: 975 include project name on project info page

### DIFF
--- a/src/components/pages/ProjectInfo/ProjectInfo.js
+++ b/src/components/pages/ProjectInfo/ProjectInfo.js
@@ -150,17 +150,6 @@ const OrganizationList = ({ organizations, handleOrganizationsChange }) => {
   )
 }
 
-const ReadOnlyAdminContent = ({ project }) => (
-  <ReadOnlyContentWrapper>
-    <H3>Notes</H3>
-    <P>{project.notes.length ? project.notes : 'no notes for this project'}</P>
-    <H3>Organizations</H3>
-    {project.tags.map((org) => (
-      <li key={org}>{org}</li>
-    ))}
-  </ReadOnlyContentWrapper>
-)
-
 const ProjectInfo = () => {
   const [idsNotAssociatedWithData, setIdsNotAssociatedWithData] = useState([])
   const [isLoading, setIsLoading] = useState(true)
@@ -296,7 +285,7 @@ const ProjectInfo = () => {
     return errorMessage
   }
 
-  const contentViewByRole = isAdminUser ? (
+  const adminContent = (
     <form id="project-info-form" onSubmit={formik.handleSubmit}>
       <InputWrapper>
         <InputWithLabelAndValidation
@@ -358,9 +347,22 @@ const ProjectInfo = () => {
         }}
       />
     </form>
-  ) : (
-    <ReadOnlyAdminContent project={formik.values} />
   )
+
+  const { name, notes, tags } = formik.values
+  const readOnlyContent = (
+    <ReadOnlyContentWrapper>
+      <H2>{name}</H2>
+      <H3>Notes</H3>
+      <P>{notes.length ? notes : language.pages.projectInfo.noNotes}</P>
+      <H3>Organizations</H3>
+      {tags.map((org) => (
+        <li key={org}>{org}</li>
+      ))}
+    </ReadOnlyContentWrapper>
+  )
+
+  const contentViewByRole = isAdminUser ? adminContent : readOnlyContent
 
   return idsNotAssociatedWithData.length ? (
     <ContentPageLayout
@@ -402,13 +404,6 @@ const ProjectInfo = () => {
 OrganizationList.propTypes = {
   organizations: PropTypes.arrayOf(PropTypes.string).isRequired,
   handleOrganizationsChange: PropTypes.func.isRequired,
-}
-
-ReadOnlyAdminContent.propTypes = {
-  project: PropTypes.shape({
-    notes: PropTypes.string,
-    tags: PropTypes.arrayOf(PropTypes.string),
-  }).isRequired,
 }
 
 export default ProjectInfo

--- a/src/language.js
+++ b/src/language.js
@@ -238,13 +238,14 @@ const pages = {
     newBenthicAttributeLink: 'Propose New Benthic Attribute...',
   },
   projectInfo: {
-    title: 'Project Info',
-    newOrganizationNameLink: 'Suggest a new organization to MERMAID...',
     createOrganizationTitle: 'Suggest a new organization',
-    suggestionOrganizationHelperText: `If your organization is approved, it'll be automatically added to your project.`,
-    organizationsHelperText: `Type to search for an organization.`,
+    newOrganizationNameLink: 'Suggest a new organization to MERMAID...',
+    noNotes: 'no notes for this project',
     noOrganizationFound: `No organization found.`,
+    organizationsHelperText: `Type to search for an organization.`,
     removeOrganization: `Remove organization from project`,
+    suggestionOrganizationHelperText: `If your organization is approved, it'll be automatically added to your project.`,
+    title: 'Project Info',
   },
   dataSharing: {
     title: 'Data Sharing',


### PR DESCRIPTION
to test: 
- sign in as a read only user for a project (you may need to create read-only or collector new user for yourself at an email alias eg `julia+test1@sparkgeo.com`)
- navigate to project info page
- expect that there is a project name included in the project info