### PR TITLE
feat: 1032 handle push sync status codes of 500

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -50,6 +50,10 @@ function App({ dexieCurrentUserInstance }) {
     [logoutMermaid],
   )
 
+  const handleNested500SyncError = () => {
+    toast.error(...getToastArguments(language.error.pushSyncErrorMessageStatusCode500))
+  }
+
   const handleUserDeniedSyncPush = useCallback(
     (projectsWithSyncErrors) => {
       // projectsWithSyncErrors's type: { projectId: { name: string, apiDataTablesThatRejectedSyncing: string[] } }
@@ -104,6 +108,7 @@ function App({ dexieCurrentUserInstance }) {
         apiBaseUrl,
         getAccessToken,
         handleUserDeniedSyncPush,
+        handleNested500SyncError,
       })
     }
 

--- a/src/App/mermaidData/databaseSwitchboard/ProjectsMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/ProjectsMixin.js
@@ -277,7 +277,11 @@ const ProjectsMixin = (Base) =>
                 })
             }
 
-            return Promise.reject(new Error('The API status is unsuccessful'))
+            return Promise.reject(
+              new Error(
+                'the API record returned from addUser doesnt have a successful status code',
+              ),
+            )
           })
       }
 
@@ -303,12 +307,25 @@ const ProjectsMixin = (Base) =>
               ...(await getAuthorizationHeaders(this._getAccessToken)),
             },
           )
-          .then(() => {
-            return this._apiSyncInstance
-              .pushThenPullAllProjectDataExceptChoices(projectId)
-              .then(({ pullData }) => {
-                return pullData
-              })
+          .then((response) => {
+            const [recordResponseFromApiPush] = response.data.project_profiles
+            const isRecordStatusCodeSuccessful = this._isStatusCodeSuccessful(
+              recordResponseFromApiPush.status_code,
+            )
+
+            if (isRecordStatusCodeSuccessful) {
+              return this._apiSyncInstance
+                .pushThenPullAllProjectDataExceptChoices(projectId)
+                .then(({ pullData }) => {
+                  return pullData
+                })
+            }
+
+            return Promise.reject(
+              new Error(
+                'the API record returned from removeUser doesnt have a successful status code',
+              ),
+            )
           })
       }
 

--- a/src/App/mermaidData/databaseSwitchboard/tests/testHelpers.DatabseSwitchboard.js
+++ b/src/App/mermaidData/databaseSwitchboard/tests/testHelpers.DatabseSwitchboard.js
@@ -19,6 +19,7 @@ export const getDatabaseSwitchboardInstanceAuthenticatedOnlineDexieSuccess = () 
       apiBaseUrl,
       getAccessToken: getFakeAccessToken,
       handleUserDeniedSyncPush: () => {},
+      handleNested500SyncError: () => {},
     }),
     getAccessToken,
     dexiePerUserDataInstance,
@@ -47,6 +48,7 @@ export const getDatabaseSwitchboardInstanceAuthenticatedOnlineDexieError = () =>
       apiBaseUrl,
       getAccessToken: getFakeAccessToken,
       handleUserDeniedSyncPush: () => {},
+      handleNested500SyncError: () => {},
     }),
   })
 }
@@ -65,6 +67,7 @@ export const getDatabaseSwitchboardInstanceAuthenticatedOfflineDexieError = () =
       apiBaseUrl,
       getAccessToken: getFakeAccessToken,
       handleUserDeniedSyncPush: () => {},
+      handleNested500SyncError: () => {},
     }),
   })
 }
@@ -80,6 +83,7 @@ export const getDatabaseSwitchboardInstanceAuthenticatedOfflineDexieSuccess = ()
       apiBaseUrl,
       getAccessToken: getFakeAccessToken,
       handleUserDeniedSyncPush: () => {},
+      handleNested500SyncError: () => {},
     }),
     getAccessToken,
     dexiePerUserDataInstance,

--- a/src/App/mermaidData/syncApiDataIntoOfflineStorage/SyncApiDataInfoOfflineStorage.test.js
+++ b/src/App/mermaidData/syncApiDataIntoOfflineStorage/SyncApiDataInfoOfflineStorage.test.js
@@ -50,6 +50,7 @@ test('pushThenPullAllProjectDataExceptChoices keeps track of returned last_revis
     getAccessToken: getFakeAccessToken,
     dexiePerUserDataInstance,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   // initial pull from api with last revision numbers being null
@@ -103,6 +104,7 @@ test('pushThenPullAllProjectData keeps track of returned last_revision_nums and 
     getAccessToken: getFakeAccessToken,
     dexiePerUserDataInstance,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   // initial pull from api with last revision numbers being null
@@ -152,6 +154,7 @@ test('pushThenPullEverything keeps track of returned last_revision_nums and send
     getAccessToken: getFakeAccessToken,
     dexiePerUserDataInstance,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   // initial pull from api with last revision numbers being null
@@ -169,6 +172,7 @@ test('pushThenPullAllProjectDataExceptChoices updates IDB with API data', async 
     getAccessToken: getFakeAccessToken,
     dexiePerUserDataInstance,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   const apiDataNamesToPullNonProject = [
@@ -343,6 +347,7 @@ test('pushThenPullAllProjectData updates IDB with API data', async () => {
     getAccessToken: getFakeAccessToken,
     dexiePerUserDataInstance,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   const apiDataNamesToPullNonProject = [
@@ -532,6 +537,7 @@ test('pushThenPullEverything updates IDB with API data', async () => {
     getAccessToken: getFakeAccessToken,
     dexiePerUserDataInstance,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   const apiDataNamesToPullNonProject = [
@@ -703,6 +709,7 @@ test('pushChanges includes the force flag', async () => {
     getAccessToken: getFakeAccessToken,
     dexiePerUserDataInstance,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   mockMermaidApiAllSuccessful.use(
@@ -771,6 +778,7 @@ test('pushChanges includes the expected modified data', async () => {
     getAccessToken: getFakeAccessToken,
     dexiePerUserDataInstance,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   mockMermaidApiAllSuccessful.use(
@@ -828,8 +836,8 @@ test('All of the push functions handle sync errors with the handleUserDeniedSync
     apiBaseUrl: process.env.REACT_APP_MERMAID_API,
     getAccessToken: getFakeAccessToken,
     dexiePerUserDataInstance,
-
     handleUserDeniedSyncPush: pushSyncErrorCallback,
+    handleNested500SyncError: () => {},
   })
 
   await apiSync.pushChanges()

--- a/src/components/pages/Projects/Projects.test.js
+++ b/src/components/pages/Projects/Projects.test.js
@@ -22,6 +22,7 @@ test('Projects component renders with the expected UI elements', async () => {
     apiBaseUrl: process.env.REACT_APP_MERMAID_API,
     getAccessToken: getFakeAccessToken,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
@@ -67,6 +68,7 @@ test('A project card renders with the expected UI elements for button groups', a
     apiBaseUrl: process.env.REACT_APP_MERMAID_API,
     getAccessToken: getFakeAccessToken,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
@@ -104,6 +106,7 @@ test('A project card shows relevant data for a project', async () => {
     apiBaseUrl: process.env.REACT_APP_MERMAID_API,
     getAccessToken: getFakeAccessToken,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
@@ -160,6 +163,7 @@ test('A project card renders appropriately when offline', async () => {
     apiBaseUrl: process.env.REACT_APP_MERMAID_API,
     getAccessToken: getFakeAccessToken,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   renderAuthenticatedOffline(<Projects apiSyncInstance={apiSyncInstance} />, {
@@ -203,6 +207,7 @@ test('A project card renders appropriately when online', async () => {
     apiBaseUrl: process.env.REACT_APP_MERMAID_API,
     getAccessToken: getFakeAccessToken,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   renderAuthenticatedOnline(<Projects apiSyncInstance={apiSyncInstance} />, {
@@ -249,6 +254,7 @@ test('Hide new project button in project toolbar when offline', async () => {
     apiBaseUrl: process.env.REACT_APP_MERMAID_API,
     getAccessToken: getFakeAccessToken,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   renderAuthenticatedOffline(<Projects apiSyncInstance={apiSyncInstance} />, {
@@ -275,6 +281,7 @@ test('Projects can be sorted by countries', async () => {
     apiBaseUrl: process.env.REACT_APP_MERMAID_API,
     getAccessToken: getFakeAccessToken,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   renderAuthenticatedOnline(<Projects apiSyncInstance={apiSyncInstance} />, {
@@ -306,6 +313,7 @@ test('Projects can be sorted by number of sites', async () => {
     apiBaseUrl: process.env.REACT_APP_MERMAID_API,
     getAccessToken: getFakeAccessToken,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   renderAuthenticatedOnline(<Projects apiSyncInstance={apiSyncInstance} />, {
@@ -337,6 +345,7 @@ test('Projects can be sorted by updated on date', async () => {
     apiBaseUrl: process.env.REACT_APP_MERMAID_API,
     getAccessToken: getFakeAccessToken,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   renderAuthenticatedOnline(<Projects apiSyncInstance={apiSyncInstance} />, {
@@ -368,6 +377,7 @@ test('Project sorted descending', async () => {
     apiBaseUrl: process.env.REACT_APP_MERMAID_API,
     getAccessToken: getFakeAccessToken,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   renderAuthenticatedOnline(<Projects apiSyncInstance={apiSyncInstance} />, {
@@ -398,6 +408,7 @@ test('Project filter filters by name and country', async () => {
     apiBaseUrl: process.env.REACT_APP_MERMAID_API,
     getAccessToken: getFakeAccessToken,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   renderAuthenticatedOnline(<Projects apiSyncInstance={apiSyncInstance} />, {
@@ -438,6 +449,7 @@ test('Project filter can accomodate words containing apostrophes', async () => {
     apiBaseUrl: process.env.REACT_APP_MERMAID_API,
     getAccessToken: getFakeAccessToken,
     handleUserDeniedSyncPush: () => {},
+    handleNested500SyncError: () => {},
   })
 
   renderAuthenticatedOnline(<Projects apiSyncInstance={apiSyncInstance} />, {

--- a/src/language.js
+++ b/src/language.js
@@ -31,7 +31,7 @@ const error = {
   503: 'MERMAID error: please contact support@datamermaid.org',
   apiDataSync: 'MERMAID was not able to sync data.',
   appNotAuthenticatedOrReady:
-    'MERMAID did not load correclty. Try loggin out and then logging back in.',
+    'MERMAID did not load correctly. Try logging out and then logging back in.',
   collectRecordSupportingDataUnavailable:
     'Supporting data for creating a sample unit is currently unavailable.',
   collectRecordDelete: 'The sample unit has not been deleted.',
@@ -93,21 +93,14 @@ const error = {
     `The Project ${projectName}, may not be ready to be used offline.`,
   getProjectTurnOffOfflineReadyFailure: (projectName) =>
     `The Project ${projectName}, has not been removed from being offline-ready.`,
-  getPullSyncErrorMessage: (projectName) => (
-    <>
-      You do not have permission to read data from <strong>{projectName}</strong>. Please check your
-      notifications and consult with a project administrator.
-    </>
-  ),
   getPushSyncErrorMessage: (projectName) => (
     <>
       You do not have permission to sync data to <strong>{projectName}</strong>. Please check your
       notifications and consult with a project administrator about your project role.
     </>
   ),
-
   pushSyncErrorMessageUnsavedData: 'The following have not been saved: ',
-
+  pushSyncErrorMessageStatusCode500: 'MERMAID sync error: please contact support@datamermaid.org',
   getUserRoleChangeFailureMessage: (userName) => `${userName}'s role has not been changed.`,
   pageUnavailableOffline: 'This page is unavailable offline.',
   pageNotFound: 'This page cannot be found.',

--- a/src/testUtilities/mockOnlineDatabaseSwitchboardInstance.js
+++ b/src/testUtilities/mockOnlineDatabaseSwitchboardInstance.js
@@ -23,6 +23,7 @@ const getMockOnlineDatabaseSwitchboardInstance = ({ dexiePerUserDataInstance }) 
       apiBaseUrl,
       getAccessToken: getFakeAccessToken,
       handleUserDeniedSyncPush: () => {},
+      handleNested500SyncError: () => {},
     }),
     isOfflineStorageHydrated: true,
   })
@@ -45,6 +46,7 @@ const getMockOfflineDatabaseSwitchboardInstance = ({ dexiePerUserDataInstance })
       apiBaseUrl,
       getAccessToken: getFakeAccessToken,
       handleUserDeniedSyncPush: () => {},
+      handleNested500SyncError: () => {},
     }),
     isOfflineStorageHydrated: true,
   })


### PR DESCRIPTION
Description:

This is to handle push sync error codes of 500. Will only show on project-specific pages.

It was discovered in [this ticket,](https://trello.com/c/87bMaBfN/1032-cant-add-or-remove-a-user-front-end-and-back-end-bug) so I am using that ticket for the branch number. Edit: I am creating a[ new ticket](https://trello.com/c/xGx7JS44/1035-handle-sync-push-500-status-codes) for this to make life easier for whoever QA's this and to preserve the potential back end bug that is the in the previous ticket


Steps to reproduce:
1. add the mocked response below to a network mocking extension like Mokku for the push endpoint
1. reload the app on the projects list page
1. navigate to a project specific page

Expected results:
~~- on the project list page, there should be no toast showing~~
- on a project specific page, a toast with 'MERMAID sync error: please contact support@datamermaid.org' will show (it doesnt care which project the 500 is being generated from for now)
- Same for the projects list page (when this error occurs, its likely to do with code, than with a specific project configuration)


Mock push response (eg `http://localhost:8080/v1/push/`)
```
{
	"benthic_attributes": [{
			"status_code": 500,
			"message": "Server error",
			"data": {
				"name": ""
			}
		},{
			"status_code": 500,
			"message": "Server error",
			"data": {
				"name": ""
			}
		}],


	"project_profiles": [
		{
			"status_code": 500,
			"message": "Server error",
			"data": {
				"name": ""
			}
		}
	]
}
```

