### PR TITLE
Fix percentage calculation in bleached colonies

### DIFF
--- a/src/components/BleachingColoniesBleachedSummaryStats/BleachingColoniesBleachedSummaryStats.js
+++ b/src/components/BleachingColoniesBleachedSummaryStats/BleachingColoniesBleachedSummaryStats.js
@@ -45,7 +45,7 @@ const BleachincColoniesBleachedSummaryStats = ({ observationsColoniesBleached })
         )
       })
     } else {
-      totals = observationsColoniesBleached.map((item) => item[colonyType])
+      totals = observationsColoniesBleached.map((item) => Number(item[colonyType]))
     }
 
     return (


### PR DESCRIPTION
[trello card](https://trello.com/c/UfEi0d0T/1056-the-bleaching-summary-does-not-calculate-correctly-for-normal-and-pale)

to test:
1. add a new bleaching collect page
2. go to 1st observation table
3. add a few rows and fill in numbers
4. ensure %'s add up to 100
<img width="246" alt="Screen Shot 2023-04-12 at 3 30 56 PM" src="https://user-images.githubusercontent.com/26089140/231564838-2c311531-e0b4-4dea-b84f-3e3761d5f3a8.png">


