### PR TITLE
Switch cursor to auto on data sharing page

### DIFF
--- a/src/components/pages/DataSharing/DataSharing.js
+++ b/src/components/pages/DataSharing/DataSharing.js
@@ -187,7 +187,7 @@ const DataSharing = () => {
 
   const isTestProject = projectBeingEdited?.status === PROJECT_CODES.status.test
   const contentViewByRole = (
-    <MaxWidthInputWrapper cursor={isDataUpdating ? 'wait' : 'pointer'}>
+    <MaxWidthInputWrapper cursor={isDataUpdating ? 'wait' : 'auto'}>
       <h3>Data are much more powerful when shared.</h3>
       <P>{language.pages.dataSharing.introductionParagraph}</P>
       <ButtonPrimary type="button" onClick={openDataSharingInfoModal}>


### PR DESCRIPTION
[trello ticket ](https://trello.com/c/FKkSLucU/382-incorrect-cursor-on-data-sharing-page)

previously, the cursor was set to `pointer` on the entire page instead of `auto`

to test:
1. go to data sharing page
2. cursor should be auto instead of pointer outside of buttons