### PR TITLE
946: Collect titles refresh bug

### DIFF
--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitForm.js
@@ -76,7 +76,7 @@ const BenthicLitform = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
-                  protocol: collectRecordResponse.data.protocol,
+                  protocol: collectRecordResponse?.data.protocol,
                 }),
               )
 
@@ -132,7 +132,7 @@ const BenthicLitform = ({ isNewRecord }) => {
         isNewRecord,
         collectRecord: collectRecordResponse,
         sites,
-        protocol: collectRecordResponse.data.protocol,
+        protocol: collectRecordResponse?.data.protocol,
       }),
     )
   }

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitForm.js
@@ -76,7 +76,7 @@ const BenthicLitform = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
-                  protocol: 'benthiclit',
+                  protocol: collectRecordResponse.data.protocol,
                 }),
               )
 
@@ -125,14 +125,14 @@ const BenthicLitform = ({ isNewRecord }) => {
     )
   }, [collectRecordBeingEdited, getPersistedUnsavedFormikData])
 
-  const handleCollectRecordChange = (updatedCollectRecord) => {
-    setCollectRecordBeingEdited(updatedCollectRecord)
+  const handleCollectRecordChange = (collectRecordResponse) => {
+    setCollectRecordBeingEdited(collectRecordResponse)
     setSubNavNode(
       getDataForSubNavNode({
         isNewRecord,
-        collectRecord: updatedCollectRecord,
+        collectRecord: collectRecordResponse,
         sites,
-        protocol: 'benthiclit',
+        protocol: collectRecordResponse.data.protocol,
       }),
     )
   }

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitForm.js
@@ -10,7 +10,7 @@ import {
 } from '../collectRecordFormInitialValues'
 
 import { getBenthicOptions } from '../../../../library/getOptions'
-import { getRecordSubNavNodeInfo } from '../../../../library/getRecordSubNavNodeInfo'
+import { getDataForSubNavNode } from '../../../../library/getDataForSubNavNode'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import { reformatFormValuesIntoBenthicLitRecord } from '../CollectRecordFormPage/reformatFormValuesIntoRecord'
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
@@ -44,6 +44,7 @@ const BenthicLitform = ({ isNewRecord }) => {
   const handleHttpResponseError = useHttpResponseErrorHandler()
   const isMounted = useIsMounted()
   const observationsReducer = useReducer(benthicLitObservationReducer, [])
+  const [sites, setSites] = useState()
 
   const [, observationsDispatch] = observationsReducer
 
@@ -70,18 +71,18 @@ const BenthicLitform = ({ isNewRecord }) => {
                 setIdsNotAssociatedWithData((previousState) => [...previousState, recordId])
               }
 
-              const recordNameForSubNode =
-                !isNewRecord && collectRecordResponse
-                  ? getRecordSubNavNodeInfo(
-                      collectRecordResponse.data,
-                      sitesResponse,
-                      collectRecordResponse.data.protocol,
-                    )
-                  : { name: language.protocolTitles.benthiclit }
+              setSubNavNode(
+                getDataForSubNavNode({
+                  isNewRecord,
+                  collectRecord: collectRecordResponse,
+                  sites: sitesResponse,
+                  protocol: 'benthiclit',
+                }),
+              )
 
               setCollectRecordBeingEdited(collectRecordResponse)
               setBenthicAttributeSelectOptions(getBenthicOptions(benthicAttributesResponse))
-              setSubNavNode(recordNameForSubNode)
+              setSites(sitesResponse)
 
               setIsLoading(false)
             }
@@ -124,8 +125,17 @@ const BenthicLitform = ({ isNewRecord }) => {
     )
   }, [collectRecordBeingEdited, getPersistedUnsavedFormikData])
 
-  const handleCollectRecordChange = (updatedCollectRecord) =>
+  const handleCollectRecordChange = (updatedCollectRecord) => {
     setCollectRecordBeingEdited(updatedCollectRecord)
+    setSubNavNode(
+      getDataForSubNavNode({
+        isNewRecord,
+        collectRecord: updatedCollectRecord,
+        sites,
+        protocol: 'benthiclit',
+      }),
+    )
+  }
 
   const updateBenthicAttributeOptionsStateWithOfflineStorageData = useCallback(() => {
     if (databaseSwitchboardInstance) {

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
@@ -77,7 +77,7 @@ const BenthicPhotoQuadratForm = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
-                  protocol: 'benthicpqt',
+                  protocol: collectRecordResponse.data.protocol,
                 }),
               )
 
@@ -116,15 +116,15 @@ const BenthicPhotoQuadratForm = ({ isNewRecord }) => {
     handleHttpResponseError,
   ])
 
-  const handleCollectRecordChange = (updatedCollectRecord) => {
-    setCollectRecordBeingEdited(updatedCollectRecord)
+  const handleCollectRecordChange = (collectRecordResponse) => {
+    setCollectRecordBeingEdited(collectRecordResponse)
 
     setSubNavNode(
       getDataForSubNavNode({
         isNewRecord,
-        collectRecord: updatedCollectRecord,
+        collectRecord: collectRecordResponse,
         sites,
-        protocol: 'benthicpqt',
+        protocol: collectRecordResponse.data.protocol,
       }),
     )
   }

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
@@ -117,8 +117,6 @@ const BenthicPhotoQuadratForm = ({ isNewRecord }) => {
   ])
 
   const handleCollectRecordChange = (updatedCollectRecord) => {
-    // eslint-disable-next-line no-console
-    console.log('updated: ', updatedCollectRecord)
     setCollectRecordBeingEdited(updatedCollectRecord)
 
     setSubNavNode(

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
@@ -77,7 +77,7 @@ const BenthicPhotoQuadratForm = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
-                  protocol: collectRecordResponse.data.protocol,
+                  protocol: collectRecordResponse?.data.protocol,
                 }),
               )
 
@@ -124,7 +124,7 @@ const BenthicPhotoQuadratForm = ({ isNewRecord }) => {
         isNewRecord,
         collectRecord: collectRecordResponse,
         sites,
-        protocol: collectRecordResponse.data.protocol,
+        protocol: collectRecordResponse?.data.protocol,
       }),
     )
   }

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
@@ -5,7 +5,7 @@ import { useParams } from 'react-router-dom'
 
 import benthicpqtObservationReducer from './benthicpqtObservationReducer'
 import { getBenthicOptions } from '../../../../library/getOptions'
-import { getRecordSubNavNodeInfo } from '../../../../library/getRecordSubNavNodeInfo'
+import { getDataForSubNavNode } from '../../../../library/getDataForSubNavNode'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import language from '../../../../language'
 import { sortArrayByObjectKey } from '../../../../library/arrays/sortArrayByObjectKey'
@@ -72,14 +72,14 @@ const BenthicPhotoQuadratForm = ({ isNewRecord }) => {
                 setIdsNotAssociatedWithData((previousState) => [...previousState, projectId])
               }
 
-              const recordNameForSubNode =
-                !isNewRecord && collectRecordResponse
-                  ? getRecordSubNavNodeInfo(
-                      collectRecordResponse.data,
-                      sitesResponse,
-                      collectRecordResponse.data.protocol,
-                    )
-                  : { name: language.protocolTitles.benthicpqt }
+              setSubNavNode(
+                getDataForSubNavNode({
+                  isNewRecord,
+                  collectRecord: collectRecordResponse,
+                  sites: sitesResponse,
+                  protocol: 'benthicpqt',
+                }),
+              )
 
               const updateBenthicAttributeOptions = getBenthicOptions(benthicAttributes)
 
@@ -89,7 +89,6 @@ const BenthicPhotoQuadratForm = ({ isNewRecord }) => {
               setObserverProfiles(sortArrayByObjectKey(projectProfilesResponse, 'profile_name'))
               setBenthicAttributeOptions(updateBenthicAttributeOptions)
               setCollectRecordBeingEdited(collectRecordResponse)
-              setSubNavNode(recordNameForSubNode)
               setIsLoading(false)
             }
           },
@@ -117,8 +116,20 @@ const BenthicPhotoQuadratForm = ({ isNewRecord }) => {
     handleHttpResponseError,
   ])
 
-  const handleCollectRecordChange = (updatedCollectRecord) =>
+  const handleCollectRecordChange = (updatedCollectRecord) => {
+    // eslint-disable-next-line no-console
+    console.log('updated: ', updatedCollectRecord)
     setCollectRecordBeingEdited(updatedCollectRecord)
+
+    setSubNavNode(
+      getDataForSubNavNode({
+        isNewRecord,
+        collectRecord: updatedCollectRecord,
+        sites,
+        protocol: 'benthicpqt',
+      }),
+    )
+  }
 
   const handleNewObservationAdd = (observationAttributeId) =>
     setNewObservationToAdd(observationAttributeId)

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitForm.js
@@ -11,7 +11,7 @@ import {
 } from '../collectRecordFormInitialValues'
 
 import { getBenthicOptions } from '../../../../library/getOptions'
-import { getRecordSubNavNodeInfo } from '../../../../library/getRecordSubNavNodeInfo'
+import { getDataForSubNavNode } from '../../../../library/getDataForSubNavNode'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import { reformatFormValuesIntoBenthicPitRecord } from '../CollectRecordFormPage/reformatFormValuesIntoRecord'
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
@@ -38,6 +38,7 @@ const BenthicPitForm = ({ isNewRecord }) => {
   const [observationIdToAddNewBenthicAttributeTo, setObservationIdToAddNewBenthicAttributeTo] =
     useState()
   const [subNavNode, setSubNavNode] = useState()
+  const [sites, setSites] = useState()
 
   const { currentUser } = useCurrentUser()
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
@@ -72,18 +73,18 @@ const BenthicPitForm = ({ isNewRecord }) => {
                 setIdsNotAssociatedWithData((previousState) => [...previousState, recordId])
               }
 
-              const recordNameForSubNode =
-                !isNewRecord && collectRecordResponse
-                  ? getRecordSubNavNodeInfo(
-                      collectRecordResponse.data,
-                      sitesResponse,
-                      collectRecordResponse.data.protocol,
-                    )
-                  : { name: language.protocolTitles.benthicpit }
+              setSubNavNode(
+                getDataForSubNavNode({
+                  isNewRecord,
+                  collectRecord: collectRecordResponse,
+                  sites: sitesResponse,
+                  protocol: 'benthicpit',
+                }),
+              )
 
               setCollectRecordBeingEdited(collectRecordResponse)
               setBenthicAttributeSelectOptions(getBenthicOptions(benthicAttributesResponse))
-              setSubNavNode(recordNameForSubNode)
+              setSites(sitesResponse)
 
               setIsLoading(false)
             }
@@ -127,8 +128,17 @@ const BenthicPitForm = ({ isNewRecord }) => {
     )
   }, [collectRecordBeingEdited, getPersistedUnsavedFormikData])
 
-  const handleCollectRecordChange = (updatedCollectRecord) =>
+  const handleCollectRecordChange = (updatedCollectRecord) => {
     setCollectRecordBeingEdited(updatedCollectRecord)
+    setSubNavNode(
+      getDataForSubNavNode({
+        isNewRecord,
+        collectRecord: updatedCollectRecord,
+        sites,
+        protocol: 'benthicpit',
+      }),
+    )
+  }
 
   const updateBenthicAttributeOptionsStateWithOfflineStorageData = useCallback(() => {
     if (databaseSwitchboardInstance) {

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitForm.js
@@ -78,7 +78,7 @@ const BenthicPitForm = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
-                  protocol: collectRecordResponse.data.protocol,
+                  protocol: collectRecordResponse?.data.protocol,
                 }),
               )
 
@@ -135,7 +135,7 @@ const BenthicPitForm = ({ isNewRecord }) => {
         isNewRecord,
         collectRecord: collectRecordResponse,
         sites,
-        protocol: collectRecordResponse.data.protocol,
+        protocol: collectRecordResponse?.data.protocol,
       }),
     )
   }

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitForm.js
@@ -78,7 +78,7 @@ const BenthicPitForm = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
-                  protocol: 'benthicpit',
+                  protocol: collectRecordResponse.data.protocol,
                 }),
               )
 
@@ -128,14 +128,14 @@ const BenthicPitForm = ({ isNewRecord }) => {
     )
   }, [collectRecordBeingEdited, getPersistedUnsavedFormikData])
 
-  const handleCollectRecordChange = (updatedCollectRecord) => {
-    setCollectRecordBeingEdited(updatedCollectRecord)
+  const handleCollectRecordChange = (collectRecordResponse) => {
+    setCollectRecordBeingEdited(collectRecordResponse)
     setSubNavNode(
       getDataForSubNavNode({
         isNewRecord,
-        collectRecord: updatedCollectRecord,
+        collectRecord: collectRecordResponse,
         sites,
-        protocol: 'benthicpit',
+        protocol: collectRecordResponse.data.protocol,
       }),
     )
   }

--- a/src/components/pages/collectRecordFormPages/BleachingForm/BleachingForm.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/BleachingForm.js
@@ -79,6 +79,7 @@ const BleachingForm = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
+                  protocol: 'bleachingqc',
                 }),
               )
 
@@ -133,6 +134,7 @@ const BleachingForm = ({ isNewRecord }) => {
         isNewRecord,
         collectRecord: updatedCollectRecord,
         sites,
+        protocol: 'bleachingqc',
       }),
     )
   }

--- a/src/components/pages/collectRecordFormPages/BleachingForm/BleachingForm.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/BleachingForm.js
@@ -79,7 +79,7 @@ const BleachingForm = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
-                  protocol: 'bleachingqc',
+                  protocol: collectRecordResponse.data.protocol,
                 }),
               )
 
@@ -127,14 +127,14 @@ const BleachingForm = ({ isNewRecord }) => {
     )
   }, [collectRecordBeingEdited, getPersistedUnsavedFormikData])
 
-  const handleCollectRecordChange = (updatedCollectRecord) => {
-    setCollectRecordBeingEdited(updatedCollectRecord)
+  const handleCollectRecordChange = (collectRecordResponse) => {
+    setCollectRecordBeingEdited(collectRecordResponse)
     setSubNavNode(
       getDataForSubNavNode({
         isNewRecord,
-        collectRecord: updatedCollectRecord,
+        collectRecord: collectRecordResponse,
         sites,
-        protocol: 'bleachingqc',
+        protocol: collectRecordResponse.data.protocol,
       }),
     )
   }

--- a/src/components/pages/collectRecordFormPages/BleachingForm/BleachingForm.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/BleachingForm.js
@@ -79,7 +79,7 @@ const BleachingForm = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
-                  protocol: collectRecordResponse.data.protocol,
+                  protocol: collectRecordResponse?.data.protocol,
                 }),
               )
 
@@ -134,7 +134,7 @@ const BleachingForm = ({ isNewRecord }) => {
         isNewRecord,
         collectRecord: collectRecordResponse,
         sites,
-        protocol: collectRecordResponse.data.protocol,
+        protocol: collectRecordResponse?.data.protocol,
       }),
     )
   }

--- a/src/components/pages/collectRecordFormPages/BleachingForm/BleachingForm.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/BleachingForm.js
@@ -9,7 +9,7 @@ import {
   getSampleInfoInitialValues,
 } from '../collectRecordFormInitialValues'
 import { getBenthicOptions } from '../../../../library/getOptions'
-import { getRecordSubNavNodeInfo } from '../../../../library/getRecordSubNavNodeInfo'
+import { getDataForSubNavNode } from '../../../../library/getDataForSubNavNode'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import { reformatFormValuesIntoBleachingRecord } from '../CollectRecordFormPage/reformatFormValuesIntoRecord'
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
@@ -38,6 +38,7 @@ const BleachingForm = ({ isNewRecord }) => {
   const [observationIdToAddNewBenthicAttributeTo, setObservationIdToAddNewBenthicAttributeTo] =
     useState()
   const [subNavNode, setSubNavNode] = useState(null)
+  const [sites, setSites] = useState()
 
   const { currentUser } = useCurrentUser()
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
@@ -73,19 +74,17 @@ const BleachingForm = ({ isNewRecord }) => {
                 setIdsNotAssociatedWithData((previousState) => [...previousState, recordId])
               }
 
-              const recordNameForSubNode =
-                !isNewRecord && collectRecordResponse
-                  ? getRecordSubNavNodeInfo(
-                      collectRecordResponse.data,
-                      sitesResponse,
-                      collectRecordResponse.data.protocol,
-                    )
-                  : { name: language.protocolTitles.bleachingqc }
+              setSubNavNode(
+                getDataForSubNavNode({
+                  isNewRecord,
+                  collectRecord: collectRecordResponse,
+                  sites: sitesResponse,
+                }),
+              )
 
               setCollectRecordBeingEdited(collectRecordResponse)
               setBenthicAttributeSelectOptions(getBenthicOptions(benthicAttributesResponse))
-              setSubNavNode(recordNameForSubNode)
-
+              setSites(sitesResponse)
               setIsLoading(false)
             }
           })
@@ -127,8 +126,16 @@ const BleachingForm = ({ isNewRecord }) => {
     )
   }, [collectRecordBeingEdited, getPersistedUnsavedFormikData])
 
-  const handleCollectRecordChange = (updatedCollectRecord) =>
+  const handleCollectRecordChange = (updatedCollectRecord) => {
     setCollectRecordBeingEdited(updatedCollectRecord)
+    setSubNavNode(
+      getDataForSubNavNode({
+        isNewRecord,
+        collectRecord: updatedCollectRecord,
+        sites,
+      }),
+    )
+  }
 
   const updateBenthicAttributeOptionsStateWithOfflineStorageData = useCallback(() => {
     if (databaseSwitchboardInstance) {

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
@@ -227,7 +227,7 @@ const CollectRecordFormPage = ({
         projectId,
         protocol: sampleUnitName,
       })
-      .then((response) => {
+      .then((collectRecordResponse) => {
         toast.success(...getToastArguments(language.success.collectRecordSave))
         clearPersistedUnsavedFormikData()
         clearPersistedUnsavedObservationsData()
@@ -236,9 +236,12 @@ const CollectRecordFormPage = ({
         setValidateButtonState(buttonGroupStates.validatable)
         setIsFormDirty(false)
         formik.resetForm({ values: formik.values }) // this resets formik's dirty state
+        handleCollectRecordChange(collectRecordResponse)
 
         if (isNewRecord) {
-          history.push(`${ensureTrailingSlash(history.location.pathname)}${response.id}`)
+          history.push(
+            `${ensureTrailingSlash(history.location.pathname)}${collectRecordResponse.id}`,
+          )
         }
       })
       .catch((error) => {

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPageAlternative/CollectRecordFormPageAlternative.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPageAlternative/CollectRecordFormPageAlternative.js
@@ -326,7 +326,7 @@ const CollectRecordFormPageAlternative = ({
         projectId,
         protocol: sampleUnitName,
       })
-      .then((response) => {
+      .then((collectRecordResponse) => {
         toast.success(...getToastArguments(language.success.collectRecordSave))
         clearPersistedUnsavedFormikData()
         clearPersistedUnsavedObservationsTable1Data()
@@ -336,9 +336,12 @@ const CollectRecordFormPageAlternative = ({
         setValidateButtonState(buttonGroupStates.validatable)
         setIsFormDirty(false)
         formik.resetForm({ values: formik.values }) // this resets formik's dirty state
+        handleCollectRecordChange(collectRecordResponse)
 
         if (isNewRecord) {
-          history.push(`${ensureTrailingSlash(history.location.pathname)}${response.id}`)
+          history.push(
+            `${ensureTrailingSlash(history.location.pathname)}${collectRecordResponse.id}`,
+          )
         }
       })
       .catch((error) => {

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltForm.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltForm.js
@@ -8,7 +8,7 @@ import {
   getFishNameConstants,
   getFishNameOptions,
 } from '../../../../App/mermaidData/fishNameHelpers'
-import { getRecordSubNavNodeInfo } from '../../../../library/getRecordSubNavNodeInfo'
+import { getDataForSubNavNode } from '../../../../library/getDataForSubNavNode'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import language from '../../../../language'
 import { sortArrayByObjectKey } from '../../../../library/arrays/sortArrayByObjectKey'
@@ -94,14 +94,14 @@ const FishBeltForm = ({ isNewRecord }) => {
 
               const generaOptions = genera.map((genus) => ({ label: genus.name, value: genus.id }))
 
-              const recordNameForSubNode =
-                !isNewRecord && collectRecordResponse
-                  ? getRecordSubNavNodeInfo(
-                      collectRecordResponse.data,
-                      sitesResponse,
-                      collectRecordResponse.data.protocol,
-                    )
-                  : { name: language.protocolTitles.fishbelt }
+              setSubNavNode(
+                getDataForSubNavNode({
+                  isNewRecord,
+                  collectRecord: collectRecordResponse,
+                  sites: sitesResponse,
+                  protocol: 'fishbelt',
+                }),
+              )
 
               setSites(sortArrayByObjectKey(sitesResponse, 'name'))
               setManagementRegimes(sortArrayByObjectKey(managementRegimesResponse, 'name'))
@@ -111,7 +111,6 @@ const FishBeltForm = ({ isNewRecord }) => {
               setFishNameConstants(updateFishNameConstants)
               setFishNameOptions(updateFishNameOptions)
               setModalAttributeOptions(generaOptions)
-              setSubNavNode(recordNameForSubNode)
               setIsLoading(false)
             }
           },
@@ -139,8 +138,17 @@ const FishBeltForm = ({ isNewRecord }) => {
     isSyncInProgress,
   ])
 
-  const handleCollectRecordChange = (updatedCollectRecord) =>
+  const handleCollectRecordChange = (updatedCollectRecord) => {
     setCollectRecordBeingEdited(updatedCollectRecord)
+    setSubNavNode(
+      getDataForSubNavNode({
+        isNewRecord,
+        collectRecord: updatedCollectRecord,
+        sites,
+        protocol: 'fishbelt',
+      }),
+    )
+  }
 
   const handleNewObservationAdd = (observationAttributeId) =>
     setNewObservationToAdd(observationAttributeId)

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltForm.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltForm.js
@@ -99,7 +99,7 @@ const FishBeltForm = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
-                  protocol: collectRecordResponse.data.protocol,
+                  protocol: collectRecordResponse?.data.protocol,
                 }),
               )
 

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltForm.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltForm.js
@@ -99,7 +99,7 @@ const FishBeltForm = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
-                  protocol: 'fishbelt',
+                  protocol: collectRecordResponse.data.protocol,
                 }),
               )
 
@@ -138,14 +138,14 @@ const FishBeltForm = ({ isNewRecord }) => {
     isSyncInProgress,
   ])
 
-  const handleCollectRecordChange = (updatedCollectRecord) => {
-    setCollectRecordBeingEdited(updatedCollectRecord)
+  const handleCollectRecordChange = (collectRecordResponse) => {
+    setCollectRecordBeingEdited(collectRecordResponse)
     setSubNavNode(
       getDataForSubNavNode({
         isNewRecord,
-        collectRecord: updatedCollectRecord,
+        collectRecord: collectRecordResponse,
         sites,
-        protocol: 'fishbelt',
+        protocol: collectRecordResponse.data.protocol,
       }),
     )
   }

--- a/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm.js
+++ b/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm.js
@@ -67,7 +67,7 @@ const HabitatComplexityForm = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
-                  protocol: 'habitatcomplexity',
+                  protocol: collectRecordResponse.data.protocol,
                 }),
               )
 
@@ -115,14 +115,14 @@ const HabitatComplexityForm = ({ isNewRecord }) => {
     )
   }, [collectRecordBeingEdited, getPersistedUnsavedFormikData])
 
-  const handleCollectRecordChange = (updatedCollectRecord) => {
-    setCollectRecordBeingEdited(updatedCollectRecord)
+  const handleCollectRecordChange = (collectRecordResponse) => {
+    setCollectRecordBeingEdited(collectRecordResponse)
     setSubNavNode(
       getDataForSubNavNode({
         isNewRecord,
-        collectRecord: updatedCollectRecord,
+        collectRecord: collectRecordResponse,
         sites,
-        protocol: 'habitatcomplexity',
+        protocol: collectRecordResponse.data.protocol,
       }),
     )
   }

--- a/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm.js
+++ b/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm.js
@@ -67,7 +67,7 @@ const HabitatComplexityForm = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
-                  protocol: collectRecordResponse.data.protocol,
+                  protocol: collectRecordResponse?.data.protocol,
                 }),
               )
 
@@ -122,7 +122,7 @@ const HabitatComplexityForm = ({ isNewRecord }) => {
         isNewRecord,
         collectRecord: collectRecordResponse,
         sites,
-        protocol: collectRecordResponse.data.protocol,
+        protocol: collectRecordResponse?.data.protocol,
       }),
     )
   }

--- a/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm.js
+++ b/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm.js
@@ -26,12 +26,18 @@ import language from '../../../../language'
 import useIsMounted from '../../../../library/useIsMounted'
 import ErrorBoundary from '../../../ErrorBoundary'
 
+const getDataForSubNavNode = ({ isNewRecord, collectRecord, sites }) =>
+  !isNewRecord && collectRecord
+    ? getRecordSubNavNodeInfo(collectRecord.data, sites, collectRecord.data.protocol)
+    : { name: language.protocolTitles[collectRecord.data.protocol] }
+
 const HabitatComplexityForm = ({ isNewRecord }) => {
   const [areObservationsInputsDirty, setAreObservationsInputsDirty] = useState(false)
   const [collectRecordBeingEdited, setCollectRecordBeingEdited] = useState()
   const [idsNotAssociatedWithData, setIdsNotAssociatedWithData] = useState([])
   const [isLoading, setIsLoading] = useState(true)
   const [subNavNode, setSubNavNode] = useState()
+  const [sites, setSites] = useState()
 
   const { currentUser } = useCurrentUser()
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
@@ -61,17 +67,16 @@ const HabitatComplexityForm = ({ isNewRecord }) => {
                 setIdsNotAssociatedWithData((previousState) => [...previousState, recordId])
               }
 
-              const recordNameForSubNode =
-                !isNewRecord && collectRecordResponse
-                  ? getRecordSubNavNodeInfo(
-                      collectRecordResponse.data,
-                      sitesResponse,
-                      collectRecordResponse.data.protocol,
-                    )
-                  : { name: language.protocolTitles.habitatcomplexity }
+              setSubNavNode(
+                getDataForSubNavNode({
+                  isNewRecord,
+                  collectRecord: collectRecordResponse,
+                  sites: sitesResponse,
+                }),
+              )
 
               setCollectRecordBeingEdited(collectRecordResponse)
-              setSubNavNode(recordNameForSubNode)
+              setSites(sitesResponse)
               setIsLoading(false)
             }
           })
@@ -114,8 +119,16 @@ const HabitatComplexityForm = ({ isNewRecord }) => {
     )
   }, [collectRecordBeingEdited, getPersistedUnsavedFormikData])
 
-  const handleCollectRecordChange = (updatedCollectRecord) =>
+  const handleCollectRecordChange = (updatedCollectRecord) => {
     setCollectRecordBeingEdited(updatedCollectRecord)
+    setSubNavNode(
+      getDataForSubNavNode({
+        isNewRecord,
+        collectRecord: updatedCollectRecord,
+        sites,
+      }),
+    )
+  }
 
   return (
     <ErrorBoundary>

--- a/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm.js
+++ b/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm.js
@@ -10,7 +10,7 @@ import {
   getTransectInitialValues,
 } from '../collectRecordFormInitialValues'
 
-import { getRecordSubNavNodeInfo } from '../../../../library/getRecordSubNavNodeInfo'
+import { getDataForSubNavNode } from '../../../../library/getDataForSubNavNode'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import { reformatFormValuesIntoHabitatComplexityRecord } from '../CollectRecordFormPage/reformatFormValuesIntoRecord'
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
@@ -25,11 +25,6 @@ import CollectRecordFormPageAlternative from '../CollectRecordFormPageAlternativ
 import language from '../../../../language'
 import useIsMounted from '../../../../library/useIsMounted'
 import ErrorBoundary from '../../../ErrorBoundary'
-
-const getDataForSubNavNode = ({ isNewRecord, collectRecord, sites }) =>
-  !isNewRecord && collectRecord
-    ? getRecordSubNavNodeInfo(collectRecord.data, sites, collectRecord.data.protocol)
-    : { name: language.protocolTitles[collectRecord.data.protocol] }
 
 const HabitatComplexityForm = ({ isNewRecord }) => {
   const [areObservationsInputsDirty, setAreObservationsInputsDirty] = useState(false)

--- a/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm.js
+++ b/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityForm.js
@@ -67,6 +67,7 @@ const HabitatComplexityForm = ({ isNewRecord }) => {
                   isNewRecord,
                   collectRecord: collectRecordResponse,
                   sites: sitesResponse,
+                  protocol: 'habitatcomplexity',
                 }),
               )
 
@@ -121,6 +122,7 @@ const HabitatComplexityForm = ({ isNewRecord }) => {
         isNewRecord,
         collectRecord: updatedCollectRecord,
         sites,
+        protocol: 'habitatcomplexity',
       }),
     )
   }

--- a/src/library/getDataForSubNavNode.js
+++ b/src/library/getDataForSubNavNode.js
@@ -1,7 +1,8 @@
+/* eslint-disable no-console */
 import { getRecordSubNavNodeInfo } from './getRecordSubNavNodeInfo'
 import language from '../language'
 
-export const getDataForSubNavNode = ({ isNewRecord, collectRecord, sites }) =>
+export const getDataForSubNavNode = ({ isNewRecord, collectRecord, sites, protocol }) =>
   !isNewRecord && collectRecord
     ? getRecordSubNavNodeInfo(collectRecord.data, sites, collectRecord.data.protocol)
-    : { name: language.protocolTitles[collectRecord.data.protocol] }
+    : { name: language.protocolTitles[protocol] }

--- a/src/library/getDataForSubNavNode.js
+++ b/src/library/getDataForSubNavNode.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { getRecordSubNavNodeInfo } from './getRecordSubNavNodeInfo'
 import language from '../language'
 

--- a/src/library/getDataForSubNavNode.js
+++ b/src/library/getDataForSubNavNode.js
@@ -1,0 +1,7 @@
+import { getRecordSubNavNodeInfo } from './getRecordSubNavNodeInfo'
+import language from '../language'
+
+export const getDataForSubNavNode = ({ isNewRecord, collectRecord, sites }) =>
+  !isNewRecord && collectRecord
+    ? getRecordSubNavNodeInfo(collectRecord.data, sites, collectRecord.data.protocol)
+    : { name: language.protocolTitles[collectRecord.data.protocol] }


### PR DESCRIPTION
[trello ticket](https://trello.com/c/MaBgWnf4/946-collect-record-title-sub-nav-node-title-dont-refresh-when-inputs-updated-and-saved)

previously, titles would only update in a manual refresh after saving

now, titles update automatically on save

to test:

1. add a collect record
2. add site name, transect number
3. save
4. check to see that both titles update (nav and sub nav)
<img width="687" alt="Screen_Shot_2023-03-17_at_1_23_51_PM" src="https://user-images.githubusercontent.com/26089140/225975482-fb53b5f0-e4ff-47e0-b43c-eb2d8ed930c4.png">

5. update site name & transect number again with new items
6. check to see that items update again
7. repeat for each protocol