### PR TITLE
Melissa/982 disallow cr transfer to read only user

### DIFF
--- a/src/App/currentUserProfileHelpers.js
+++ b/src/App/currentUserProfileHelpers.js
@@ -123,10 +123,12 @@ export const getProjectRole = (userProfile, projectId) => {
   return userProfile?.projects?.find(({ id: idToCheck }) => idToCheck === projectId)?.role
 }
 
-export const getIsReadOnlyUserRole = (userProfile, projectId) => {
+export const getIsUserReadOnlyForProject = (userProfile, projectId) => {
   return getProjectRole(userProfile, projectId) === userRole.read_only
 }
 
-export const getIsAdminUserRole = (userProfile, projectId) => {
+export const getIsProjectProfileReadOnly = (profile) => profile.role === userRole.read_only
+
+export const getIsUserAdminForProject = (userProfile, projectId) => {
   return getProjectRole(userProfile, projectId) === userRole.admin
 }

--- a/src/components/NavMenu/NavMenu.js
+++ b/src/components/NavMenu/NavMenu.js
@@ -17,7 +17,7 @@ import {
   IconUsersAndTransects,
   IconManagementRegimesOverview,
 } from '../icons'
-import { getIsReadOnlyUserRole } from '../../App/currentUserProfileHelpers'
+import { getIsUserReadOnlyForProject } from '../../App/currentUserProfileHelpers'
 import OfflineHide from '../generic/OfflineHide'
 import CollectRecordsCount from '../CollectRecordsCount'
 import SubNavMenuRecordName from '../SubNavMenuRecordName'
@@ -141,7 +141,7 @@ const NavMenu = ({ subNavNode }) => {
   const isCollectingSubNode = recordId || pathname.includes('collecting')
   const isSiteSubNode = siteId || pathname.includes('sites')
   const isManagementRegimeSubNode = managementRegimeId || pathname.includes('management-regimes')
-  const isReadOnlyUser = getIsReadOnlyUserRole(currentUser, projectId)
+  const isReadOnlyUser = getIsUserReadOnlyForProject(currentUser, projectId)
 
   const handleImageError = (event) => {
     // eslint-disable-next-line no-param-reassign

--- a/src/components/ProjectCard/ProjectCard.js
+++ b/src/components/ProjectCard/ProjectCard.js
@@ -23,7 +23,7 @@ import { ButtonSecondary } from '../generic/buttons'
 import { removeTimeZoneFromDate } from '../../library/removeTimeZoneFromDate'
 import ProjectCardSummary from './ProjectCardSummary'
 import ProjectModal from './ProjectModal'
-import { getIsReadOnlyUserRole } from '../../App/currentUserProfileHelpers'
+import { getIsUserReadOnlyForProject } from '../../App/currentUserProfileHelpers'
 import { useCurrentUser } from '../../App/CurrentUserContext'
 import { useHttpResponseErrorHandler } from '../../App/HttpResponseErrorHandlerContext'
 
@@ -37,7 +37,7 @@ const ProjectCard = ({
   const { isAppOnline } = useOnlineStatus()
   const { name, countries, updated_on, id } = project
   const { currentUser } = useCurrentUser()
-  const isReadOnlyUser = getIsReadOnlyUserRole(currentUser, id)
+  const isReadOnlyUser = getIsUserReadOnlyForProject(currentUser, id)
   const { setIsSyncInProgress } = useSyncStatus()
   const history = useHistory()
   const projectUrl = `projects/${id}`

--- a/src/components/ProjectCard/ProjectCardSummary.js
+++ b/src/components/ProjectCard/ProjectCardSummary.js
@@ -16,7 +16,7 @@ import { IconCollect, IconData, IconSites, IconUsers } from '../icons'
 import { projectPropType } from '../../App/mermaidData/mermaidDataProptypes'
 import stopEventPropagation from '../../library/stopEventPropagation'
 import { useCurrentUser } from '../../App/CurrentUserContext'
-import { getIsReadOnlyUserRole } from '../../App/currentUserProfileHelpers'
+import { getIsUserReadOnlyForProject } from '../../App/currentUserProfileHelpers'
 import language from '../../language'
 
 const ProjectCardSummary = ({ project, isAppOnline }) => {
@@ -32,7 +32,7 @@ const ProjectCardSummary = ({ project, isAppOnline }) => {
     id,
   } = project
 
-  const isReadOnlyUser = getIsReadOnlyUserRole(currentUser, id)
+  const isReadOnlyUser = getIsUserReadOnlyForProject(currentUser, id)
   const projectUrl = `projects/${id}`
 
   const userCollectCount = useMemo(() => {
@@ -84,7 +84,11 @@ const ProjectCardSummary = ({ project, isAppOnline }) => {
   )
 
   const submittedCardOnline = (
-    <SummaryCard to={`${projectUrl}/submitted`} aria-label="Submitted" onClick={stopEventPropagation}>
+    <SummaryCard
+      to={`${projectUrl}/submitted`}
+      aria-label="Submitted"
+      onClick={stopEventPropagation}
+    >
       <SubCardTitle>Submitted</SubCardTitle>
       <SubCardIconAndCount>
         <IconData />

--- a/src/components/TransferSampleUnitsModal/TransferSampleUnitsModal.js
+++ b/src/components/TransferSampleUnitsModal/TransferSampleUnitsModal.js
@@ -12,6 +12,7 @@ import Modal, { RightFooter } from '../generic/Modal/Modal'
 import { pluralize } from '../../library/strings/pluralize'
 import { getProfileNameOrEmailForPendingUser } from '../../library/getProfileNameOrEmailForPendingUser'
 import theme from '../../theme'
+import { getIsProjectProfileReadOnly } from '../../App/currentUserProfileHelpers'
 
 const ModalBoxItem = styled(Column)`
   width: 100%;
@@ -57,7 +58,12 @@ const TransferSampleUnitsModal = ({
   }, [fromUser, currentUserId])
 
   const optionList = userOptions
-    .filter(({ profile }) => profile !== fromUser.profile)
+    .filter((projectProfile) => {
+      const isProjectProfileReadOnly = getIsProjectProfileReadOnly(projectProfile)
+      const isProjectProfileCurrentUser = projectProfile.profile === fromUser.profile
+
+      return !isProjectProfileCurrentUser && !isProjectProfileReadOnly
+    })
     .map((user) => {
       const profileName = getProfileNameOrEmailForPendingUser(user)
 

--- a/src/components/pages/Collect/Collect.js
+++ b/src/components/pages/Collect/Collect.js
@@ -41,7 +41,7 @@ import {
   getIsQuadratSampleUnit,
   noLabelSymbol,
 } from '../../../App/mermaidData/recordProtocolHelpers'
-import { getIsReadOnlyUserRole } from '../../../App/currentUserProfileHelpers'
+import { getIsUserReadOnlyForProject } from '../../../App/currentUserProfileHelpers'
 import { PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
 
 const Collect = () => {
@@ -54,7 +54,7 @@ const Collect = () => {
   const { currentUser } = useCurrentUser()
   const isMounted = useIsMounted()
   const handleHttpResponseError = useHttpResponseErrorHandler()
-  const isReadOnlyUser = getIsReadOnlyUserRole(currentUser, projectId)
+  const isReadOnlyUser = getIsUserReadOnlyForProject(currentUser, projectId)
 
   useDocumentTitle(`${language.pages.collectTable.title} - ${language.title.mermaid}`)
 

--- a/src/components/pages/DataSharing/DataSharing.js
+++ b/src/components/pages/DataSharing/DataSharing.js
@@ -26,7 +26,7 @@ import theme from '../../../theme'
 import useDocumentTitle from '../../../library/useDocumentTitle'
 import useIsMounted from '../../../library/useIsMounted'
 import { useCurrentUser } from '../../../App/CurrentUserContext'
-import { getIsAdminUserRole } from '../../../App/currentUserProfileHelpers'
+import { getIsUserAdminForProject } from '../../../App/currentUserProfileHelpers'
 import { PROJECT_CODES } from '../../../library/constants/constants'
 
 const DataSharingTable = styled(Table)`
@@ -74,7 +74,7 @@ const DataSharing = () => {
   const { projectId } = useParams()
   const { currentUser } = useCurrentUser()
   const isMounted = useIsMounted()
-  const isAdminUser = getIsAdminUserRole(currentUser, projectId)
+  const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
   const [isDataUpdating, setIsDataUpdating] = useState(false)
 
   useDocumentTitle(`${language.pages.dataSharing.title} - ${language.title.mermaid}`)

--- a/src/components/pages/ManagementRegime/ManagementRegime.js
+++ b/src/components/pages/ManagementRegime/ManagementRegime.js
@@ -9,7 +9,10 @@ import { ContentPageLayout } from '../../Layout'
 import { ContentPageToolbarWrapper } from '../../Layout/subLayouts/ContentPageLayout/ContentPageLayout'
 import { ensureTrailingSlash } from '../../../library/strings/ensureTrailingSlash'
 import { formikPropType } from '../../../library/formikPropType'
-import { getIsReadOnlyUserRole, getIsAdminUserRole } from '../../../App/currentUserProfileHelpers'
+import {
+  getIsUserReadOnlyForProject,
+  getIsUserAdminForProject,
+} from '../../../App/currentUserProfileHelpers'
 import { getManagementRegimeInitialValues } from './managementRegimeFormInitialValues'
 import { getOptions } from '../../../library/getOptions'
 import { getToastArguments } from '../../../library/getToastArguments'
@@ -214,8 +217,8 @@ const ManagementRegime = ({ isNewManagementRegime }) => {
     setIsDeleteRecordModalOpen(false)
   }
 
-  const isReadOnlyUser = getIsReadOnlyUserRole(currentUser, projectId)
-  const isAdminUser = getIsAdminUserRole(currentUser, projectId)
+  const isReadOnlyUser = getIsUserReadOnlyForProject(currentUser, projectId)
+  const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
 
   const _getSupportingData = useEffect(() => {
     if (databaseSwitchboardInstance && !isSyncInProgress) {

--- a/src/components/pages/ManagementRegimes/ManagementRegimes.js
+++ b/src/components/pages/ManagementRegimes/ManagementRegimes.js
@@ -45,7 +45,7 @@ import useDocumentTitle from '../../../library/useDocumentTitle'
 import usePersistUserTablePreferences from '../../generic/Table/usePersistUserTablePreferences'
 import useIsMounted from '../../../library/useIsMounted'
 import PageUnavailable from '../PageUnavailable'
-import { getIsReadOnlyUserRole } from '../../../App/currentUserProfileHelpers'
+import { getIsUserReadOnlyForProject } from '../../../App/currentUserProfileHelpers'
 import { useOnlineStatus } from '../../../library/onlineStatusContext'
 import { getFileExportName } from '../../../library/getFileExportName'
 import { PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
@@ -67,7 +67,7 @@ const ManagementRegimes = () => {
   const [isLoading, setIsLoading] = useState(true)
   const [managementRegimeExportName, setManagementRegimeExportName] = useState('')
   const [managementRegimeRecordsForUiDisplay, setManagementRegimeRecordsForUiDisplay] = useState([])
-  const isReadOnlyUser = getIsReadOnlyUserRole(currentUser, projectId)
+  const isReadOnlyUser = getIsUserReadOnlyForProject(currentUser, projectId)
   const closeCopyManagementRegimesModal = () => setIsCopyManagementRegimesModalOpen(false)
   const openCopyManagementRegimesModal = () => setIsCopyManagementRegimesModalOpen(true)
 

--- a/src/components/pages/ProjectInfo/ProjectInfo.js
+++ b/src/components/pages/ProjectInfo/ProjectInfo.js
@@ -33,7 +33,7 @@ import useDocumentTitle from '../../../library/useDocumentTitle'
 import SaveButton from '../../generic/SaveButton'
 import LoadingModal from '../../LoadingModal/LoadingModal'
 import { useCurrentUser } from '../../../App/CurrentUserContext'
-import { getIsAdminUserRole } from '../../../App/currentUserProfileHelpers'
+import { getIsUserAdminForProject } from '../../../App/currentUserProfileHelpers'
 import { useHttpResponseErrorHandler } from '../../../App/HttpResponseErrorHandlerContext'
 
 const SuggestNewOrganizationButton = styled(ButtonThatLooksLikeLink)`
@@ -162,7 +162,7 @@ const ProjectInfo = () => {
   const { currentUser } = useCurrentUser()
   const isMounted = useIsMounted()
   const handleHttpResponseError = useHttpResponseErrorHandler()
-  const isAdminUser = getIsAdminUserRole(currentUser, projectId)
+  const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
   const [projectNameError, setProjectNameError] = useState(false)
 
   useDocumentTitle(`${language.pages.projectInfo.title} - ${language.title.mermaid}`)

--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -9,7 +9,10 @@ import { ContentPageLayout } from '../../Layout'
 import { ContentPageToolbarWrapper } from '../../Layout/subLayouts/ContentPageLayout/ContentPageLayout'
 import { ensureTrailingSlash } from '../../../library/strings/ensureTrailingSlash'
 import { formikPropType } from '../../../library/formikPropType'
-import { getIsReadOnlyUserRole, getIsAdminUserRole } from '../../../App/currentUserProfileHelpers'
+import {
+  getIsUserReadOnlyForProject,
+  getIsUserAdminForProject,
+} from '../../../App/currentUserProfileHelpers'
 import { getOptions } from '../../../library/getOptions'
 import { getSiteInitialValues } from './siteRecordFormInitialValues'
 import { getToastArguments } from '../../../library/getToastArguments'
@@ -242,8 +245,8 @@ const Site = ({ isNewSite }) => {
     setIsDeleteRecordModalOpen(false)
   }
 
-  const isReadOnlyUser = getIsReadOnlyUserRole(currentUser, projectId)
-  const isAdminUser = getIsAdminUserRole(currentUser, projectId)
+  const isReadOnlyUser = getIsUserReadOnlyForProject(currentUser, projectId)
+  const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
 
   const _getSupportingData = useEffect(() => {
     if (databaseSwitchboardInstance && !isSyncInProgress) {

--- a/src/components/pages/Sites/Sites.js
+++ b/src/components/pages/Sites/Sites.js
@@ -7,7 +7,7 @@ import { usePagination, useSortBy, useGlobalFilter, useTable } from 'react-table
 import { ContentPageLayout } from '../../Layout'
 import CopySitesModal from '../../CopySitesModal'
 import FilterSearchToolbar from '../../FilterSearchToolbar/FilterSearchToolbar'
-import { getIsReadOnlyUserRole } from '../../../App/currentUserProfileHelpers'
+import { getIsUserReadOnlyForProject } from '../../../App/currentUserProfileHelpers'
 import { getObjectById } from '../../../library/getObjectById'
 import { getTableColumnHeaderProps } from '../../../library/getTableColumnHeaderProps'
 import { getTableFilteredRows } from '../../../library/getTableFilteredRows'
@@ -66,7 +66,7 @@ const Sites = () => {
   const [siteExportName, setSiteExportName] = useState('')
   const [choices, setChoices] = useState({})
   const [sitesForMapMarkers, setSitesForMapMarkers] = useState([])
-  const isReadOnlyUser = getIsReadOnlyUserRole(currentUser, projectId)
+  const isReadOnlyUser = getIsUserReadOnlyForProject(currentUser, projectId)
   const [isCopySitesModalOpen, setIsCopySitesModalOpen] = useState(false)
   const openCopySitesModal = () => setIsCopySitesModalOpen(true)
   const closeCopySitesModal = () => setIsCopySitesModalOpen(false)

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -55,7 +55,10 @@ import useIsMounted from '../../../library/useIsMounted'
 import usePersistUserTablePreferences from '../../generic/Table/usePersistUserTablePreferences'
 import { userRole } from '../../../App/mermaidData/userRole'
 import { useSyncStatus } from '../../../App/mermaidData/syncApiDataIntoOfflineStorage/SyncStatusContext'
-import { getIsAdminUserRole } from '../../../App/currentUserProfileHelpers'
+import {
+  getIsUserAdminForProject,
+  getIsProjectProfileReadOnly,
+} from '../../../App/currentUserProfileHelpers'
 import { PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
 import { useHttpResponseErrorHandler } from '../../../App/HttpResponseErrorHandlerContext'
 
@@ -126,7 +129,6 @@ const getRoleLabel = (roleCode) => {
 }
 
 const getDoesUserHaveActiveSampleUnits = (profile) => profile.num_active_sample_units > 0
-const getIsUserRoleReadOnly = (profile) => profile.role === userRole.read_only
 
 const Users = () => {
   const [fromUser, setFromUser] = useState({})
@@ -152,7 +154,7 @@ const Users = () => {
   const { isAppOnline } = useOnlineStatus()
   const { projectId } = useParams()
   const { setIsSyncInProgress } = useSyncStatus()
-  const isAdminUser = getIsAdminUserRole(currentUser, projectId)
+  const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
   const isMounted = useIsMounted()
 
   const handleHttpResponseError = useHttpResponseErrorHandler()
@@ -197,7 +199,7 @@ const Users = () => {
     setIsReadonlyUserWithActiveSampleUnits(false)
     observerProfiles.forEach((profile) => {
       const userHasActiveSampleUnits = getDoesUserHaveActiveSampleUnits(profile)
-      const isUserRoleReadOnly = getIsUserRoleReadOnly(profile)
+      const isUserRoleReadOnly = getIsProjectProfileReadOnly(profile)
 
       if (userHasActiveSampleUnits && isUserRoleReadOnly) {
         setIsReadonlyUserWithActiveSampleUnits(true)
@@ -518,7 +520,7 @@ const Users = () => {
       } = profile
 
       const userHasActiveSampleUnits = getDoesUserHaveActiveSampleUnits(profile)
-      const isUserRoleReadOnly = getIsUserRoleReadOnly(profile)
+      const isUserRoleReadOnly = getIsProjectProfileReadOnly(profile)
       const isCurrentUser = userId === currentUser.id
       const isActiveSampleUnitsWarningShowing = userHasActiveSampleUnits && isUserRoleReadOnly
 

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
@@ -52,7 +52,7 @@ import { inputOptionsPropTypes } from '../../../../library/miscPropTypes'
 import IdsNotFound from '../../IdsNotFound/IdsNotFound'
 import FishBeltTransectInputs from '../FishBeltForm/FishBeltTransectInputs'
 import language from '../../../../language'
-import { getIsReadOnlyUserRole } from '../../../../App/currentUserProfileHelpers'
+import { getIsUserReadOnlyForProject } from '../../../../App/currentUserProfileHelpers'
 import PageUnavailable from '../../PageUnavailable'
 import { getIsFishBelt } from '../../../../App/mermaidData/recordProtocolHelpers'
 import { useScrollCheckError } from '../../../../library/useScrollCheckError'
@@ -114,7 +114,7 @@ const CollectRecordFormPage = ({
     setIsDeleteRecordModalOpen(false)
   }
 
-  const isReadOnlyUser = getIsReadOnlyUserRole(currentUser, projectId)
+  const isReadOnlyUser = getIsUserReadOnlyForProject(currentUser, projectId)
   const isFishBeltSampleUnit = getIsFishBelt(sampleUnitName)
   const recordLevelValidations = collectRecordBeingEdited?.validations?.results?.$record ?? []
   const validationsApiData = collectRecordBeingEdited?.validations?.results?.data ?? {}

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPageAlternative/CollectRecordFormPageAlternative.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPageAlternative/CollectRecordFormPageAlternative.js
@@ -21,7 +21,7 @@ import {
   ErrorTextSubmit,
   ErrorBoxSubmit,
 } from '../CollectingFormPage.Styles'
-import { getIsReadOnlyUserRole } from '../../../../App/currentUserProfileHelpers'
+import { getIsUserReadOnlyForProject } from '../../../../App/currentUserProfileHelpers'
 import { getObservationsPropertyNames } from '../../../../App/mermaidData/recordProtocolHelpers'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import { H2 } from '../../../generic/text'
@@ -107,7 +107,7 @@ const CollectRecordFormPageAlternative = ({
   const handleHttpResponseError = useHttpResponseErrorHandler()
   const history = useHistory()
   const isMounted = useIsMounted()
-  const isReadOnlyUser = getIsReadOnlyUserRole(currentUser, projectId)
+  const isReadOnlyUser = getIsUserReadOnlyForProject(currentUser, projectId)
   const observationTableRef = useRef(null)
 
   const handleSitesChange = (updatedSiteRecords) => setSites(updatedSiteRecords)

--- a/src/components/pages/submittedRecordPages/SubmittedBenthicLit/SubmittedBenthicLit.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBenthicLit/SubmittedBenthicLit.js
@@ -17,7 +17,7 @@ import RecordFormTitle from '../../../RecordFormTitle'
 import { RowSpaceBetween } from '../../../generic/positioning'
 import { IconPen } from '../../../icons'
 import { ButtonSecondary } from '../../../generic/buttons'
-import { getIsAdminUserRole } from '../../../../App/currentUserProfileHelpers'
+import { getIsUserAdminForProject } from '../../../../App/currentUserProfileHelpers'
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
 import useCurrentProjectPath from '../../../../library/useCurrentProjectPath'
 import { ensureTrailingSlash } from '../../../../library/strings/ensureTrailingSlash'
@@ -48,7 +48,7 @@ const SubmittedBenthicLit = () => {
   const [isMoveToButtonDisabled, setIsMoveToButtonDisabled] = useState(false)
   const [benthicAttributeOptions, setBenthicAttributeOptions] = useState([])
 
-  const isAdminUser = getIsAdminUserRole(currentUser, projectId)
+  const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
   const observers = submittedRecord?.observers ?? []
 
   const _getSupportingData = useEffect(() => {

--- a/src/components/pages/submittedRecordPages/SubmittedBenthicPhotoQuadrat/SubmittedBenthicPhotoQuadrat.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBenthicPhotoQuadrat/SubmittedBenthicPhotoQuadrat.js
@@ -8,7 +8,7 @@ import { ensureTrailingSlash } from '../../../../library/strings/ensureTrailingS
 import { IconPen } from '../../../icons'
 import IdsNotFound from '../../IdsNotFound/IdsNotFound'
 import { getBenthicOptions } from '../../../../library/getOptions'
-import { getIsAdminUserRole } from '../../../../App/currentUserProfileHelpers'
+import { getIsUserAdminForProject } from '../../../../App/currentUserProfileHelpers'
 import { getRecordSubNavNodeInfo } from '../../../../library/getRecordSubNavNodeInfo'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import language from '../../../../language'
@@ -48,7 +48,7 @@ const SubmittedBenthicPhotoQuadrat = () => {
   const [subNavNode, setSubNavNode] = useState(null)
   const handleHttpResponseError = useHttpResponseErrorHandler()
 
-  const isAdminUser = getIsAdminUserRole(currentUser, projectId)
+  const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
   const observers = submittedRecord?.observers ?? []
 
   const _getSupportingData = useEffect(() => {

--- a/src/components/pages/submittedRecordPages/SubmittedBenthicPit/SubmittedBenthicPit.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBenthicPit/SubmittedBenthicPit.js
@@ -17,7 +17,7 @@ import RecordFormTitle from '../../../RecordFormTitle'
 import { RowSpaceBetween } from '../../../generic/positioning'
 import { IconPen } from '../../../icons'
 import { ButtonSecondary } from '../../../generic/buttons'
-import { getIsAdminUserRole } from '../../../../App/currentUserProfileHelpers'
+import { getIsUserAdminForProject } from '../../../../App/currentUserProfileHelpers'
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
 import useCurrentProjectPath from '../../../../library/useCurrentProjectPath'
 import { ensureTrailingSlash } from '../../../../library/strings/ensureTrailingSlash'
@@ -48,7 +48,7 @@ const SubmittedBenthicPit = () => {
   const [isMoveToButtonDisabled, setIsMoveToButtonDisabled] = useState(false)
   const [benthicAttributeOptions, setBenthicAttributeOptions] = useState([])
 
-  const isAdminUser = getIsAdminUserRole(currentUser, projectId)
+  const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
   const observers = submittedRecord?.observers ?? []
 
   const _getSupportingData = useEffect(() => {

--- a/src/components/pages/submittedRecordPages/SubmittedBleaching/SubmittedBleaching.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBleaching/SubmittedBleaching.js
@@ -17,7 +17,7 @@ import RecordFormTitle from '../../../RecordFormTitle'
 import { RowSpaceBetween } from '../../../generic/positioning'
 import { IconPen } from '../../../icons'
 import { ButtonSecondary } from '../../../generic/buttons'
-import { getIsAdminUserRole } from '../../../../App/currentUserProfileHelpers'
+import { getIsUserAdminForProject } from '../../../../App/currentUserProfileHelpers'
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
 import useCurrentProjectPath from '../../../../library/useCurrentProjectPath'
 import { ensureTrailingSlash } from '../../../../library/strings/ensureTrailingSlash'
@@ -49,7 +49,7 @@ const SubmittedBleaching = () => {
   const [isMoveToButtonDisabled, setIsMoveToButtonDisabled] = useState(false)
   const [benthicAttributeOptions, setBenthicAttributeOptions] = useState([])
 
-  const isAdminUser = getIsAdminUserRole(currentUser, projectId)
+  const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
   const observers = submittedRecord?.observers ?? []
 
   const _getSupportingData = useEffect(() => {

--- a/src/components/pages/submittedRecordPages/SubmittedHabitatComplexity/SubmittedHabitatComplexity.js
+++ b/src/components/pages/submittedRecordPages/SubmittedHabitatComplexity/SubmittedHabitatComplexity.js
@@ -17,7 +17,7 @@ import RecordFormTitle from '../../../RecordFormTitle'
 import { RowSpaceBetween } from '../../../generic/positioning'
 import { IconPen } from '../../../icons'
 import { ButtonSecondary } from '../../../generic/buttons'
-import { getIsAdminUserRole } from '../../../../App/currentUserProfileHelpers'
+import { getIsUserAdminForProject } from '../../../../App/currentUserProfileHelpers'
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
 import useCurrentProjectPath from '../../../../library/useCurrentProjectPath'
 import { ensureTrailingSlash } from '../../../../library/strings/ensureTrailingSlash'
@@ -48,7 +48,7 @@ const SubmittedHabitatComplexity = () => {
   const [isMoveToButtonDisabled, setIsMoveToButtonDisabled] = useState(false)
   const [benthicAttributeOptions, setBenthicAttributeOptions] = useState([])
 
-  const isAdminUser = getIsAdminUserRole(currentUser, projectId)
+  const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
   const observers = submittedRecord?.observers ?? []
 
   const _getSupportingData = useEffect(() => {


### PR DESCRIPTION
Description:
- most of this diff is renaming some helper functions to differentiate them from another that I am moving to the same helper file that does a similar but slightly different thing. (Everything **other than** what is in the `src/components/TransferSampleUnitsModal/TransferSampleUnitsModal.js` file
- remove read only profiles from the list of people a user can transfer CRs to in the users page (entirely in the `src/components/TransferSampleUnitsModal/TransferSampleUnitsModal.js` file


Steps to test: 
- log in as an admin for a project
- navigate to that project's users page
- click to make a user read only
- click to transfer sample units (you may need to make sample units to transfer)


Expected results:
- the list of users you can transfer CRs to should not include the current user and not include any read only users


keep testing toggling more users as read only and then back to admin or collector. 




[ticket](https://trello.com/c/0dOrnEbI/982-disallow-cr-transfer-to-read-only-user)