### PR TITLE
Add disabled number field to bleaching transect inputs + Required indicator to MR rules

### DIFF
--- a/src/components/pages/ManagementRegime/ManagementRegime.js
+++ b/src/components/pages/ManagementRegime/ManagementRegime.js
@@ -163,6 +163,7 @@ const ManagementRegimeForm = ({ formik, managementComplianceOptions, managementP
           validationType={formik.errors.rules ? 'error' : null}
           validationMessages={formik.errors.rules}
           data-testid="rules"
+          required={true}
         />
         <InputRadioWithLabelAndValidation
           label="Compliance"

--- a/src/components/pages/ManagementRulesInput/ManagementRulesInput.js
+++ b/src/components/pages/ManagementRulesInput/ManagementRulesInput.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { InputRow, CheckRadioLabel, CheckRadioWrapper } from '../../generic/form'
+import { InputRow, CheckRadioLabel, CheckRadioWrapper, RequiredIndicator } from '../../generic/form'
 import { managementRegimePropType } from '../../../App/mermaidData/mermaidDataProptypes'
 import InputValidationInfo from '../../mermaidInputs/InputValidationInfo/InputValidationInfo'
 import mermaidInputsPropTypes from '../../mermaidInputs/mermaidInputsPropTypes'
@@ -33,6 +33,7 @@ const ManagementRulesInput = ({
   label,
   managementFormValues,
   onChange,
+  required,
   validationMessages,
   validationType,
   ...restOfProps
@@ -149,7 +150,10 @@ const ManagementRulesInput = ({
   return (
     <InputRow {...restOfProps} validationType={validationType}>
       {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-      <label id={`${id}-management-rules-input`}>{label}</label>
+      <label id={`${id}-management-rules-input`}>
+        {label}
+        {required ? <RequiredIndicator /> : null}
+      </label>
       <div aria-labelledby={`${id}-management-rules-input`}>
         <StyledCheckRadioWrapper>
           <input
@@ -210,6 +214,7 @@ ManagementRulesInput.propTypes = {
   label: PropTypes.string,
   managementFormValues: managementRegimePropType,
   onChange: PropTypes.func.isRequired,
+  required: PropTypes.bool.isRequired,
   validationMessages: mermaidInputsPropTypes.validationMessagesPropType,
   validationType: PropTypes.string,
 }

--- a/src/components/pages/collectRecordFormPages/BleachingForm/BleachingTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/BleachingTransectInputs.js
@@ -14,7 +14,6 @@ import InputRadioWithLabelAndValidation from '../../../mermaidInputs/InputRadioW
 import InputWithLabelAndValidation from '../../../mermaidInputs/InputWithLabelAndValidation'
 import TextareaWithLabelAndValidation from '../../../mermaidInputs/TextareaWithLabelAndValidation'
 
-const NUMBER_VALIDATION_PATH = 'data.quadrat_collection.number'
 const CURRENT_VALIDATION_PATH = 'data.quadrat_collection.current'
 const DEPTH_VALIDATION_PATH = 'data.quadrat_collection.depth'
 const LABEL_VALIDATION_PATH = 'data.quadrat_collection.label'
@@ -154,15 +153,9 @@ const BleachingTransectInputs = ({
           disabled
           label="Number"
           id="number"
+          testId="number"
           type="number"
-          ignoreNonObservationFieldValidations={() => {
-            ignoreNonObservationFieldValidations({ validationPath: NUMBER_VALIDATION_PATH })
-          }}
-          resetNonObservationFieldValidations={() => {
-            resetNonObservationFieldValidations({ validationPath: NUMBER_VALIDATION_PATH })
-          }}
           {...labelValidationProperties}
-          onBlur={formik.handleBlur}
           value={formik.values.number}
         />
         <InputWithLabelAndValidation

--- a/src/components/pages/collectRecordFormPages/BleachingForm/BleachingTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/BleachingTransectInputs.js
@@ -14,6 +14,7 @@ import InputRadioWithLabelAndValidation from '../../../mermaidInputs/InputRadioW
 import InputWithLabelAndValidation from '../../../mermaidInputs/InputWithLabelAndValidation'
 import TextareaWithLabelAndValidation from '../../../mermaidInputs/TextareaWithLabelAndValidation'
 
+const NUMBER_VALIDATION_PATH = 'data.quadrat_collection.number'
 const CURRENT_VALIDATION_PATH = 'data.quadrat_collection.current'
 const DEPTH_VALIDATION_PATH = 'data.quadrat_collection.depth'
 const LABEL_VALIDATION_PATH = 'data.quadrat_collection.label'
@@ -84,6 +85,13 @@ const BleachingTransectInputs = ({
     areValidationsShowing,
   )
 
+  const handleNumberChange = (event) => {
+    formik.handleChange(event)
+    resetNonObservationFieldValidations({
+      validationPath: NUMBER_VALIDATION_PATH,
+    })
+  }
+
   const handleLabelChange = (event) => {
     formik.handleChange(event)
     resetNonObservationFieldValidations({
@@ -149,6 +157,23 @@ const BleachingTransectInputs = ({
       <InputWrapper>
         <H2>Quadrat</H2>
 
+        <InputWithLabelAndValidation
+          disabled
+          label="Number"
+          id="number"
+          testId="number"
+          type="number"
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({ validationPath: NUMBER_VALIDATION_PATH })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: NUMBER_VALIDATION_PATH })
+          }}
+          {...labelValidationProperties}
+          onBlur={formik.handleBlur}
+          value={formik.values.number}
+          onChange={handleNumberChange}
+        />
         <InputWithLabelAndValidation
           label="Label"
           id="label"

--- a/src/components/pages/collectRecordFormPages/BleachingForm/BleachingTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/BleachingTransectInputs.js
@@ -85,13 +85,6 @@ const BleachingTransectInputs = ({
     areValidationsShowing,
   )
 
-  const handleNumberChange = (event) => {
-    formik.handleChange(event)
-    resetNonObservationFieldValidations({
-      validationPath: NUMBER_VALIDATION_PATH,
-    })
-  }
-
   const handleLabelChange = (event) => {
     formik.handleChange(event)
     resetNonObservationFieldValidations({
@@ -161,7 +154,6 @@ const BleachingTransectInputs = ({
           disabled
           label="Number"
           id="number"
-          testId="number"
           type="number"
           ignoreNonObservationFieldValidations={() => {
             ignoreNonObservationFieldValidations({ validationPath: NUMBER_VALIDATION_PATH })
@@ -172,7 +164,6 @@ const BleachingTransectInputs = ({
           {...labelValidationProperties}
           onBlur={formik.handleBlur}
           value={formik.values.number}
-          onChange={handleNumberChange}
         />
         <InputWithLabelAndValidation
           label="Label"


### PR DESCRIPTION
note : wanted to make these as separate prs but accidentally made a commit to the same branch so just leaving it since they're both relatively small tasks

[trello card 1](https://trello.com/c/ocsQTJbZ/1010-add-disabled-number-field-to-bleaching-cr)
[trello card 2](https://trello.com/c/LZNZRIFR/1031-mr-rules-field-should-have-a-red-asterisk)

**Summary**
task 1: add disabled Number field to Bleaching CR - labeled Number and appearing above Label.
task 2: MR Rules field name should have a red asterisk to indicate it’s required

to test:

first task
1. go to new bleaching collect record
2. ensure number field exists and is disabled

second task
1. go to management rules
2. add new rule
3. check to see that rules has an asterisk