### PR TITLE
Fix number inputs on observation tables

### DIFF
--- a/src/components/generic/InputNumberNoScroll/InputNumberNoScroll.js
+++ b/src/components/generic/InputNumberNoScroll/InputNumberNoScroll.js
@@ -7,7 +7,7 @@ const InputNumberNoScroll = (props) => {
 
   useStopInputScrollingIncrementNumber(textFieldRef)
 
-  return <Input type="number" {...props} ref={textFieldRef} />
+  return <Input type="text" inputmode="numeric" pattern="[0-9]*" {...props} ref={textFieldRef} />
 }
 
 InputNumberNoScroll.propTypes = {}

--- a/src/components/generic/InputNumberNoScroll/InputNumberNoScroll.js
+++ b/src/components/generic/InputNumberNoScroll/InputNumberNoScroll.js
@@ -7,7 +7,7 @@ const InputNumberNoScroll = (props) => {
 
   useStopInputScrollingIncrementNumber(textFieldRef)
 
-  return <Input type="text" inputmode="numeric" pattern="[0-9]*" {...props} ref={textFieldRef} />
+  return <Input type="number" {...props} ref={textFieldRef} />
 }
 
 InputNumberNoScroll.propTypes = {}

--- a/src/components/generic/InputNumberNumericCharctersOnly/InputNumberNumericCharactersOnly.js
+++ b/src/components/generic/InputNumberNumericCharctersOnly/InputNumberNumericCharactersOnly.js
@@ -1,0 +1,12 @@
+import React, { useRef } from 'react'
+import { Input } from '../form'
+
+const InputNumberNumericCharactersOnly = (props) => {
+  const textFieldRef = useRef()
+
+  return <Input type="text" inputmode="numeric" pattern="[0-9]*" {...props} ref={textFieldRef} />
+}
+
+InputNumberNumericCharactersOnly.propTypes = {}
+
+export default InputNumberNumericCharactersOnly

--- a/src/components/generic/InputNumberNumericCharctersOnly/index.js
+++ b/src/components/generic/InputNumberNumericCharctersOnly/index.js
@@ -1,0 +1,3 @@
+import InputNumberNumericCharactersOnly from './InputNumberNumericCharactersOnly'
+
+export default InputNumberNumericCharactersOnly

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import {
@@ -56,9 +56,12 @@ const BenthicLitObservationsTable = ({
   testId,
 }) => {
   const [observationsState, observationsDispatch] = observationsReducer
+  const [autoFocusAllowed, setAutoFocusAllowed] = useState(false)
 
   const handleAddObservation = () => {
     setAreObservationsInputsDirty(true)
+    setAutoFocusAllowed(true)
+
     observationsDispatch({ type: 'addObservation' })
   }
 
@@ -72,6 +75,7 @@ const BenthicLitObservationsTable = ({
 
       if (isTabKey && isLastRow && isLastCell) {
         event.preventDefault()
+        setAutoFocusAllowed(true)
         observationsDispatch({
           type: 'duplicateLastObservation',
           payload: { referenceObservation: observation },
@@ -81,6 +85,7 @@ const BenthicLitObservationsTable = ({
 
       if (isEnterKey) {
         event.preventDefault()
+        setAutoFocusAllowed(true)
         observationsDispatch({
           type: 'addNewObservationBelow',
           payload: {
@@ -184,6 +189,7 @@ const BenthicLitObservationsTable = ({
               <InputAutocompleteContainer>
                 <ObservationAutocomplete
                   id={`observation-${observationId}`}
+                  autoFocus={autoFocusAllowed}
                   aria-labelledby="benthic-attribute-label"
                   options={benthicAttributeSelectOptions}
                   onChange={handleBenthicAttributeChange}
@@ -250,6 +256,7 @@ const BenthicLitObservationsTable = ({
     })
   }, [
     areValidationsShowing,
+    autoFocusAllowed,
     benthicAttributeSelectOptions,
     choices,
     collectRecord,

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -156,7 +156,8 @@ const BenthicLitObservationsTable = ({
       }
 
       const handleLengthChange = (event) => {
-        const newValue = event.target.value.replace(/\D/g, '')
+        const regexNumbersOnly = new RegExp(/\D/g)
+        const newValue = event.target.value.replace(regexNumbersOnly, '')
 
         setAreObservationsInputsDirty(true)
         observationsDispatch({

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -156,8 +156,8 @@ const BenthicLitObservationsTable = ({
       }
 
       const handleLengthChange = (event) => {
-        const regexNumbersOnly = new RegExp(/\D/g)
-        const newValue = event.target.value.replace(regexNumbersOnly, '')
+        const regExNumbers = new RegExp(/\D/g)
+        const newValue = event.target.value.replace(regExNumbers, '')
 
         setAreObservationsInputsDirty(true)
         observationsDispatch({

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -26,7 +26,7 @@ import { InputWrapper, RequiredIndicator, Select } from '../../../generic/form'
 import { Tr, Td, Th } from '../../../generic/Table/table'
 import BenthicPitLitObservationSummaryStats from '../../../BenthicPitLitObservationSummaryStats/BenthicPitLitObservationSummaryStats'
 import getObservationValidationInfo from '../CollectRecordFormPageAlternative/getObservationValidationInfo'
-import InputNumberNoScroll from '../../../generic/InputNumberNoScroll'
+import InputNumberNumericCharactersOnly from '../../../generic/InputNumberNumericCharctersOnly/InputNumberNumericCharactersOnly'
 import language from '../../../../language'
 import ObservationValidationInfo from '../ObservationValidationInfo'
 import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
@@ -221,7 +221,7 @@ const BenthicLitObservationsTable = ({
             </Select>
           </Td>
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               value={length}
               aria-labelledby="length-label"
               onChange={handleLengthChange}

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import styled from 'styled-components'
 
 import {
@@ -56,12 +56,9 @@ const BenthicLitObservationsTable = ({
   testId,
 }) => {
   const [observationsState, observationsDispatch] = observationsReducer
-  const [autoFocusAllowed, setAutoFocusAllowed] = useState(false)
 
   const handleAddObservation = () => {
     setAreObservationsInputsDirty(true)
-    setAutoFocusAllowed(true)
-
     observationsDispatch({ type: 'addObservation' })
   }
 
@@ -75,7 +72,6 @@ const BenthicLitObservationsTable = ({
 
       if (isTabKey && isLastRow && isLastCell) {
         event.preventDefault()
-        setAutoFocusAllowed(true)
         observationsDispatch({
           type: 'duplicateLastObservation',
           payload: { referenceObservation: observation },
@@ -85,7 +81,6 @@ const BenthicLitObservationsTable = ({
 
       if (isEnterKey) {
         event.preventDefault()
-        setAutoFocusAllowed(true)
         observationsDispatch({
           type: 'addNewObservationBelow',
           payload: {
@@ -156,7 +151,7 @@ const BenthicLitObservationsTable = ({
       }
 
       const handleLengthChange = (event) => {
-        const newValue = event.target.value
+        const newValue = event.target.value.replace(/\D/g, '')
 
         setAreObservationsInputsDirty(true)
         observationsDispatch({
@@ -189,7 +184,6 @@ const BenthicLitObservationsTable = ({
               <InputAutocompleteContainer>
                 <ObservationAutocomplete
                   id={`observation-${observationId}`}
-                  autoFocus={autoFocusAllowed}
                   aria-labelledby="benthic-attribute-label"
                   options={benthicAttributeSelectOptions}
                   onChange={handleBenthicAttributeChange}
@@ -256,7 +250,6 @@ const BenthicLitObservationsTable = ({
     })
   }, [
     areValidationsShowing,
-    autoFocusAllowed,
     benthicAttributeSelectOptions,
     choices,
     collectRecord,

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -271,8 +271,8 @@ const BenthicPhotoQuadratObservationTable = ({
       }
 
       const handleNumberOfPointsChange = (event) => {
-        const regexNumbersOnly = new RegExp(/\D/g)
-        const newValue = event.target.value.replace(regexNumbersOnly, '')
+        const regExNumbers = new RegExp(/\D/g)
+        const newValue = event.target.value.replace(regExNumbers, '')
 
         setAreObservationsInputsDirty(true)
         observationsDispatch({

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -28,7 +28,7 @@ import { roundToOneDecimal } from '../../../../library/numbers/roundToOneDecimal
 import { summarizeArrayObjectValuesByProperty } from '../../../../library/summarizeArrayObjectValuesByProperty'
 import { Tr, Td, Th } from '../../../generic/Table/table'
 import getObservationValidationInfo from '../CollectRecordFormPageAlternative/getObservationValidationInfo'
-import InputNumberNoScroll from '../../../generic/InputNumberNoScroll/InputNumberNoScroll'
+import InputNumberNumericCharactersOnly from '../../../generic/InputNumberNumericCharctersOnly/InputNumberNumericCharactersOnly'
 import language from '../../../../language'
 import ObservationValidationInfo from '../ObservationValidationInfo'
 import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
@@ -294,7 +294,7 @@ const BenthicPhotoQuadratObservationTable = ({
         <ObservationTr key={observationId}>
           <Td align="center">{rowNumber}</Td>
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               type="number"
               autoFocus={autoFocusAllowed}
               min="0"
@@ -340,7 +340,7 @@ const BenthicPhotoQuadratObservationTable = ({
             </Select>
           </Td>
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               value={numberOfPointsOrEmptyStringToAvoidInputValueErrors}
               step="any"
               aria-labelledby="number-of-points-label"

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -271,7 +271,8 @@ const BenthicPhotoQuadratObservationTable = ({
       }
 
       const handleNumberOfPointsChange = (event) => {
-        const newValue = event.target.value.replace(/\D/g, '')
+        const regexNumbersOnly = new RegExp(/\D/g)
+        const newValue = event.target.value.replace(regexNumbersOnly, '')
 
         setAreObservationsInputsDirty(true)
         observationsDispatch({

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -271,10 +271,12 @@ const BenthicPhotoQuadratObservationTable = ({
       }
 
       const handleNumberOfPointsChange = (event) => {
+        const newValue = event.target.value.replace(/\D/g, '')
+
         setAreObservationsInputsDirty(true)
         observationsDispatch({
           type: 'updateNumberOfPoints',
-          payload: { newNumberOfPoints: event.target.value, observationId },
+          payload: { newNumberOfPoints: newValue, observationId },
         })
         resetObservationValidations({
           observationId,
@@ -338,8 +340,6 @@ const BenthicPhotoQuadratObservationTable = ({
           </Td>
           <Td align="right">
             <InputNumberNoScroll
-              type="number"
-              min="0"
               value={numberOfPointsOrEmptyStringToAvoidInputValueErrors}
               step="any"
               aria-labelledby="number-of-points-label"

--- a/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
@@ -173,7 +173,7 @@ const ColoniesBleachedObservationTable = ({
       }
 
       const handleObservationInputChange = ({ event, dispatchType }) => {
-        const newValue = event.target.value
+        const newValue = event.target.value.replace(/\D/g, '')
 
         setAreObservationsInputsDirty(true)
         observationsDispatch({

--- a/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
@@ -26,7 +26,7 @@ import { InputWrapper, RequiredIndicator, Select } from '../../../generic/form'
 import { Tr, Td, Th } from '../../../generic/Table/table'
 import BleachincColoniesBleachedSummaryStats from '../../../BleachingColoniesBleachedSummaryStats/BleachingColoniesBleachedSummaryStats'
 import getObservationValidationInfo from '../CollectRecordFormPageAlternative/getObservationValidationInfo'
-import InputNumberNoScroll from '../../../generic/InputNumberNoScroll/InputNumberNoScroll'
+import InputNumberNumericCharactersOnly from '../../../generic/InputNumberNumericCharctersOnly/InputNumberNumericCharactersOnly'
 import language from '../../../../language'
 import ObservationValidationInfo from '../ObservationValidationInfo'
 import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
@@ -237,7 +237,7 @@ const ColoniesBleachedObservationTable = ({
             </Select>
           </Td>
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               aria-labelledby="normal-label"
               value={count_normal}
               min="0"
@@ -249,7 +249,7 @@ const ColoniesBleachedObservationTable = ({
             />
           </Td>
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               aria-labelledby="pale-label"
               value={count_pale}
               min="0"
@@ -261,7 +261,7 @@ const ColoniesBleachedObservationTable = ({
             />
           </Td>
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               aria-labelledby="20-bleached-label"
               value={count_20}
               min="0"
@@ -273,7 +273,7 @@ const ColoniesBleachedObservationTable = ({
             />
           </Td>
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               aria-labelledby="50-bleached-label"
               value={count_50}
               min="0"
@@ -285,7 +285,7 @@ const ColoniesBleachedObservationTable = ({
             />
           </Td>
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               aria-labelledby="80-bleached-label"
               value={count_80}
               min="0"
@@ -297,7 +297,7 @@ const ColoniesBleachedObservationTable = ({
             />
           </Td>
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               aria-labelledby="100-bleached-label"
               value={count_100}
               min="0"
@@ -309,7 +309,7 @@ const ColoniesBleachedObservationTable = ({
             />
           </Td>
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               aria-labelledby="recently-dead-label"
               value={count_dead}
               min="0"

--- a/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
@@ -173,8 +173,8 @@ const ColoniesBleachedObservationTable = ({
       }
 
       const handleObservationInputChange = ({ event, dispatchType }) => {
-        const regexNumbersOnly = new RegExp(/\D/g)
-        const newValue = event.target.value.replace(regexNumbersOnly, '')
+        const regExNumbers = new RegExp(/\D/g)
+        const newValue = event.target.value.replace(regExNumbers, '')
 
         setAreObservationsInputsDirty(true)
         observationsDispatch({

--- a/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
@@ -173,7 +173,8 @@ const ColoniesBleachedObservationTable = ({
       }
 
       const handleObservationInputChange = ({ event, dispatchType }) => {
-        const newValue = event.target.value.replace(/\D/g, '')
+        const regexNumbersOnly = new RegExp(/\D/g)
+        const newValue = event.target.value.replace(regexNumbersOnly, '')
 
         setAreObservationsInputsDirty(true)
         observationsDispatch({

--- a/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
@@ -123,7 +123,8 @@ const PercentCoverObservationTable = ({
       }
 
       const handleObservationInputChange = ({ event, dispatchType }) => {
-        const newValue = event.target.value.replace(/\D/g, '')
+        const regexNumbersOnly = new RegExp(/\D/g)
+        const newValue = event.target.value.replace(regexNumbersOnly, '')
 
         setAreObservationsInputsDirty(true)
         observationsDispatch({

--- a/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
@@ -123,8 +123,8 @@ const PercentCoverObservationTable = ({
       }
 
       const handleObservationInputChange = ({ event, dispatchType }) => {
-        const regexNumbersOnly = new RegExp(/\D/g)
-        const newValue = event.target.value.replace(regexNumbersOnly, '')
+        const regExNumbers = new RegExp(/\D/g)
+        const newValue = event.target.value.replace(regExNumbers, '')
 
         setAreObservationsInputsDirty(true)
         observationsDispatch({

--- a/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
@@ -19,7 +19,7 @@ import { IconClose, IconPlus } from '../../../icons'
 import { InputWrapper, RequiredIndicator } from '../../../generic/form'
 import { Tr, Td, Th } from '../../../generic/Table/table'
 import getObservationValidationInfo from '../CollectRecordFormPageAlternative/getObservationValidationInfo'
-import InputNumberNoScroll from '../../../generic/InputNumberNoScroll/InputNumberNoScroll'
+import InputNumberNumericCharactersOnly from '../../../generic/InputNumberNumericCharctersOnly/InputNumberNumericCharactersOnly'
 import { getObservationsPropertyNames } from '../../../../App/mermaidData/recordProtocolHelpers'
 import BleachingPercentCoverSummaryStats from '../../../BleachingPercentCoverSummaryStats/BleachingPercentCoverSummaryStats'
 import ObservationValidationInfo from '../ObservationValidationInfo'
@@ -149,7 +149,7 @@ const PercentCoverObservationTable = ({
           <Td align="center">{quadrat_number}</Td>
 
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               aria-labelledby="hard-coral-percent-cover-label"
               value={percent_hard}
               min="0"
@@ -162,7 +162,7 @@ const PercentCoverObservationTable = ({
             />
           </Td>
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               aria-labelledby="soft-coral-percent-cover-label"
               value={percent_soft}
               min="0"
@@ -174,7 +174,7 @@ const PercentCoverObservationTable = ({
             />
           </Td>
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               aria-labelledby="microalgae-percent-cover-label"
               value={percent_algae}
               min="0"

--- a/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
@@ -123,7 +123,7 @@ const PercentCoverObservationTable = ({
       }
 
       const handleObservationInputChange = ({ event, dispatchType }) => {
-        const newValue = event.target.value
+        const newValue = event.target.value.replace(/\D/g, '')
 
         setAreObservationsInputsDirty(true)
         observationsDispatch({

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -236,7 +236,8 @@ const FishBeltObservationTable = ({
       }
 
       const handleUpdateSizeEvent = (event) => {
-        const newValue = event.target.value.replace(/\D/g, '')
+        const regexNumbersOnly = new RegExp(/\D/g)
+        const newValue = event.target.value.replace(regexNumbersOnly, '')
 
         handleUpdateSize(newValue, observationId)
       }
@@ -246,7 +247,8 @@ const FishBeltObservationTable = ({
       }
 
       const handleUpdateCount = (event) => {
-        const newValue = event.target.value.replace(/\D/g, '')
+        const regexNumbersOnly = new RegExp(/\D/g)
+        const newValue = event.target.value.replace(regexNumbersOnly, '')
 
         setAreObservationsInputsDirty(true)
         observationsDispatch({

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -236,7 +236,9 @@ const FishBeltObservationTable = ({
       }
 
       const handleUpdateSizeEvent = (event) => {
-        handleUpdateSize(event.target.value, observationId)
+        const newValue = event.target.value.replace(/\D/g, '')
+
+        handleUpdateSize(newValue, observationId)
       }
 
       const handleObservationKeyDown = (event) => {
@@ -244,10 +246,12 @@ const FishBeltObservationTable = ({
       }
 
       const handleUpdateCount = (event) => {
+        const newValue = event.target.value.replace(/\D/g, '')
+
         setAreObservationsInputsDirty(true)
         observationsDispatch({
           type: 'updateCount',
-          payload: { newCount: event.target.value, observationId },
+          payload: { newCount: newValue, observationId },
         })
         resetObservationValidations({
           observationId,
@@ -266,8 +270,6 @@ const FishBeltObservationTable = ({
 
       const sizeInput = showNumericSizeInput ? (
         <InputNumberNoScroll
-          type="number"
-          min="0"
           value={sizeOrEmptyStringToAvoidInputValueErrors}
           step="any"
           aria-labelledby="fish-size-label"
@@ -355,8 +357,6 @@ const FishBeltObservationTable = ({
           <Td align="right">{sizeInput}</Td>
           <Td align="right">
             <InputNumberNoScroll
-              type="number"
-              min="0"
               value={countOrEmptyStringToAvoidInputValueErrors}
               step="any"
               aria-labelledby="fish-count-label"

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -236,8 +236,8 @@ const FishBeltObservationTable = ({
       }
 
       const handleUpdateSizeEvent = (event) => {
-        const regexNumbersOnly = new RegExp(/\D/g)
-        const newValue = event.target.value.replace(regexNumbersOnly, '')
+        const regExNumbers = new RegExp(/\D/g)
+        const newValue = event.target.value.replace(regExNumbers, '')
 
         handleUpdateSize(newValue, observationId)
       }
@@ -247,8 +247,8 @@ const FishBeltObservationTable = ({
       }
 
       const handleUpdateCount = (event) => {
-        const regexNumbersOnly = new RegExp(/\D/g)
-        const newValue = event.target.value.replace(regexNumbersOnly, '')
+        const regExNumbers = new RegExp(/\D/g)
+        const newValue = event.target.value.replace(regExNumbers, '')
 
         setAreObservationsInputsDirty(true)
         observationsDispatch({

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -21,7 +21,7 @@ import { roundToOneDecimal } from '../../../../library/numbers/roundToOneDecimal
 import { summarizeArrayObjectValuesByProperty } from '../../../../library/summarizeArrayObjectValuesByProperty'
 import { Tr, Td, Th } from '../../../generic/Table/table'
 import getValidationPropertiesForInput from '../getValidationPropertiesForInput'
-import InputNumberNoScroll from '../../../generic/InputNumberNoScroll/InputNumberNoScroll'
+import InputNumberNumericCharactersOnly from '../../../generic/InputNumberNumericCharctersOnly/InputNumberNumericCharactersOnly'
 import language from '../../../../language'
 import {
   ButtonRemoveRow,
@@ -271,7 +271,7 @@ const FishBeltObservationTable = ({
       ) : null
 
       const sizeInput = showNumericSizeInput ? (
-        <InputNumberNoScroll
+        <InputNumberNumericCharactersOnly
           value={sizeOrEmptyStringToAvoidInputValueErrors}
           step="any"
           aria-labelledby="fish-size-label"
@@ -358,7 +358,7 @@ const FishBeltObservationTable = ({
           </Td>
           <Td align="right">{sizeInput}</Td>
           <Td align="right">
-            <InputNumberNoScroll
+            <InputNumberNumericCharactersOnly
               value={countOrEmptyStringToAvoidInputValueErrors}
               step="any"
               aria-labelledby="fish-count-label"

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/tests/FishBeltObservationTable.test.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/tests/FishBeltObservationTable.test.js
@@ -20,7 +20,7 @@ const fakeCurrentUser = {
   first_name: 'FakeFirstName',
 }
 
-test('FishBelt observations size shows a numeric input when fish size bin is 1', async () => {
+test('FishBelt observations size shows a numeric pattern when fish size bin is 1', async () => {
   const { dexiePerUserDataInstance } = getMockDexieInstancesAllSuccess()
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
@@ -46,10 +46,7 @@ test('FishBelt observations size shows a numeric input when fish size bin is 1',
 
   const sizeInput = await within(observationsTable).findByLabelText('Size (cm)')
 
-  // coming out as null for some reason
-  // previous: expect(sizeInput).toHaveAttribute('type', 'number')
-  // input now includes: type="text" inputmode="numeric" pattern="[0-9]*"
-  expect(sizeInput).toHaveAttribute('inputmode', 'numeric')
+  expect(sizeInput).toHaveAttribute('pattern', '[0-9]*')
 })
 
 test('FishBelt observations size shows a select input when fish size bin is 5', async () => {

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/tests/FishBeltObservationTable.test.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/tests/FishBeltObservationTable.test.js
@@ -46,7 +46,10 @@ test('FishBelt observations size shows a numeric input when fish size bin is 1',
 
   const sizeInput = await within(observationsTable).findByLabelText('Size (cm)')
 
-  expect(sizeInput).toHaveAttribute('type', 'number')
+  // coming out as null for some reason
+  // previous: expect(sizeInput).toHaveAttribute('type', 'number')
+  // input now includes: type="text" inputmode="numeric" pattern="[0-9]*"
+  expect(sizeInput).toHaveAttribute('inputmode', 'numeric')
 })
 
 test('FishBelt observations size shows a select input when fish size bin is 5', async () => {


### PR DESCRIPTION
fixes [1057](https://trello.com/c/TsgPnWPj/1057-allow-only-numbers-in-the-bleaching-su) **Allow only numbers in the Bleaching SU** & [1058](https://trello.com/c/hFsbLyp1/1058-disable-adding-minus-sign-in-the-observation-tables-for-fish-belt-benthic-lit-and-bpq) **Disable adding minus (-) sign in the observation tables for fish belt, benthic LIT, and BPQ**

main change here is that I am getting rid of `type = number` and replacing it with `<input type="text" inputmode="numeric" pattern="[0-9]*"> ` for `InputNumberNoScroll`

problems with type = number
-  includes characters such as ., -, + , and e which we don't want
- ignores `pattern="[0-9]*"`
- min/max attributes can easily be bypassed
- accessibilty: cannot be [dictated or selected when using Dragon Naturally Speaking](https://github.com/alphagov/reported-bugs/issues/34)

more info [here ](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/)and [here](https://stackoverflow.blog/2022/12/26/why-the-number-input-is-the-worst-input/)



**to test:**

try to add non-number inputs (including -, +, ., e) to the following observation tables:
1.  bleaching: colonies bleached and percentages
2. fishbelt: size and count
3. BPQ: number of points