### PR TITLE
Add number sort to management regimes label

### DIFF
--- a/src/App/mermaidData/databaseSwitchboard/ProjectHealthMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/ProjectHealthMixin.js
@@ -387,7 +387,9 @@ const ProjectHealthMixin = (Base) =>
             }
 
             sampleEventUnitRow.management_regimes.forEach((regime) => {
-              return regime.labels.sort((a, b) => a.label - b.label)
+              const labelsSortedNumerically = regime.labels.sort((a, b) => a.label - b.label)
+
+              return labelsSortedNumerically
             })
 
             sampleEventUnitRowsCopy.push(sampleEventUnitRow)

--- a/src/App/mermaidData/databaseSwitchboard/ProjectHealthMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/ProjectHealthMixin.js
@@ -386,6 +386,10 @@ const ProjectHealthMixin = (Base) =>
               management_regimes: Object.values(managements),
             }
 
+            sampleEventUnitRow.management_regimes.forEach((regime) => {
+              return regime.labels.sort((a, b) => a.label - b.label)
+            })
+
             sampleEventUnitRowsCopy.push(sampleEventUnitRow)
           }
         }


### PR DESCRIPTION
[trello card](https://trello.com/c/ntjxdn80/1022-change-ordering-of-su-numbers-in-mr-overview)

previous behaviour:
- transect numbers would appear as `10, 1, 2, 3, 4, 5, 6, 7, 8, 9` instead of `1, 2, 3, 4, 5, 6, 7, 8, 9, 10`

to test:
1. go to a project with at least a few records for an MR (I use Belize Glover's Atoll 2020)
2. go. to MR overview page
3. ensure numbers are ordered properly:
<img width="490" alt="Screen_Shot_2023-04-20_at_3_06_59_PM" src="https://user-images.githubusercontent.com/26089140/233463949-7f7a6260-58f4-4540-a680-207c6692d6f9.png">

