### PR TITLE
[813] Data sharing & Users: disable controls after click

### DIFF
--- a/src/components/generic/Table/table.js
+++ b/src/components/generic/Table/table.js
@@ -267,6 +267,7 @@ export const GenericStickyTable = styled(Table)`
   tr th {
     ${stickyStyles}
   }
+  cursor: ${(props) => props.cursor || 'pointer'};
 `
 export const GenericStickyTableTextWrapTh = styled(GenericStickyTable)`
   tr th {

--- a/src/components/generic/form.js
+++ b/src/components/generic/form.js
@@ -52,6 +52,7 @@ export const InputWrapper = styled.div`
 `
 export const MaxWidthInputWrapper = styled(InputWrapper)`
   max-width: ${theme.spacing.maxWidth};
+  cursor: ${(props) => props.cursor || 'pointer'};
 `
 export const HelperText = styled.span`
   font-size: ${theme.typography.smallFontSize};

--- a/src/components/pages/DataSharing/DataSharing.js
+++ b/src/components/pages/DataSharing/DataSharing.js
@@ -33,6 +33,7 @@ const DataSharingTable = styled(Table)`
     position: relative;
     label {
       position: absolute;
+      cursor: ${(props) => props.cursor || 'pointer'};
       top: 0;
       left: 0;
       display: grid;
@@ -75,6 +76,7 @@ const DataSharing = () => {
   const { currentUser } = useCurrentUser()
   const isMounted = useIsMounted()
   const isAdminUser = getIsAdminUserRole(currentUser, projectId)
+  const [isPolicyUpdating, setIsPolicyUpdating] = useState(false)
 
   useDocumentTitle(`${language.pages.dataSharing.title} - ${language.title.mermaid}`)
 
@@ -137,6 +139,7 @@ const DataSharing = () => {
         .then((updatedProject) => {
           setProjectBeingEdited(updatedProject)
           toast.success(...getToastArguments(toastMessage))
+          setIsPolicyUpdating(false)
         })
         .catch(() => {
           toast.error(...getToastArguments(language.error.projectSave))
@@ -149,6 +152,8 @@ const DataSharing = () => {
     const policyCode = parseInt(event.target.value, 10)
     const editedValues = { ...projectBeingEdited }
     const toastMessage = getToastMessageForDataPolicyChange(propertyToUpdate, policyCode)
+
+    setIsPolicyUpdating(true)
 
     if (propertyToUpdate === 'data_policy_benthiclit') {
       editedValues.data_policy_benthiclit = policyCode
@@ -181,7 +186,7 @@ const DataSharing = () => {
       </ButtonPrimary>
       {isAdminUser ? (
         <TableOverflowWrapper>
-          <DataSharingTable>
+          <DataSharingTable cursor={isPolicyUpdating ? 'wait' : 'pointer'}>
             <thead>
               <Tr>
                 <Th>&nbsp;</Th>
@@ -221,6 +226,7 @@ const DataSharing = () => {
                         id={`fish-belt${item.value}`}
                         checked={projectBeingEdited?.data_policy_beltfish === item.value}
                         onChange={(e) => handleDataPolicyChange(e, 'data_policy_beltfish')}
+                        disabled={isPolicyUpdating}
                       />
                     </label>
                   </Td>
@@ -238,6 +244,7 @@ const DataSharing = () => {
                         id={`benthic${item.value}`}
                         checked={projectBeingEdited?.data_policy_benthiclit === item.value}
                         onChange={(e) => handleDataPolicyChange(e, 'data_policy_benthiclit')}
+                        disabled={isPolicyUpdating}
                       />
                     </label>
                   </Td>
@@ -255,6 +262,7 @@ const DataSharing = () => {
                         value={item.value}
                         checked={projectBeingEdited?.data_policy_bleachingqc === item.value}
                         onChange={(e) => handleDataPolicyChange(e, 'data_policy_bleachingqc')}
+                        disabled={isPolicyUpdating}
                       />
                     </label>
                   </Td>

--- a/src/components/pages/DataSharing/DataSharing.js
+++ b/src/components/pages/DataSharing/DataSharing.js
@@ -33,7 +33,6 @@ const DataSharingTable = styled(Table)`
     position: relative;
     label {
       position: absolute;
-      cursor: ${(props) => props.cursor || 'pointer'};
       top: 0;
       left: 0;
       display: grid;
@@ -50,7 +49,6 @@ const CheckBoxLabel = styled.label`
   display: inline-block;
   input {
     margin: 0 ${theme.spacing.xsmall} 0 0;
-    cursor: ${(props) => props.cursor || 'pointer'};
   }
 `
 
@@ -76,8 +74,7 @@ const DataSharing = () => {
   const { currentUser } = useCurrentUser()
   const isMounted = useIsMounted()
   const isAdminUser = getIsAdminUserRole(currentUser, projectId)
-  const [isTableUpdating, setIsTableUpdating] = useState(false)
-  const [isTestProjectUpdating, setIsTestProjectUpdating] = useState(false)
+  const [isDataUpdating, setIsDataUpdating] = useState(false)
 
   useDocumentTitle(`${language.pages.dataSharing.title} - ${language.title.mermaid}`)
 
@@ -138,10 +135,9 @@ const DataSharing = () => {
           editedValues,
         })
         .then((updatedProject) => {
-          setIsTestProjectUpdating(false)
+          setIsDataUpdating(false)
           setProjectBeingEdited(updatedProject)
           toast.success(...getToastArguments(toastMessage))
-          setIsTableUpdating(false)
         })
         .catch(() => {
           toast.error(...getToastArguments(language.error.projectSave))
@@ -155,7 +151,7 @@ const DataSharing = () => {
     const editedValues = { ...projectBeingEdited }
     const toastMessage = getToastMessageForDataPolicyChange(propertyToUpdate, policyCode)
 
-    setIsTableUpdating(true)
+    setIsDataUpdating(true)
 
     if (propertyToUpdate === 'data_policy_benthiclit') {
       editedValues.data_policy_benthiclit = policyCode
@@ -169,7 +165,7 @@ const DataSharing = () => {
   }
 
   const handleTestProjectChange = (event) => {
-    setIsTestProjectUpdating(true)
+    setIsDataUpdating(true)
     const isChecked = event.target.checked
     const status = isChecked ? language.projectCodes.status.test : language.projectCodes.status.open
     const editedValues = { ...projectBeingEdited, status }
@@ -181,7 +177,7 @@ const DataSharing = () => {
     dataPolicyOptions.find(({ label }) => label === policy)?.description || ''
 
   const contentViewByRole = (
-    <MaxWidthInputWrapper>
+    <MaxWidthInputWrapper cursor={isDataUpdating ? 'wait' : 'pointer'}>
       <h3>Data is much more powerful when shared.</h3>
       <P>{language.pages.dataSharing.introductionParagraph}</P>
       <ButtonPrimary type="button" onClick={openDataSharingInfoModal}>
@@ -189,7 +185,7 @@ const DataSharing = () => {
       </ButtonPrimary>
       {isAdminUser ? (
         <TableOverflowWrapper>
-          <DataSharingTable cursor={isTableUpdating ? 'wait' : 'pointer'}>
+          <DataSharingTable>
             <thead>
               <Tr>
                 <Th>&nbsp;</Th>
@@ -229,7 +225,7 @@ const DataSharing = () => {
                         id={`fish-belt${item.value}`}
                         checked={projectBeingEdited?.data_policy_beltfish === item.value}
                         onChange={(e) => handleDataPolicyChange(e, 'data_policy_beltfish')}
-                        disabled={isTableUpdating}
+                        disabled={isDataUpdating}
                       />
                     </label>
                   </Td>
@@ -247,7 +243,7 @@ const DataSharing = () => {
                         id={`benthic${item.value}`}
                         checked={projectBeingEdited?.data_policy_benthiclit === item.value}
                         onChange={(e) => handleDataPolicyChange(e, 'data_policy_benthiclit')}
-                        disabled={isTableUpdating}
+                        disabled={isDataUpdating}
                       />
                     </label>
                   </Td>
@@ -265,7 +261,7 @@ const DataSharing = () => {
                         value={item.value}
                         checked={projectBeingEdited?.data_policy_bleachingqc === item.value}
                         onChange={(e) => handleDataPolicyChange(e, 'data_policy_bleachingqc')}
-                        disabled={isTableUpdating}
+                        disabled={isDataUpdating}
                       />
                     </label>
                   </Td>
@@ -279,13 +275,13 @@ const DataSharing = () => {
       )}
       {isAdminUser && (
         <>
-          <CheckBoxLabel cursor={isTestProjectUpdating ? 'wait' : 'pointer'}>
+          <CheckBoxLabel>
             <input
               id="test-project-toggle"
               type="checkbox"
               checked={projectBeingEdited?.status === language.projectCodes.status.test}
               onChange={handleTestProjectChange}
-              disabled={isTestProjectUpdating}
+              disabled={isDataUpdating}
             />{' '}
             This is a test project
           </CheckBoxLabel>

--- a/src/components/pages/DataSharing/DataSharing.js
+++ b/src/components/pages/DataSharing/DataSharing.js
@@ -76,7 +76,7 @@ const DataSharing = () => {
   const { currentUser } = useCurrentUser()
   const isMounted = useIsMounted()
   const isAdminUser = getIsAdminUserRole(currentUser, projectId)
-  const [isPolicyUpdating, setIsPolicyUpdating] = useState(false)
+  const [isTableUpdating, setIsTableUpdating] = useState(false)
 
   useDocumentTitle(`${language.pages.dataSharing.title} - ${language.title.mermaid}`)
 
@@ -139,7 +139,7 @@ const DataSharing = () => {
         .then((updatedProject) => {
           setProjectBeingEdited(updatedProject)
           toast.success(...getToastArguments(toastMessage))
-          setIsPolicyUpdating(false)
+          setIsTableUpdating(false)
         })
         .catch(() => {
           toast.error(...getToastArguments(language.error.projectSave))
@@ -153,7 +153,7 @@ const DataSharing = () => {
     const editedValues = { ...projectBeingEdited }
     const toastMessage = getToastMessageForDataPolicyChange(propertyToUpdate, policyCode)
 
-    setIsPolicyUpdating(true)
+    setIsTableUpdating(true)
 
     if (propertyToUpdate === 'data_policy_benthiclit') {
       editedValues.data_policy_benthiclit = policyCode
@@ -186,7 +186,7 @@ const DataSharing = () => {
       </ButtonPrimary>
       {isAdminUser ? (
         <TableOverflowWrapper>
-          <DataSharingTable cursor={isPolicyUpdating ? 'wait' : 'pointer'}>
+          <DataSharingTable cursor={isTableUpdating ? 'wait' : 'pointer'}>
             <thead>
               <Tr>
                 <Th>&nbsp;</Th>
@@ -226,7 +226,7 @@ const DataSharing = () => {
                         id={`fish-belt${item.value}`}
                         checked={projectBeingEdited?.data_policy_beltfish === item.value}
                         onChange={(e) => handleDataPolicyChange(e, 'data_policy_beltfish')}
-                        disabled={isPolicyUpdating}
+                        disabled={isTableUpdating}
                       />
                     </label>
                   </Td>
@@ -244,7 +244,7 @@ const DataSharing = () => {
                         id={`benthic${item.value}`}
                         checked={projectBeingEdited?.data_policy_benthiclit === item.value}
                         onChange={(e) => handleDataPolicyChange(e, 'data_policy_benthiclit')}
-                        disabled={isPolicyUpdating}
+                        disabled={isTableUpdating}
                       />
                     </label>
                   </Td>
@@ -262,7 +262,7 @@ const DataSharing = () => {
                         value={item.value}
                         checked={projectBeingEdited?.data_policy_bleachingqc === item.value}
                         onChange={(e) => handleDataPolicyChange(e, 'data_policy_bleachingqc')}
-                        disabled={isPolicyUpdating}
+                        disabled={isTableUpdating}
                       />
                     </label>
                   </Td>

--- a/src/components/pages/DataSharing/DataSharing.js
+++ b/src/components/pages/DataSharing/DataSharing.js
@@ -50,7 +50,7 @@ const CheckBoxLabel = styled.label`
   display: inline-block;
   input {
     margin: 0 ${theme.spacing.xsmall} 0 0;
-    cursor: pointer;
+    cursor: ${(props) => props.cursor || 'pointer'};
   }
 `
 
@@ -77,6 +77,7 @@ const DataSharing = () => {
   const isMounted = useIsMounted()
   const isAdminUser = getIsAdminUserRole(currentUser, projectId)
   const [isTableUpdating, setIsTableUpdating] = useState(false)
+  const [isTestProjectUpdating, setIsTestProjectUpdating] = useState(false)
 
   useDocumentTitle(`${language.pages.dataSharing.title} - ${language.title.mermaid}`)
 
@@ -137,6 +138,7 @@ const DataSharing = () => {
           editedValues,
         })
         .then((updatedProject) => {
+          setIsTestProjectUpdating(false)
           setProjectBeingEdited(updatedProject)
           toast.success(...getToastArguments(toastMessage))
           setIsTableUpdating(false)
@@ -167,6 +169,7 @@ const DataSharing = () => {
   }
 
   const handleTestProjectChange = (event) => {
+    setIsTestProjectUpdating(true)
     const isChecked = event.target.checked
     const status = isChecked ? language.projectCodes.status.test : language.projectCodes.status.open
     const editedValues = { ...projectBeingEdited, status }
@@ -276,12 +279,13 @@ const DataSharing = () => {
       )}
       {isAdminUser && (
         <>
-          <CheckBoxLabel>
+          <CheckBoxLabel cursor={isTestProjectUpdating ? 'wait' : 'pointer'}>
             <input
               id="test-project-toggle"
               type="checkbox"
               checked={projectBeingEdited?.status === language.projectCodes.status.test}
               onChange={handleTestProjectChange}
+              disabled={isTestProjectUpdating}
             />{' '}
             This is a test project
           </CheckBoxLabel>

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -103,9 +103,6 @@ const NameCellStyle = styled('div')`
 `
 const UserTableTd = styled(Td)`
   position: relative;
-  label {
-    cursor: ${(props) => props.cursor || 'pointer'};
-  }
 `
 const TableRadioLabel = styled('label')`
   top: 0;
@@ -716,7 +713,7 @@ const Users = () => {
   const table = (
     <>
       <StickyTableOverflowWrapper>
-        <GenericStickyTable {...getTableProps()}>
+        <GenericStickyTable {...getTableProps()} cursor={isTableUpdating ? 'wait' : 'pointer'}>
           <thead>
             {headerGroups.map((headerGroup) => (
               <Tr {...headerGroup.getHeaderGroupProps()}>
@@ -749,11 +746,7 @@ const Users = () => {
                 <Tr {...row.getRowProps()}>
                   {row.cells.map((cell) => {
                     return (
-                      <UserTableTd
-                        {...cell.getCellProps()}
-                        align={cell.column.align}
-                        cursor={isTableUpdating ? 'wait' : 'pointer'}
-                      >
+                      <UserTableTd {...cell.getCellProps()} align={cell.column.align}>
                         {cell.render('Cell')}
                       </UserTableTd>
                     )

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -103,6 +103,9 @@ const NameCellStyle = styled('div')`
 `
 const UserTableTd = styled(Td)`
   position: relative;
+  label {
+    cursor: ${(props) => props.cursor || 'pointer'};
+  }
 `
 const TableRadioLabel = styled('label')`
   top: 0;
@@ -746,7 +749,11 @@ const Users = () => {
                 <Tr {...row.getRowProps()}>
                   {row.cells.map((cell) => {
                     return (
-                      <UserTableTd {...cell.getCellProps()} align={cell.column.align}>
+                      <UserTableTd
+                        {...cell.getCellProps()}
+                        align={cell.column.align}
+                        cursor={isTableUpdating ? 'wait' : 'pointer'}
+                      >
                         {cell.render('Cell')}
                       </UserTableTd>
                     )


### PR DESCRIPTION
[trello ticket 813](https://trello.com/c/Vqcuzicp/813-disable-controls-after-clicking-until-theres-a-response-on-data-sharing-page)

**task:** disable radio buttons on data sharing page when updating, also add wait cursor to radio button items

also disabled for checkbox on data sharing

**to test:**
1. go to data sharing & users pages
2. click a radio button to update
3. check to see that radio buttons are disabled while updating, and that wait cursor appears over radio button labels