### PR TITLE
fix: 985 display only one decimal place for interval in the observation table to avoid weird floating point math

### DIFF
--- a/src/App/integrationTests/collectRecords/benthicPit/App.ObservationIntervalBenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.ObservationIntervalBenthicPit.test.js
@@ -41,10 +41,10 @@ test('Benthic Pit observations: intervals are derived from interval start and in
     const observationIntervalLabelsAfterFourRowsAdded =
       within(observationsSection).getAllByLabelText('Interval')
 
-    expect(observationIntervalLabelsAfterFourRowsAdded[0]).toHaveTextContent('0m')
-    expect(observationIntervalLabelsAfterFourRowsAdded[1]).toHaveTextContent('5m')
-    expect(observationIntervalLabelsAfterFourRowsAdded[2]).toHaveTextContent('10m')
-    expect(observationIntervalLabelsAfterFourRowsAdded[3]).toHaveTextContent('15m')
+    expect(observationIntervalLabelsAfterFourRowsAdded[0]).toHaveTextContent('0.0m')
+    expect(observationIntervalLabelsAfterFourRowsAdded[1]).toHaveTextContent('5.0m')
+    expect(observationIntervalLabelsAfterFourRowsAdded[2]).toHaveTextContent('10.0m')
+    expect(observationIntervalLabelsAfterFourRowsAdded[3]).toHaveTextContent('15.0m')
   })
 
   // user changes interval start value
@@ -55,10 +55,10 @@ test('Benthic Pit observations: intervals are derived from interval start and in
     const observationIntervalLabelsAfterIntervalStartChange =
       within(observationsSection).getAllByLabelText('Interval')
 
-    expect(observationIntervalLabelsAfterIntervalStartChange[0]).toHaveTextContent('5m')
-    expect(observationIntervalLabelsAfterIntervalStartChange[1]).toHaveTextContent('10m')
-    expect(observationIntervalLabelsAfterIntervalStartChange[2]).toHaveTextContent('15m')
-    expect(observationIntervalLabelsAfterIntervalStartChange[3]).toHaveTextContent('20m')
+    expect(observationIntervalLabelsAfterIntervalStartChange[0]).toHaveTextContent('5.0m')
+    expect(observationIntervalLabelsAfterIntervalStartChange[1]).toHaveTextContent('10.0m')
+    expect(observationIntervalLabelsAfterIntervalStartChange[2]).toHaveTextContent('15.0m')
+    expect(observationIntervalLabelsAfterIntervalStartChange[3]).toHaveTextContent('20.0m')
   })
 
   // user changes interval size value
@@ -69,10 +69,10 @@ test('Benthic Pit observations: intervals are derived from interval start and in
     const observationIntervalLabelsAfterIntervalSizeChange =
       within(observationsSection).getAllByLabelText('Interval')
 
-    expect(observationIntervalLabelsAfterIntervalSizeChange[0]).toHaveTextContent('5m')
-    expect(observationIntervalLabelsAfterIntervalSizeChange[1]).toHaveTextContent('105m')
-    expect(observationIntervalLabelsAfterIntervalSizeChange[2]).toHaveTextContent('205m')
-    expect(observationIntervalLabelsAfterIntervalSizeChange[3]).toHaveTextContent('305m')
+    expect(observationIntervalLabelsAfterIntervalSizeChange[0]).toHaveTextContent('5.0m')
+    expect(observationIntervalLabelsAfterIntervalSizeChange[1]).toHaveTextContent('105.0m')
+    expect(observationIntervalLabelsAfterIntervalSizeChange[2]).toHaveTextContent('205.0m')
+    expect(observationIntervalLabelsAfterIntervalSizeChange[3]).toHaveTextContent('305.0m')
   })
 })
 
@@ -105,10 +105,10 @@ test('Benthic PIT observations: intervals recalculate when user deletes an obser
     const observationIntervalLabelsAfterFourRowsAdded =
       within(observationsSection).getAllByLabelText('Interval')
 
-    expect(observationIntervalLabelsAfterFourRowsAdded[0]).toHaveTextContent('0m')
-    expect(observationIntervalLabelsAfterFourRowsAdded[1]).toHaveTextContent('5m')
-    expect(observationIntervalLabelsAfterFourRowsAdded[2]).toHaveTextContent('10m')
-    expect(observationIntervalLabelsAfterFourRowsAdded[3]).toHaveTextContent('15m')
+    expect(observationIntervalLabelsAfterFourRowsAdded[0]).toHaveTextContent('0.0m')
+    expect(observationIntervalLabelsAfterFourRowsAdded[1]).toHaveTextContent('5.0m')
+    expect(observationIntervalLabelsAfterFourRowsAdded[2]).toHaveTextContent('10.0m')
+    expect(observationIntervalLabelsAfterFourRowsAdded[3]).toHaveTextContent('15.0m')
   })
 
   // delete the first observation, the intervals should recalculate
@@ -122,9 +122,9 @@ test('Benthic PIT observations: intervals recalculate when user deletes an obser
   const observationIntervalLabelsAfterObservationDelete =
     within(observationsSection).getAllByLabelText('Interval')
 
-  expect(observationIntervalLabelsAfterObservationDelete[0]).toHaveTextContent('0m')
-  expect(observationIntervalLabelsAfterObservationDelete[1]).toHaveTextContent('5m')
-  expect(observationIntervalLabelsAfterObservationDelete[2]).toHaveTextContent('10m')
+  expect(observationIntervalLabelsAfterObservationDelete[0]).toHaveTextContent('0.0m')
+  expect(observationIntervalLabelsAfterObservationDelete[1]).toHaveTextContent('5.0m')
+  expect(observationIntervalLabelsAfterObservationDelete[2]).toHaveTextContent('10.0m')
   expect(observationIntervalLabelsAfterObservationDelete[3]).toBeUndefined()
 })
 
@@ -157,10 +157,10 @@ test('Benthic Pit observations: intervals reclaculate when a user inserts a row 
     const observationIntervalLabelsAfterFourRowsAdded =
       within(observationsSection).getAllByLabelText('Interval')
 
-    expect(observationIntervalLabelsAfterFourRowsAdded[0]).toHaveTextContent('0m')
-    expect(observationIntervalLabelsAfterFourRowsAdded[1]).toHaveTextContent('5m')
-    expect(observationIntervalLabelsAfterFourRowsAdded[2]).toHaveTextContent('10m')
-    expect(observationIntervalLabelsAfterFourRowsAdded[3]).toHaveTextContent('15m')
+    expect(observationIntervalLabelsAfterFourRowsAdded[0]).toHaveTextContent('0.0m')
+    expect(observationIntervalLabelsAfterFourRowsAdded[1]).toHaveTextContent('5.0m')
+    expect(observationIntervalLabelsAfterFourRowsAdded[2]).toHaveTextContent('10.0m')
+    expect(observationIntervalLabelsAfterFourRowsAdded[3]).toHaveTextContent('15.0m')
     expect(observationIntervalLabelsAfterFourRowsAdded[4]).toBeUndefined()
   })
 
@@ -174,10 +174,10 @@ test('Benthic Pit observations: intervals reclaculate when a user inserts a row 
     const observationIntervalLabelsAfterEnterKey =
       within(observationsSection).getAllByLabelText('Interval')
 
-    expect(observationIntervalLabelsAfterEnterKey[0]).toHaveTextContent('0m')
-    expect(observationIntervalLabelsAfterEnterKey[1]).toHaveTextContent('5m')
-    expect(observationIntervalLabelsAfterEnterKey[2]).toHaveTextContent('10m')
-    expect(observationIntervalLabelsAfterEnterKey[3]).toHaveTextContent('15m')
-    expect(observationIntervalLabelsAfterEnterKey[4]).toHaveTextContent('20m')
+    expect(observationIntervalLabelsAfterEnterKey[0]).toHaveTextContent('0.0m')
+    expect(observationIntervalLabelsAfterEnterKey[1]).toHaveTextContent('5.0m')
+    expect(observationIntervalLabelsAfterEnterKey[2]).toHaveTextContent('10.0m')
+    expect(observationIntervalLabelsAfterEnterKey[3]).toHaveTextContent('15.0m')
+    expect(observationIntervalLabelsAfterEnterKey[4]).toHaveTextContent('20.0m')
   })
 })

--- a/src/App/integrationTests/collectRecords/benthicPit/App.updateBenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.updateBenthicPit.test.js
@@ -109,7 +109,7 @@ describe('Offline', () => {
     const newObservation = updatedCollectRecord.data.obs_benthic_pits[3]
 
     expect(newObservation.attribute).toEqual('fcf25ee3-701b-4d15-9a17-71f40406db4c')
-    expect(newObservation.interval).toEqual(6)
+    expect(newObservation.interval).toEqual('6.0')
     expect(newObservation.growth_form).toEqual('cbff6080-6387-44e5-b7ad-35f35f3db3a7')
   })
   test('Edit Benthic PIT save failure shows toast message with new edits persisting', async () => {

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/benthicPitObservationReducer.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/benthicPitObservationReducer.js
@@ -17,8 +17,8 @@ const benthicPitObservationReducer = (state, action) => {
     observations.forEach((observation, index) => {
       const previousObservation = recalculatedObservations[index - 1]
       const interval = !previousObservation
-        ? intervalStartToUse
-        : previousObservation.interval + intervalSize
+        ? Number(intervalStartToUse).toFixed(1)
+        : (Number(previousObservation.interval) + Number(intervalSize)).toFixed(1)
 
       recalculatedObservations.push({ ...observation, interval })
     })


### PR DESCRIPTION
Steps to test:
- Create a new benthic PIT sample unit.
- Set the Interval Size to 0.1
- Add some observations (can be blank, just tab through the fields)

Expected:
Interval column starts at Interval Start and increases by Interval Size value. In this case 0.1
0.1
0.2
0.3
0.4
0.5


JS wont support giant numbers, but I tested this with the earth's circumference in meters (40070000) with an added decimal  and numbers of similar magnitude (a few orders higher) and it works.

I initially coded the interval size input to not allow more than one decimal place but it opened a can of worms and also made for some strange ux when typing. So the user can type a ton of decimal places, but the observation interval will only show one decimal place (confirmed with Kim that that only one decimal place is what the front end shoudl have). 

Tradeoff is that one decimal place will always be showing now (to keep the code not expensive)
...
[ticket](https://trello.com/c/YUwyRKZD/985-rounding-error-javascript-floating-point)