### PR TITLE
fix: 975 data sharing page. Added missing info for read only mode.

### DIFF
--- a/src/components/pages/DataSharing/DataSharing.js
+++ b/src/components/pages/DataSharing/DataSharing.js
@@ -27,6 +27,7 @@ import useDocumentTitle from '../../../library/useDocumentTitle'
 import useIsMounted from '../../../library/useIsMounted'
 import { useCurrentUser } from '../../../App/CurrentUserContext'
 import { getIsAdminUserRole } from '../../../App/currentUserProfileHelpers'
+import { PROJECT_CODES } from '../../../library/constants/constants'
 
 const DataSharingTable = styled(Table)`
   td {
@@ -163,7 +164,7 @@ const DataSharing = () => {
 
   const handleTestProjectChange = (event) => {
     const isChecked = event.target.checked
-    const status = isChecked ? language.projectCodes.status.test : language.projectCodes.status.open
+    const status = isChecked ? PROJECT_CODES.status.test : PROJECT_CODES.status.open
     const editedValues = { ...projectBeingEdited, status }
 
     handleSaveProject(editedValues, language.success.projectStatusSaved)
@@ -172,6 +173,7 @@ const DataSharing = () => {
   const findToolTipDescription = (policy) =>
     dataPolicyOptions.find(({ label }) => label === policy)?.description || ''
 
+  const isTestProject = projectBeingEdited?.status === PROJECT_CODES.status.test
   const contentViewByRole = (
     <MaxWidthInputWrapper>
       <h3>Data is much more powerful when shared.</h3>
@@ -266,20 +268,21 @@ const DataSharing = () => {
       ) : (
         <ReadOnlyDataSharingContent project={projectBeingEdited} />
       )}
-      {isAdminUser && (
+      {isAdminUser ? (
         <>
           <CheckBoxLabel>
             <input
               id="test-project-toggle"
               type="checkbox"
-              checked={projectBeingEdited?.status === language.projectCodes.status.test}
+              checked={isTestProject}
               onChange={handleTestProjectChange}
             />{' '}
-            This is a test project
+            {language.pages.dataSharing.isTestProject}
           </CheckBoxLabel>
           <P>{language.pages.dataSharing.testProjectHelperText}</P>
         </>
-      )}
+      ) : null}
+      {!isAdminUser && isTestProject ? <p>{language.pages.dataSharing.isTestProject}</p> : null}
       <DataSharingInfoModal
         isOpen={issDataSharingInfoModalOpen}
         onDismiss={closeDataSharingInfoModal}

--- a/src/language.js
+++ b/src/language.js
@@ -1,10 +1,10 @@
 // prettier-ignore
-import { getSystemValidationErrorMessage, getDuplicateSampleUnitLink, goToManagementOverviewPageLink } from './library/validationMessageHelpers'
-
-const projectCodes = {
-  status: { open: 90, test: 80 },
-  policy: { private: 10, publicSummary: 50 },
-}
+import { PROJECT_CODES } from './library/constants/constants'
+import {
+  getSystemValidationErrorMessage,
+  getDuplicateSampleUnitLink,
+  goToManagementOverviewPageLink,
+} from './library/validationMessageHelpers'
 
 const inlineMessage = {
   ignore: 'ignored',
@@ -138,9 +138,9 @@ const success = {
   projectStatusSaved: `Test project selection saved.`,
   getDataSharingPolicyChangeSuccess: (method, policy_code) => {
     switch (policy_code) {
-      case projectCodes.policy.private:
+      case PROJECT_CODES.policy.private:
         return `${method} is now set to private`
-      case projectCodes.policy.publicSummary:
+      case PROJECT_CODES.policy.publicSummary:
         return `${method} is now set to public summary`
       default:
         // policy code for public is 100
@@ -247,10 +247,11 @@ const pages = {
     removeOrganization: `Remove organization from project`,
   },
   dataSharing: {
-    title: 'Data Sharing',
     introductionParagraph: `Given the urgent need for global coral reef conservation, MERMAID is committed to working collectively as a community and using the power of data to help make faster, better decisions. Coral reef monitoring data is collected with the intent of advancing coral reef science and improving management. We recognize the large effort to collect data and your sense of ownership. While not required, we hope you choose to make your data available to fuel new discoveries and inform conservation solutions.`,
-    testProjectHelperText: 'Data for a test project will not be included in public reporting.',
+    isTestProject: 'This is a test project',
     moreInfoTitle: 'Data sharing',
+    testProjectHelperText: 'Data for a test project will not be included in public reporting.',
+    title: 'Data Sharing',
   },
   submittedTable: {
     title: 'Submitted',
@@ -463,7 +464,6 @@ export default {
   popoverTexts,
   navigateAwayPrompt,
   pages,
-  projectCodes,
   projectModal,
   protocolTitles,
   success,

--- a/src/library/constants/constants.js
+++ b/src/library/constants/constants.js
@@ -1,2 +1,8 @@
 export const PAGE_SIZE_DEFAULT = 15
 export const API_NULL_NAME = '__null__'
+export const PROJECT_CODES = {
+  status: { open: 90, test: 80 },
+  policy: { private: 10, publicSummary: 50 },
+}
+
+Object.freeze(PROJECT_CODES)


### PR DESCRIPTION
To test:

- Login to a project that you are admin on
- Go to the data sharing page, toggle the 'this is a test project' checkmark to be checked
- log out, 
- log back in as a user that is read only or collector
- view the data sharing page

Expected results: 
- you should see some text that says 'This is a test project' with no checkbox input (because we are read only now)


Other test:
- log back in as admin
- go to datasharing page
- toggle the 'This is a test project' checkbox to be unchecked
- log out and back in as a read only or collector
- view the data sharing page

Expected results: 
- you should NOT see text that says 'This is a test project' (and there should also be no checkbox for it)

