### PR TITLE
Melissa/1016 handle nonresponsive server

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -46,7 +46,7 @@ function App({ dexieCurrentUserInstance }) {
     dexieCurrentUserInstance,
   })
 
-  const handleHttpResponseErrorPartiallyApplied = useCallback(
+  const handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied = useCallback(
     ({ error, callback, shouldShowServerNonResponseMessage }) =>
       handleHttpResponseError({
         error,
@@ -109,7 +109,7 @@ function App({ dexieCurrentUserInstance }) {
     isMermaidAuthenticated,
     isAppOnline,
     isSyncInProgress,
-    handleHttpResponseErrorPartiallyApplied,
+    handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied,
   })
 
   const { dexiePerUserDataInstance } = useDexiePerUserDataInstance({
@@ -143,7 +143,7 @@ function App({ dexieCurrentUserInstance }) {
     dexiePerUserDataInstance,
     isMounted,
     isAppOnline,
-    handleHttpResponseError: handleHttpResponseErrorPartiallyApplied,
+    handleHttpResponseError: handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied,
     syncApiDataIntoOfflineStorage: apiSyncInstance,
   })
 
@@ -176,7 +176,7 @@ function App({ dexieCurrentUserInstance }) {
     getAccessToken,
     isMermaidAuthenticated,
     isAppOnline,
-    handleHttpResponseErrorPartiallyApplied,
+    handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied,
   })
 
   const deleteMermaidData = () => {
@@ -206,7 +206,9 @@ function App({ dexieCurrentUserInstance }) {
     <ThemeProvider theme={theme}>
       <DatabaseSwitchboardInstanceProvider value={databaseSwitchboardInstance}>
         <CurrentUserProvider value={{ currentUser, saveUserProfile }}>
-          <HttpResponseErrorHandlerProvider value={handleHttpResponseErrorPartiallyApplied}>
+          <HttpResponseErrorHandlerProvider
+            value={handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied}
+          >
             <BellNotificationProvider value={{ notifications, deleteNotification }}>
               <GlobalStyle />
               <CustomToastContainer limit={5} />

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -35,7 +35,7 @@ import useIsMounted from '../library/useIsMounted'
 import { getProjectIdFromLocation } from '../library/getProjectIdFromLocation'
 
 function App({ dexieCurrentUserInstance }) {
-  const { isAppOnline } = useOnlineStatus()
+  const { isAppOnline, setServerNotReachable } = useOnlineStatus()
   const { isOfflineStorageHydrated, syncErrors, isSyncInProgress } = useSyncStatus()
   const apiBaseUrl = process.env.REACT_APP_MERMAID_API
   const history = useHistory()
@@ -46,9 +46,16 @@ function App({ dexieCurrentUserInstance }) {
     dexieCurrentUserInstance,
   })
 
-  const handleHttpResponseErrorWithLogoutFunction = useCallback(
-    ({ error, callback }) => handleHttpResponseError({ error, callback, logoutMermaid }),
-    [logoutMermaid],
+  const handleHttpResponseErrorPartiallyApplied = useCallback(
+    ({ error, callback, shouldShowServerNonResponseMessage }) =>
+      handleHttpResponseError({
+        error,
+        callback,
+        logoutMermaid,
+        shouldShowServerNonResponseMessage,
+        setServerNotReachable,
+      }),
+    [logoutMermaid, setServerNotReachable],
   )
 
   const handleNested500SyncError = () => {
@@ -102,7 +109,7 @@ function App({ dexieCurrentUserInstance }) {
     isMermaidAuthenticated,
     isAppOnline,
     isSyncInProgress,
-    handleHttpResponseErrorWithLogoutFunction,
+    handleHttpResponseErrorPartiallyApplied,
   })
 
   const { dexiePerUserDataInstance } = useDexiePerUserDataInstance({
@@ -136,7 +143,7 @@ function App({ dexieCurrentUserInstance }) {
     dexiePerUserDataInstance,
     isMounted,
     isAppOnline,
-    handleHttpResponseError: handleHttpResponseErrorWithLogoutFunction,
+    handleHttpResponseError: handleHttpResponseErrorPartiallyApplied,
     syncApiDataIntoOfflineStorage: apiSyncInstance,
   })
 
@@ -169,7 +176,7 @@ function App({ dexieCurrentUserInstance }) {
     getAccessToken,
     isMermaidAuthenticated,
     isAppOnline,
-    handleHttpResponseErrorWithLogoutFunction,
+    handleHttpResponseErrorPartiallyApplied,
   })
 
   const deleteMermaidData = () => {
@@ -199,7 +206,7 @@ function App({ dexieCurrentUserInstance }) {
     <ThemeProvider theme={theme}>
       <DatabaseSwitchboardInstanceProvider value={databaseSwitchboardInstance}>
         <CurrentUserProvider value={{ currentUser, saveUserProfile }}>
-          <HttpResponseErrorHandlerProvider value={handleHttpResponseErrorWithLogoutFunction}>
+          <HttpResponseErrorHandlerProvider value={handleHttpResponseErrorPartiallyApplied}>
             <BellNotificationProvider value={{ notifications, deleteNotification }}>
               <GlobalStyle />
               <CustomToastContainer limit={5} />

--- a/src/App/bellNotificationHelpers.js
+++ b/src/App/bellNotificationHelpers.js
@@ -29,6 +29,7 @@ export const getBellNotifications = async ({
       })
       .catch((error) => {
         console.error(error.response || error)
+        throw error
       })
   }
 

--- a/src/App/useInitializeBellNotifications.js
+++ b/src/App/useInitializeBellNotifications.js
@@ -11,7 +11,7 @@ export const useInitializeBellNotifications = ({
   getAccessToken,
   isMermaidAuthenticated,
   isAppOnline,
-  handleHttpResponseErrorPartiallyApplied,
+  handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied,
 }) => {
   const location = useLocation() // Changes when the route changes. Useful for fetching notifications again
 
@@ -33,11 +33,12 @@ export const useInitializeBellNotifications = ({
           }
         })
         .catch((error) => {
-          handleHttpResponseErrorPartiallyApplied({
+          handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied({
             error,
             callback: () => {
               toast.error(...getToastArguments(language.error.notificationsUnavailable))
             },
+            shouldShowServerNonResponseMessage: false,
           })
         })
     }
@@ -63,7 +64,7 @@ export const useInitializeBellNotifications = ({
           updateNotifications()
         })
         .catch((error) => {
-          handleHttpResponseErrorPartiallyApplied({
+          handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied({
             error,
             callback: () => {
               toast.error(...getToastArguments(language.error.notificationNotDeleted))

--- a/src/App/useInitializeBellNotifications.js
+++ b/src/App/useInitializeBellNotifications.js
@@ -11,7 +11,7 @@ export const useInitializeBellNotifications = ({
   getAccessToken,
   isMermaidAuthenticated,
   isAppOnline,
-  handleHttpResponseErrorWithLogoutFunction,
+  handleHttpResponseErrorPartiallyApplied,
 }) => {
   const location = useLocation() // Changes when the route changes. Useful for fetching notifications again
 
@@ -33,7 +33,7 @@ export const useInitializeBellNotifications = ({
           }
         })
         .catch((error) => {
-          handleHttpResponseErrorWithLogoutFunction({
+          handleHttpResponseErrorPartiallyApplied({
             error,
             callback: () => {
               toast.error(...getToastArguments(language.error.notificationsUnavailable))
@@ -63,7 +63,7 @@ export const useInitializeBellNotifications = ({
           updateNotifications()
         })
         .catch((error) => {
-          handleHttpResponseErrorWithLogoutFunction({
+          handleHttpResponseErrorPartiallyApplied({
             error,
             callback: () => {
               toast.error(...getToastArguments(language.error.notificationNotDeleted))

--- a/src/App/useInitializeCurrentUser.js
+++ b/src/App/useInitializeCurrentUser.js
@@ -11,7 +11,7 @@ export const useInitializeCurrentUser = ({
   isMermaidAuthenticated,
   isAppOnline,
   isSyncInProgress,
-  handleHttpResponseErrorWithLogoutFunction,
+  handleHttpResponseErrorPartiallyApplied,
 }) => {
   const [currentUser, setCurrentUser] = useState()
 
@@ -33,7 +33,7 @@ export const useInitializeCurrentUser = ({
           }
         })
         .catch((error) => {
-          handleHttpResponseErrorWithLogoutFunction({
+          handleHttpResponseErrorPartiallyApplied({
             error,
             callback: () => {
               toast.error(...getToastArguments(language.error.userProfileUnavailable))
@@ -52,7 +52,7 @@ export const useInitializeCurrentUser = ({
     isMermaidAuthenticated,
     isAppOnline,
     isSyncInProgress,
-    handleHttpResponseErrorWithLogoutFunction,
+    handleHttpResponseErrorPartiallyApplied,
   ])
 
   const saveUserProfile = (userProfile) => {

--- a/src/App/useInitializeCurrentUser.js
+++ b/src/App/useInitializeCurrentUser.js
@@ -11,7 +11,7 @@ export const useInitializeCurrentUser = ({
   isMermaidAuthenticated,
   isAppOnline,
   isSyncInProgress,
-  handleHttpResponseErrorPartiallyApplied,
+  handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied,
 }) => {
   const [currentUser, setCurrentUser] = useState()
 
@@ -33,7 +33,7 @@ export const useInitializeCurrentUser = ({
           }
         })
         .catch((error) => {
-          handleHttpResponseErrorPartiallyApplied({
+          handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied({
             error,
             callback: () => {
               toast.error(...getToastArguments(language.error.userProfileUnavailable))
@@ -52,7 +52,7 @@ export const useInitializeCurrentUser = ({
     isMermaidAuthenticated,
     isAppOnline,
     isSyncInProgress,
-    handleHttpResponseErrorPartiallyApplied,
+    handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied,
   ])
 
   const saveUserProfile = (userProfile) => {
@@ -68,8 +68,12 @@ export const useInitializeCurrentUser = ({
         .then((user) => {
           setCurrentUser(user)
         })
-        .catch(() => {
-          toast.error(...getToastArguments(language.error.userProfileUnavailable))
+        .catch((error) => {
+          handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied({
+            error,
+            callback: () =>
+              toast.error(...getToastArguments(language.error.userProfileUnavailable)),
+          })
         })
     }
   }

--- a/src/components/CopySitesModal/CopySitesModal.js
+++ b/src/components/CopySitesModal/CopySitesModal.js
@@ -36,6 +36,7 @@ import { splitSearchQueryStrings } from '../../library/splitSearchQueryStrings'
 import { getTableFilteredRows } from '../../library/getTableFilteredRows'
 import CopySitesMap from '../mermaidMap/CopySitesMap'
 import LoadingIndicator from '../LoadingIndicator'
+import { useHttpResponseErrorHandler } from '../../App/HttpResponseErrorHandlerContext'
 
 const DEFAULT_PAGE_SIZE = 7
 
@@ -66,6 +67,7 @@ const CopySitesModal = ({ isOpen, onDismiss, addCopiedSitesToSiteTable }) => {
   const [isViewSelectedOnly, setIsViewSelectedOnly] = useState(false)
   const [siteRecords, setSiteRecords] = useState([])
   const [selectedRowIdsForCopy, setSelectedRowIdsForCopy] = useState([])
+  const handleHttpResponseError = useHttpResponseErrorHandler()
 
   const _getSiteRecords = useEffect(() => {
     if (!isAppOnline) {
@@ -81,11 +83,23 @@ const CopySitesModal = ({ isOpen, onDismiss, addCopiedSitesToSiteTable }) => {
             setIsModalContentLoading(false)
           }
         })
-        .catch(() => {
-          toast.error(...getToastArguments(language.error.siteRecordsUnavailable))
+        .catch((error) => {
+          handleHttpResponseError({
+            error,
+            callback: () => {
+              toast.error(...getToastArguments(language.error.siteRecordsUnavailable))
+            },
+          })
         })
     }
-  }, [databaseSwitchboardInstance, projectId, isAppOnline, isMounted, isOpen])
+  }, [
+    databaseSwitchboardInstance,
+    handleHttpResponseError,
+    isAppOnline,
+    isMounted,
+    isOpen,
+    projectId,
+  ])
 
   const tableColumns = useMemo(
     () => [

--- a/src/components/pages/DataSharing/DataSharing.js
+++ b/src/components/pages/DataSharing/DataSharing.js
@@ -28,6 +28,7 @@ import useIsMounted from '../../../library/useIsMounted'
 import { useCurrentUser } from '../../../App/CurrentUserContext'
 import { getIsUserAdminForProject } from '../../../App/currentUserProfileHelpers'
 import { PROJECT_CODES } from '../../../library/constants/constants'
+import { useHttpResponseErrorHandler } from '../../../App/HttpResponseErrorHandlerContext'
 
 const DataSharingTable = styled(Table)`
   td {
@@ -76,6 +77,7 @@ const DataSharing = () => {
   const isMounted = useIsMounted()
   const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
   const [isDataUpdating, setIsDataUpdating] = useState(false)
+  const handleHttpResponseError = useHttpResponseErrorHandler()
 
   useDocumentTitle(`${language.pages.dataSharing.title} - ${language.title.mermaid}`)
 
@@ -106,11 +108,14 @@ const DataSharing = () => {
             setIsLoading(false)
           }
         })
-        .catch(() => {
-          toast.error(...getToastArguments(language.error.projectsUnavailable))
+        .catch((error) => {
+          handleHttpResponseError({
+            error,
+            callback: toast.error(...getToastArguments(language.error.projectsUnavailable)),
+          })
         })
     }
-  }, [isAppOnline, databaseSwitchboardInstance, projectId, isMounted])
+  }, [isAppOnline, databaseSwitchboardInstance, projectId, isMounted, handleHttpResponseError])
 
   const getToastMessageForDataPolicyChange = (property, policy) => {
     switch (property) {
@@ -140,11 +145,14 @@ const DataSharing = () => {
           setProjectBeingEdited(updatedProject)
           toast.success(...getToastArguments(toastMessage))
         })
-        .catch(() => {
-          toast.error(...getToastArguments(language.error.projectSave))
+        .catch((error) => {
+          handleHttpResponseError({
+            error,
+            callback: toast.error(...getToastArguments(language.error.projectSave)),
+          })
         })
     },
-    [databaseSwitchboardInstance, projectId],
+    [databaseSwitchboardInstance, projectId, handleHttpResponseError],
   )
 
   const handleDataPolicyChange = (event, propertyToUpdate) => {

--- a/src/components/pages/Sites/Sites.js
+++ b/src/components/pages/Sites/Sites.js
@@ -50,6 +50,7 @@ import usePersistUserTablePreferences from '../../generic/Table/usePersistUserTa
 import { useSyncStatus } from '../../../App/mermaidData/syncApiDataIntoOfflineStorage/SyncStatusContext'
 import { getFileExportName } from '../../../library/getFileExportName'
 import { PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
+import { useHttpResponseErrorHandler } from '../../../App/HttpResponseErrorHandlerContext'
 
 const Sites = () => {
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
@@ -59,6 +60,7 @@ const Sites = () => {
   const isMounted = useIsMounted()
   const { isAppOnline } = useOnlineStatus()
   const { currentUser } = useCurrentUser()
+  const handleHttpResponseError = useHttpResponseErrorHandler()
 
   const [idsNotAssociatedWithData, setIdsNotAssociatedWithData] = useState([])
   const [isLoading, setIsLoading] = useState(true)
@@ -96,11 +98,16 @@ const Sites = () => {
             setIsLoading(false)
           }
         })
-        .catch(() => {
-          toast.error(...getToastArguments(language.error.siteRecordsUnavailable))
+        .catch((error) => {
+          handleHttpResponseError({
+            error,
+            callback: () => {
+              toast.error(...getToastArguments(language.error.siteRecordsUnavailable))
+            },
+          })
         })
     }
-  }, [databaseSwitchboardInstance, projectId, isSyncInProgress, isMounted])
+  }, [databaseSwitchboardInstance, projectId, isSyncInProgress, isMounted, handleHttpResponseError])
 
   const addCopiedSitesToSiteTable = (copiedSites) => {
     setSiteRecordsForUiDisplay([...siteRecordsForUiDisplay, ...copiedSites])

--- a/src/language.js
+++ b/src/language.js
@@ -119,6 +119,8 @@ const error = {
   errorBoundaryTryAgain: 'Try Again',
   disabledFishSizeBinSelect: "You can't change the fish size bin when there are observations",
   addRowUnavailable: 'You must select a fish size bin before adding any observations.',
+  noServerResponse:
+    'Unable to communicate with server. Changes saved on your computer, but not online.',
 }
 
 const success = {

--- a/src/library/handleHttpResponseError.js
+++ b/src/library/handleHttpResponseError.js
@@ -2,9 +2,26 @@ import { toast } from 'react-toastify'
 import language from '../language'
 import { getToastArguments } from './getToastArguments'
 
-const handleHttpResponseError = ({ error, callback, logoutMermaid }) => {
+const handleHttpResponseError = ({
+  error,
+  callback,
+  logoutMermaid,
+  shouldShowServerNonResponseMessage = true,
+  setServerNotReachable,
+}) => {
   if (error) {
     console.error(error)
+  }
+  const requestWasMadeWithNoResponse = error?.request && !error?.response
+
+  if (requestWasMadeWithNoResponse) {
+    if (shouldShowServerNonResponseMessage) {
+      toast.error(...getToastArguments(language.error.noServerResponse))
+    }
+
+    setServerNotReachable()
+
+    return
   }
 
   const errorStatus = error?.response?.status
@@ -34,7 +51,8 @@ const handleHttpResponseError = ({ error, callback, logoutMermaid }) => {
   }
 
   if (callback) {
-    // This allows the logic to be extended.
+    // This allows the logic to be extended in the
+    // scenario where one of the above error conditions isnt met
     // If a callback is used, the user will want to
     // consider providing a generic message as well.
     callback()

--- a/src/library/onlineStatusContext.js
+++ b/src/library/onlineStatusContext.js
@@ -57,6 +57,10 @@ const OnlineStatusProvider = ({ children, value }) => {
     setHasUserTurnedAppOffline(!hasUserTurnedAppOffline)
   }
 
+  const setServerNotReachable = () => {
+    setIsServerReachable(false)
+  }
+
   const _setIsNavigatorOnline = useEffect(() => {
     const handleOnline = () => {
       setIsNavigatorOnline(true)
@@ -82,6 +86,7 @@ const OnlineStatusProvider = ({ children, value }) => {
         isAppOnline,
         canUserOverrideOnlineStatus,
         toggleUserOnlineStatusOverride,
+        setServerNotReachable,
         ...value,
       }}
     >


### PR DESCRIPTION
[ticket](https://trello.com/c/gJ684ORe/1016-front-end-handle-when-server-doesnt-respond-to-any-request-eg-internet-cut-out)

Description:
when a http request throws an error because the server was unresponsive, show a toast and put the app into offline mode (dont show a toast if the request is a background process and not user-initiated). I also audited the app (searching all the caught promises) to make sure we are using the http handler where appropriate. 

To test (locally). 
- Run the server, run the front end.
- go to any page while the server is running
- do something (navigating to a project-related page), and while the server is computing, kill the server

Expected results:
A toast with 'Unable to communicate with server. Changes saved on your computer, but not online.' shows
The app goes into online mode

More test:
after the above, restart the server and wait a while. The app shoudl return to online mode after it pings the server (a 'health check')