### PR TITLE
fix: 981 make sure sites, MRs, users page get refreshed after user readded to project

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,7 @@ As a tradeoff between mixing concerns and having an overlycomplex, it was decide
 
 - ` uiState_pushToApi` set to true if you want an entity to be included in the next push to the API
 - API stuff:
-  - `last_revision_num` is tricky and there are no API docs for it. Definitely Dustin for an overview if you need to touch it (I cant remember the details).
+  - `last_revision_num` is tricky and there are no API docs for it. Definitely ask Dustin or Kim for an overview if you need to touch it (I cant remember the details).
   - a `_deleted` property is stored and sent to the api to let it know to delete an item.
 
 #### Navigation prompts

--- a/src/App/integrationTests/app.lastRevisionNumbersForSyncing.test.js
+++ b/src/App/integrationTests/app.lastRevisionNumbersForSyncing.test.js
@@ -1,0 +1,130 @@
+import '@testing-library/jest-dom/extend-expect'
+import { rest } from 'msw'
+import React from 'react'
+import userEvent from '@testing-library/user-event'
+
+import {
+  screen,
+  renderAuthenticatedOnline,
+  mockMermaidApiAllSuccessful,
+  within,
+  waitForElementToBeRemoved,
+} from '../../testUtilities/testingLibraryWithHelpers'
+import { getMockDexieInstancesAllSuccess } from '../../testUtilities/mockDexie'
+import { initiallyHydrateOfflineStorageWithMockData } from '../../testUtilities/initiallyHydrateOfflineStorageWithMockData'
+import App from '../App'
+
+const apiBaseUrl = process.env.REACT_APP_MERMAID_API
+
+test('When a sync pull responds with sync errors for 403 (user denied pulling data), the app will reset the last revision numbers for the data type and project to ensure the user can pull fresh data if they are given permission again', async () => {
+  const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
+
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
+  renderAuthenticatedOnline(<App dexieCurrentUserInstance={dexieCurrentUserInstance} />, {
+    dexiePerUserDataInstance,
+    dexieCurrentUserInstance,
+  })
+
+  expect(await screen.findByText('Projects', { selector: 'h1' }))
+  const lastRevisionProject1CollectRecordsBeforeSyncError =
+    await dexiePerUserDataInstance.uiState_lastRevisionNumbersPulled
+      .where({ dataType: 'collect_records', projectId: '1' })
+      .toArray()
+
+  const lastRevisionProject1ManagementsBeforeSyncError =
+    await dexiePerUserDataInstance.uiState_lastRevisionNumbersPulled
+      .where({ dataType: 'project_managements', projectId: '1' })
+      .toArray()
+
+  const lastRevisionProject1ProfilesBeforeSyncError =
+    await dexiePerUserDataInstance.uiState_lastRevisionNumbersPulled
+      .where({ dataType: 'project_profiles', projectId: '1' })
+      .toArray()
+
+  const lastRevisionProject1SitesBeforeSyncError =
+    await dexiePerUserDataInstance.uiState_lastRevisionNumbersPulled
+      .where({ dataType: 'project_sites', projectId: '1' })
+      .toArray()
+
+  expect(lastRevisionProject1CollectRecordsBeforeSyncError[0].lastRevisionNumber).toEqual('initial')
+  expect(lastRevisionProject1ManagementsBeforeSyncError[0].lastRevisionNumber).toEqual('initial')
+  expect(lastRevisionProject1ProfilesBeforeSyncError[0].lastRevisionNumber).toEqual('initial')
+  expect(lastRevisionProject1SitesBeforeSyncError[0].lastRevisionNumber).toEqual('initial')
+
+  // after we have the page loaded,
+  // we set up the mock API to have sync errors,
+  // then we navigate the user to trigger a sync
+
+  mockMermaidApiAllSuccessful.use(
+    rest.post(`${apiBaseUrl}/pull/`, (req, res, ctx) => {
+      const responseWithSyncErrors = {
+        benthic_attributes: {
+          error: {
+            code: 403,
+            record_ids: [],
+          },
+        },
+        collect_records: {
+          error: {
+            code: 403,
+            record_ids: [],
+          },
+        },
+        project_managements: {
+          error: {
+            code: 403,
+            record_ids: [],
+          },
+        },
+        project_profiles: {
+          error: {
+            code: 403,
+            record_ids: [],
+          },
+        },
+        project_sites: {
+          error: {
+            code: 403,
+            record_ids: [],
+          },
+        },
+      }
+
+      return res.once(ctx.json(responseWithSyncErrors))
+    }),
+  )
+
+  const projectCard = screen.getAllByRole('listitem')[0]
+  const projectCardCollectingLink = within(projectCard).getByRole('link', { name: 'Collect' })
+
+  userEvent.click(projectCardCollectingLink)
+
+  await screen.findByLabelText('project pages loading indicator')
+  await waitForElementToBeRemoved(() => screen.queryByLabelText('project pages loading indicator'))
+
+  const lastRevisionProject1CollectRecordsAfterSyncError =
+    await dexiePerUserDataInstance.uiState_lastRevisionNumbersPulled
+      .where({ dataType: 'collect_records', projectId: '1' })
+      .toArray()
+
+  const lastRevisionProject1ManagementsAfterSyncError =
+    await dexiePerUserDataInstance.uiState_lastRevisionNumbersPulled
+      .where({ dataType: 'project_managements', projectId: '1' })
+      .toArray()
+
+  const lastRevisionProject1ProfilesAfterSyncError =
+    await dexiePerUserDataInstance.uiState_lastRevisionNumbersPulled
+      .where({ dataType: 'project_profiles', projectId: '1' })
+      .toArray()
+
+  const lastRevisionProject1SitesAfterSyncError =
+    await dexiePerUserDataInstance.uiState_lastRevisionNumbersPulled
+      .where({ dataType: 'project_sites', projectId: '1' })
+      .toArray()
+
+  expect(lastRevisionProject1CollectRecordsAfterSyncError[0].lastRevisionNumber).toBeNull()
+  expect(lastRevisionProject1ManagementsAfterSyncError[0].lastRevisionNumber).toBeNull()
+  expect(lastRevisionProject1ProfilesAfterSyncError[0].lastRevisionNumber).toBeNull()
+  expect(lastRevisionProject1SitesAfterSyncError[0].lastRevisionNumber).toBeNull()
+})

--- a/src/App/mermaidData/getIsDataTypeProjectAssociated.js
+++ b/src/App/mermaidData/getIsDataTypeProjectAssociated.js
@@ -1,0 +1,5 @@
+export const getIsDataTypeProjectAssociated = (dataType) =>
+  dataType === 'collect_records' ||
+  dataType === 'project_managements' ||
+  dataType === 'project_profiles' ||
+  dataType === 'project_sites'

--- a/src/App/mermaidData/lastRevisionNumbers.test.js
+++ b/src/App/mermaidData/lastRevisionNumbers.test.js
@@ -3,6 +3,7 @@ import { initiallyHydrateOfflineStorageWithMockData } from '../../testUtilities/
 import {
   getLastRevisionNumbersPulledForAProject,
   persistLastRevisionNumbersPulled,
+  resetLastRevisionNumberForProjectDataType,
 } from './lastRevisionNumbers'
 import mockMermaidData from '../../testUtilities/mockMermaidData'
 
@@ -89,4 +90,90 @@ test('Make sure last revision numbers are stored per project where appropriate, 
   expect(lastRevisonNumbersForProjectB.fish_genera).toEqual('pull2')
   expect(lastRevisonNumbersForProjectB.fish_species).toEqual('pull2')
   expect(lastRevisonNumbersForProjectB.projects).toEqual('pull2')
+})
+
+test("resetLastRevisionNumberForProjectDataType will replace last revision numbers for a project's data type with null", async () => {
+  const { dexiePerUserDataInstance } = getMockDexieInstancesAllSuccess()
+
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
+  const apiDataForProjectA = {
+    benthic_attributes: { updates: mockMermaidData.benthic_attributes, last_revision_num: 'pull1' },
+    choices: { updates: mockMermaidData.choices, last_revision_num: 'pull1' },
+    collect_records: { updates: mockMermaidData.collect_records, last_revision_num: 'pull1' },
+    fish_families: { updates: mockMermaidData.fish_families, last_revision_num: 'pull1' },
+    fish_genera: { updates: mockMermaidData.fish_genera, last_revision_num: 'pull1' },
+    fish_species: { updates: mockMermaidData.fish_species, last_revision_num: 'pull1' },
+    project_managements: {
+      updates: mockMermaidData.project_managements,
+      last_revision_num: 'pull1',
+    },
+    project_profiles: { updates: mockMermaidData.project_profiles, last_revision_num: 'pull1' },
+    project_sites: { updates: mockMermaidData.project_sites, last_revision_num: 'pull1' },
+    projects: { updates: mockMermaidData.projects, last_revision_num: 'pull1' },
+  }
+
+  await persistLastRevisionNumbersPulled({
+    dexiePerUserDataInstance,
+    apiData: apiDataForProjectA,
+    projectId: 'A',
+  })
+
+  const lastRevisonNumbersForProjectA = await getLastRevisionNumbersPulledForAProject({
+    dexiePerUserDataInstance,
+    projectId: 'A',
+  })
+
+  expect(lastRevisonNumbersForProjectA.collect_records).toEqual('pull1')
+  expect(lastRevisonNumbersForProjectA.project_managements).toEqual('pull1')
+  expect(lastRevisonNumbersForProjectA.project_profiles).toEqual('pull1')
+  expect(lastRevisonNumbersForProjectA.project_sites).toEqual('pull1')
+  expect(lastRevisonNumbersForProjectA.benthic_attributes).toEqual('pull1')
+  expect(lastRevisonNumbersForProjectA.choices).toEqual('pull1')
+  expect(lastRevisonNumbersForProjectA.fish_families).toEqual('pull1')
+  expect(lastRevisonNumbersForProjectA.fish_genera).toEqual('pull1')
+  expect(lastRevisonNumbersForProjectA.fish_species).toEqual('pull1')
+  expect(lastRevisonNumbersForProjectA.projects).toEqual('pull1')
+
+  await resetLastRevisionNumberForProjectDataType({
+    dataType: 'collect_records',
+    projectId: 'A',
+    dexiePerUserDataInstance,
+  })
+
+  await resetLastRevisionNumberForProjectDataType({
+    dataType: 'project_managements',
+    projectId: 'A',
+    dexiePerUserDataInstance,
+  })
+
+  await resetLastRevisionNumberForProjectDataType({
+    dataType: 'project_profiles',
+    projectId: 'A',
+    dexiePerUserDataInstance,
+  })
+
+  await resetLastRevisionNumberForProjectDataType({
+    dataType: 'project_sites',
+    projectId: 'A',
+    dexiePerUserDataInstance,
+  })
+
+  const lastRevisonNumbersAfterResetForProjectA = await getLastRevisionNumbersPulledForAProject({
+    dexiePerUserDataInstance,
+    projectId: 'A',
+  })
+
+  expect(lastRevisonNumbersAfterResetForProjectA.collect_records).toBeNull()
+  expect(lastRevisonNumbersAfterResetForProjectA.project_managements).toBeNull()
+  expect(lastRevisonNumbersAfterResetForProjectA.project_profiles).toBeNull()
+  expect(lastRevisonNumbersAfterResetForProjectA.project_sites).toBeNull()
+
+  // non-project-specific entities should remain untouched
+  expect(lastRevisonNumbersAfterResetForProjectA.benthic_attributes).toEqual('pull1')
+  expect(lastRevisonNumbersAfterResetForProjectA.choices).toEqual('pull1')
+  expect(lastRevisonNumbersAfterResetForProjectA.fish_families).toEqual('pull1')
+  expect(lastRevisonNumbersAfterResetForProjectA.fish_genera).toEqual('pull1')
+  expect(lastRevisonNumbersAfterResetForProjectA.fish_species).toEqual('pull1')
+  expect(lastRevisonNumbersAfterResetForProjectA.projects).toEqual('pull1')
 })

--- a/src/testUtilities/initiallyHydrateOfflineStorageWithMockData.js
+++ b/src/testUtilities/initiallyHydrateOfflineStorageWithMockData.js
@@ -14,6 +14,7 @@ export const initiallyHydrateOfflineStorageWithMockData = (dexiePerUserDataInsta
     dexiePerUserDataInstance.project_sites,
     dexiePerUserDataInstance.projects,
     dexiePerUserDataInstance.uiState_offlineReadyProjects,
+    dexiePerUserDataInstance.uiState_lastRevisionNumbersPulled,
 
     async () => {
       // choices is not an array, so not like th others

--- a/src/testUtilities/mockMermaidApiAllSuccessful.js
+++ b/src/testUtilities/mockMermaidApiAllSuccessful.js
@@ -66,16 +66,25 @@ const mockMermaidApiAllSuccessful = setupServer(
 
   rest.post(`${apiBaseUrl}/pull/`, (req, res, ctx) => {
     const response = {
-      benthic_attributes: { updates: mockMermaidData.benthic_attributes },
-      choices: { updates: mockMermaidData.choices },
-      collect_records: { updates: mockMermaidData.collect_records },
-      fish_families: { updates: mockMermaidData.fish_families },
-      fish_genera: { updates: mockMermaidData.fish_genera },
-      fish_species: { updates: mockMermaidData.fish_species },
-      project_managements: { updates: mockMermaidData.project_managements },
-      project_profiles: { updates: mockMermaidData.project_profiles },
-      project_sites: { updates: mockMermaidData.project_sites },
-      projects: { updates: mockMermaidData.projects },
+      benthic_attributes: {
+        updates: mockMermaidData.benthic_attributes,
+        last_revision_num: 'initial',
+      },
+      choices: { updates: mockMermaidData.choices, last_revision_num: 'initial' },
+      collect_records: { updates: mockMermaidData.collect_records, last_revision_num: 'initial' },
+      fish_families: { updates: mockMermaidData.fish_families, last_revision_num: 'initial' },
+      fish_genera: { updates: mockMermaidData.fish_genera, last_revision_num: 'initial' },
+      fish_species: { updates: mockMermaidData.fish_species, last_revision_num: 'initial' },
+      project_managements: {
+        updates: mockMermaidData.project_managements,
+        last_revision_num: 'initial',
+      },
+      project_profiles: {
+        updates: mockMermaidData.project_profiles,
+        last_revision_num: 'initial',
+      },
+      project_sites: { updates: mockMermaidData.project_sites, last_revision_num: 'initial' },
+      projects: { updates: mockMermaidData.projects, last_revision_num: 'initial' },
     }
 
     return res(ctx.json(response))


### PR DESCRIPTION
Steps to test:

User A: add User B to project
User B: go to any project page
User A: remove User B from project
User B: go to Projects (list) page (project no longer there)
User A: add User B back to project
User B: refresh Projects (list) page (project there again)
User B: go to Sites, MRs, or Users pages

Expected behavior:
User B sees same Sites, MRs, and Users as User A


Original ticket: https://trello.com/c/54Q80ITc/981-users-local-data-not-refreshed-after-being-removed-then-added-to-project

