### PR TITLE
Nick/M1033 Sites sub-card on the project card improvement

### DIFF
--- a/src/components/ProjectCard/ProjectCardSummary.js
+++ b/src/components/ProjectCard/ProjectCardSummary.js
@@ -84,7 +84,11 @@ const ProjectCardSummary = ({ project, isAppOnline }) => {
   )
 
   const submittedCardOnline = (
-    <SummaryCard to={`${projectUrl}/submitted`} aria-label="Submitted" onClick={stopEventPropagation}>
+    <SummaryCard
+      to={`${projectUrl}/submitted`}
+      aria-label="Submitted"
+      onClick={stopEventPropagation}
+    >
       <SubCardTitle>Submitted</SubCardTitle>
       <SubCardIconAndCount>
         <IconData />
@@ -168,7 +172,7 @@ const ProjectCardSummary = ({ project, isAppOnline }) => {
     <SummaryCardGroup>
       {isReadOnlyUser ? readOnlyCollectingCard : collectingCard}
       {isAppOnline ? submittedCardOnline : submittedCardOffline}
-      {isAppOnline ? sitesCardOnline : sitesCardOffline}
+      {isAppOnline || !isReadOnlyUser ? sitesCardOnline : sitesCardOffline}
       {isAppOnline ? usersCardOnline : usersCardOffline}
       {isAppOnline ? dataSharingCardOnline : dataSharingCardOffline}
     </SummaryCardGroup>

--- a/src/components/pages/Projects/Projects.test.js
+++ b/src/components/pages/Projects/Projects.test.js
@@ -180,12 +180,12 @@ test('A project card renders appropriately when offline', async () => {
 
   expect(within(projectCard).getByLabelText(/collect/i)).toBeInTheDocument()
   expect(within(projectCard).getByLabelText(/submitted offline/i)).toBeInTheDocument()
-  expect(within(projectCard).getByLabelText(/sites offline/i)).toBeInTheDocument()
+  expect(within(projectCard).getByLabelText(/sites/i)).toBeInTheDocument()
   expect(within(projectCard).getByLabelText(/users offline/i)).toBeInTheDocument()
   expect(within(projectCard).getByLabelText(/data-sharing offline/i)).toBeInTheDocument()
   expect(within(collectingSummaryCard).getByText('12'))
   expect(within(submittedSummaryCard).getByText('Online Only'))
-  expect(within(sitesSummaryCard).getByText('Online Only'))
+  expect(within(sitesSummaryCard).getByText('13'))
   expect(within(usersSummaryCard).getByText('Online Only'))
   expect(within(dataSharingSummaryCard).getByText('Online Only'))
 


### PR DESCRIPTION
**Describe the bug**
On the project page, the Sites sub-card should be enabled when the user is offline and a collector or admin. 

**To reproduce**
- Be a collector or an admin on a project
- Go to the projects page
- Set that project to Offline Ready
- Go offline

**Expected behaviour**
Sites sub-card is enabled and shows the number of sites in the project. Clicking on it navigates you to the Sites page for that project.
