### PR TITLE
Remove disabled fish belt bin sizes - add clear sizes modal

### DIFF
--- a/src/components/pages/collectRecordFormPages/FishBeltForm/ClearSizeValueModal.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/ClearSizeValueModal.js
@@ -1,0 +1,77 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { ButtonCaution, ButtonSecondary } from '../../../generic/buttons'
+import Modal, { RightFooter } from '../../../generic/Modal/Modal'
+import { DeleteRecordButtonCautionWrapper } from '../CollectingFormPage.Styles'
+import LoadingModal from '../../../LoadingModal/LoadingModal'
+
+const ClearSizeValuesModal = ({
+  currentPage,
+  isLoading,
+  isOpen,
+  modalText,
+  clearSizeValues,
+  onDismiss,
+  openModal,
+}) => {
+  const footerContentPageOne = (
+    <RightFooter>
+      <ButtonSecondary onClick={onDismiss}>{modalText.no}</ButtonSecondary>
+      <ButtonCaution disabled={isLoading} onClick={clearSizeValues}>
+        {modalText.yes}
+      </ButtonCaution>
+    </RightFooter>
+  )
+
+  const footerContentPageTwo = (
+    <RightFooter>
+      <ButtonSecondary onClick={onDismiss}>Close</ButtonSecondary>
+    </RightFooter>
+  )
+
+  const mainContent = <>{currentPage === 1 && modalText.prompt}</>
+
+  const footerContent = (
+    <>
+      {currentPage === 1 && footerContentPageOne}
+      {currentPage === 2 && footerContentPageTwo}
+    </>
+  )
+
+  return (
+    <>
+      <DeleteRecordButtonCautionWrapper>
+        <ButtonCaution onClick={openModal}>{modalText.title}</ButtonCaution>
+      </DeleteRecordButtonCautionWrapper>
+      <Modal
+        title={modalText.title}
+        isOpen={isOpen}
+        onDismiss={onDismiss}
+        mainContent={mainContent}
+        footerContent={footerContent}
+      />
+      {isLoading && <LoadingModal />}
+    </>
+  )
+}
+
+ClearSizeValuesModal.propTypes = {
+  currentPage: PropTypes.number,
+  isLoading: PropTypes.bool.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  modalText: PropTypes.shape({
+    title: PropTypes.string,
+    prompt: PropTypes.string,
+    yes: PropTypes.string,
+    no: PropTypes.string,
+  }).isRequired,
+  clearSizeValues: PropTypes.func.isRequired,
+  onDismiss: PropTypes.func.isRequired,
+  openModal: PropTypes.func.isRequired,
+}
+
+ClearSizeValuesModal.defaultProps = {
+  currentPage: 1,
+}
+
+export default ClearSizeValuesModal

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/ClearSizeValueModal.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/ClearSizeValueModal.js
@@ -2,19 +2,10 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { ButtonCaution, ButtonSecondary } from '../../../generic/buttons'
 import Modal, { RightFooter } from '../../../generic/Modal/Modal'
-import { DeleteRecordButtonCautionWrapper } from '../CollectingFormPage.Styles'
 import LoadingModal from '../../../LoadingModal/LoadingModal'
 
-const ClearSizeValuesModal = ({
-  currentPage,
-  isLoading,
-  isOpen,
-  modalText,
-  clearSizeValues,
-  onDismiss,
-  openModal,
-}) => {
-  const footerContentPageOne = (
+const ClearSizeValuesModal = ({ isLoading, isOpen, modalText, clearSizeValues, onDismiss }) => {
+  const footerContent = (
     <RightFooter>
       <ButtonSecondary onClick={onDismiss}>{modalText.no}</ButtonSecondary>
       <ButtonCaution disabled={isLoading} onClick={clearSizeValues}>
@@ -23,26 +14,10 @@ const ClearSizeValuesModal = ({
     </RightFooter>
   )
 
-  const footerContentPageTwo = (
-    <RightFooter>
-      <ButtonSecondary onClick={onDismiss}>Close</ButtonSecondary>
-    </RightFooter>
-  )
-
-  const mainContent = <>{currentPage === 1 && modalText.prompt}</>
-
-  const footerContent = (
-    <>
-      {currentPage === 1 && footerContentPageOne}
-      {currentPage === 2 && footerContentPageTwo}
-    </>
-  )
+  const mainContent = <>{modalText.prompt}</>
 
   return (
     <>
-      <DeleteRecordButtonCautionWrapper>
-        <ButtonCaution onClick={openModal}>{modalText.title}</ButtonCaution>
-      </DeleteRecordButtonCautionWrapper>
       <Modal
         title={modalText.title}
         isOpen={isOpen}
@@ -56,7 +31,6 @@ const ClearSizeValuesModal = ({
 }
 
 ClearSizeValuesModal.propTypes = {
-  currentPage: PropTypes.number,
   isLoading: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
   modalText: PropTypes.shape({
@@ -67,11 +41,6 @@ ClearSizeValuesModal.propTypes = {
   }).isRequired,
   clearSizeValues: PropTypes.func.isRequired,
   onDismiss: PropTypes.func.isRequired,
-  openModal: PropTypes.func.isRequired,
-}
-
-ClearSizeValuesModal.defaultProps = {
-  currentPage: 1,
 }
 
 export default ClearSizeValuesModal

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/ClearSizeValueModal.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/ClearSizeValueModal.js
@@ -3,11 +3,11 @@ import React from 'react'
 import { ButtonCaution, ButtonSecondary } from '../../../generic/buttons'
 import Modal, { RightFooter } from '../../../generic/Modal/Modal'
 
-const ClearSizeValuesModal = ({ isOpen, modalText, clearSizeValues, onDismiss }) => {
+const ClearSizeValuesModal = ({ isOpen, modalText, handleResetSizeValues, onDismiss }) => {
   const footerContent = (
     <RightFooter>
       <ButtonSecondary onClick={onDismiss}>{modalText.no}</ButtonSecondary>
-      <ButtonCaution onClick={clearSizeValues}>{modalText.yes}</ButtonCaution>
+      <ButtonCaution onClick={handleResetSizeValues}>{modalText.yes}</ButtonCaution>
     </RightFooter>
   )
 
@@ -32,7 +32,7 @@ ClearSizeValuesModal.propTypes = {
     yes: PropTypes.string,
     no: PropTypes.string,
   }).isRequired,
-  clearSizeValues: PropTypes.func.isRequired,
+  handleResetSizeValues: PropTypes.func.isRequired,
   onDismiss: PropTypes.func.isRequired,
 }
 

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/ClearSizeValueModal.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/ClearSizeValueModal.js
@@ -2,36 +2,29 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { ButtonCaution, ButtonSecondary } from '../../../generic/buttons'
 import Modal, { RightFooter } from '../../../generic/Modal/Modal'
-import LoadingModal from '../../../LoadingModal/LoadingModal'
 
-const ClearSizeValuesModal = ({ isLoading, isOpen, modalText, clearSizeValues, onDismiss }) => {
+const ClearSizeValuesModal = ({ isOpen, modalText, clearSizeValues, onDismiss }) => {
   const footerContent = (
     <RightFooter>
       <ButtonSecondary onClick={onDismiss}>{modalText.no}</ButtonSecondary>
-      <ButtonCaution disabled={isLoading} onClick={clearSizeValues}>
-        {modalText.yes}
-      </ButtonCaution>
+      <ButtonCaution onClick={clearSizeValues}>{modalText.yes}</ButtonCaution>
     </RightFooter>
   )
 
   const mainContent = <>{modalText.prompt}</>
 
   return (
-    <>
-      <Modal
-        title={modalText.title}
-        isOpen={isOpen}
-        onDismiss={onDismiss}
-        mainContent={mainContent}
-        footerContent={footerContent}
-      />
-      {isLoading && <LoadingModal />}
-    </>
+    <Modal
+      title={modalText.title}
+      isOpen={isOpen}
+      onDismiss={onDismiss}
+      mainContent={mainContent}
+      footerContent={footerContent}
+    />
   )
 }
 
 ClearSizeValuesModal.propTypes = {
-  isLoading: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
   modalText: PropTypes.shape({
     title: PropTypes.string,

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
@@ -75,6 +75,7 @@ const FishBeltTransectInputs = ({
   const hasFishBeltObservations =
     !!observationsState.length > 0 && observationsState[0]?.fish_attribute
   const [isClearSizeValueModalOpen, setIsClearSizeValueModalOpen] = useState(false)
+  const [sizeBinEvent, setSizeBinEvent] = useState({})
 
   const transectNumberValidationProperties = getValidationPropertiesForInput(
     fishbelt_transect?.number,
@@ -172,9 +173,11 @@ const FishBeltTransectInputs = ({
       validationPath: WIDTH_VALIDATION_PATH,
     })
   }
+
   const handleSizeBinChange = (event) => {
     if (hasFishBeltObservations) {
       openClearSizeValuesModal()
+      setSizeBinEvent(event)
     } else {
       onSizeBinChange(event)
       resetNonObservationFieldValidations({
@@ -242,7 +245,12 @@ const FishBeltTransectInputs = ({
     })
   }
 
-  const clearSizeValues = () => {
+  const handleResetSizeValues = () => {
+    onSizeBinChange(sizeBinEvent)
+    resetNonObservationFieldValidations({
+      inputName: 'size_bin',
+      validationPath: SIZE_BIN_VALIDATION_PATH,
+    })
     observationsDispatch({
       type: 'resetFishSizes',
     })
@@ -493,7 +501,7 @@ const FishBeltTransectInputs = ({
       <ClearSizeValuesModal
         isOpen={isClearSizeValueModalOpen}
         modalText={language.clearSizeValuesModal}
-        clearSizeValues={clearSizeValues}
+        handleResetSizeValues={handleResetSizeValues}
         onDismiss={closeClearSizeValuesModal}
         openModal={openClearSizeValuesModal}
       />

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
@@ -1,4 +1,5 @@
-import React from 'react'
+/* eslint-disable no-console */
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 
 import {
@@ -15,6 +16,7 @@ import InputRadioWithLabelAndValidation from '../../../mermaidInputs/InputRadioW
 import InputWithLabelAndValidation from '../../../mermaidInputs/InputWithLabelAndValidation'
 import TextareaWithLabelAndValidation from '../../../mermaidInputs/TextareaWithLabelAndValidation'
 import { sortArrayByObjectKey } from '../../../../library/arrays/sortArrayByObjectKey'
+import ClearSizeValuesModal from './ClearSizeValueModal'
 import language from '../../../../language'
 
 const CURRENT_VALIDATION_PATH = 'data.fishbelt_transect.current'
@@ -72,6 +74,8 @@ const FishBeltTransectInputs = ({
   // account for empty starter row
   const hasFishBeltObservations =
     !!observationsState.length > 0 && observationsState[0]?.fish_attribute
+  const [isClearSizeValueModalOpen, setIsClearSizeValueModalOpen] = useState(false)
+  const [isClearingSizeValues, setIsClearingSizeValues] = useState(false)
 
   const transectNumberValidationProperties = getValidationPropertiesForInput(
     fishbelt_transect?.number,
@@ -132,6 +136,13 @@ const FishBeltTransectInputs = ({
     areValidationsShowing,
   )
 
+  const openClearSizeValuesModal = () => {
+    setIsClearSizeValueModalOpen(true)
+  }
+  const closeClearSizeValuesModal = () => {
+    setIsClearSizeValueModalOpen(false)
+  }
+
   const handleTransectNumberChange = (event) => {
     formik.handleChange(event)
     resetNonObservationFieldValidations({
@@ -163,11 +174,15 @@ const FishBeltTransectInputs = ({
     })
   }
   const handleSizeBinChange = (event) => {
-    onSizeBinChange(event)
-    resetNonObservationFieldValidations({
-      inputName: 'size_bin',
-      validationPath: SIZE_BIN_VALIDATION_PATH,
-    })
+    if (hasFishBeltObservations) {
+      openClearSizeValuesModal()
+    } else {
+      onSizeBinChange(event)
+      resetNonObservationFieldValidations({
+        inputName: 'size_bin',
+        validationPath: SIZE_BIN_VALIDATION_PATH,
+      })
+    }
   }
   const handleReefSlopeChange = (event) => {
     formik.handleChange(event)
@@ -226,6 +241,12 @@ const FishBeltTransectInputs = ({
       inputName: 'depth',
       validationPath: DEPTH_VALIDATION_PATH,
     })
+  }
+
+  const clearSizeValues = () => {
+    setIsClearingSizeValues(true)
+    setIsClearingSizeValues(false)
+    console.log('clearing size values')
   }
 
   return (
@@ -349,7 +370,6 @@ const FishBeltTransectInputs = ({
           onChange={handleWidthChange}
         />
         <InputRadioWithLabelAndValidation
-          disabled={hasFishBeltObservations}
           label="Fish Size Bin (cm)"
           required={true}
           id="size_bin"
@@ -366,9 +386,6 @@ const FishBeltTransectInputs = ({
             sizeBinValidationProperties,
             'size_bin',
           )}
-          additionalText={
-            hasFishBeltObservations ? <>{language.error.disabledFishSizeBinSelect}</> : null
-          }
           value={formik.values.size_bin}
           onChange={handleSizeBinChange}
         />
@@ -473,6 +490,14 @@ const FishBeltTransectInputs = ({
           onChange={handleNotesChange}
         />
       </InputWrapper>
+      <ClearSizeValuesModal
+        isLoading={isClearingSizeValues}
+        isOpen={isClearSizeValueModalOpen}
+        modalText={language.clearSizeValuesModal}
+        clearSizeValues={clearSizeValues}
+        onDismiss={closeClearSizeValuesModal}
+        openModal={openClearSizeValuesModal}
+      />
     </>
   )
 }

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
@@ -44,7 +44,7 @@ const FishBeltTransectInputs = ({
   validationsApiData,
   validationPropertiesWithDirtyResetOnInputChange,
 }) => {
-  const [observationsState] = observationsReducer
+  const [observationsState, observationsDispatch] = observationsReducer
   const {
     belttransectwidths,
     fishsizebins,
@@ -75,7 +75,6 @@ const FishBeltTransectInputs = ({
   const hasFishBeltObservations =
     !!observationsState.length > 0 && observationsState[0]?.fish_attribute
   const [isClearSizeValueModalOpen, setIsClearSizeValueModalOpen] = useState(false)
-  const [isClearingSizeValues, setIsClearingSizeValues] = useState(false)
 
   const transectNumberValidationProperties = getValidationPropertiesForInput(
     fishbelt_transect?.number,
@@ -244,9 +243,10 @@ const FishBeltTransectInputs = ({
   }
 
   const clearSizeValues = () => {
-    setIsClearingSizeValues(true)
-    setIsClearingSizeValues(false)
-    console.log('clearing size values')
+    observationsDispatch({
+      type: 'resetFishSizes',
+    })
+    closeClearSizeValuesModal()
   }
 
   return (
@@ -491,7 +491,6 @@ const FishBeltTransectInputs = ({
         />
       </InputWrapper>
       <ClearSizeValuesModal
-        isLoading={isClearingSizeValues}
         isOpen={isClearSizeValueModalOpen}
         modalText={language.clearSizeValuesModal}
         clearSizeValues={clearSizeValues}

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/tests/FishBeltObservationTable.test.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/tests/FishBeltObservationTable.test.js
@@ -175,7 +175,7 @@ test('Fishbelt observations shows extra input for sizes over 50', async () => {
   await waitFor(() => expect(sizeInputs.length).toEqual(2))
 })
 
-test('Fish size bin radios are disabled when there are active observations, delete all observations -> Fish size bin radios are re-enabled', async () => {
+test('Fish size bin radio buttons remain enabled even after new observation rows are added', async () => {
   const { dexiePerUserDataInstance } = getMockDexieInstancesAllSuccess()
 
   await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
@@ -201,17 +201,18 @@ test('Fish size bin radios are disabled when there are active observations, dele
   const binAGRRARadio = within(fishbeltForm).getByLabelText('AGRRA')
   const binWCSIndiaRadio = within(fishbeltForm).getByLabelText('WCS India')
 
-  expect(bin1Radio).toBeDisabled()
-  expect(bin5Radio).toBeDisabled()
-  expect(bin10Radio).toBeDisabled()
-  expect(binAGRRARadio).toBeDisabled()
-  expect(binWCSIndiaRadio).toBeDisabled()
+  expect(bin1Radio).toBeEnabled()
+  expect(bin5Radio).toBeEnabled()
+  expect(bin10Radio).toBeEnabled()
+  expect(binAGRRARadio).toBeEnabled()
+  expect(binWCSIndiaRadio).toBeEnabled()
 
-  const observationRows = within(screen.getByLabelText('Observations')).getAllByRole('row')
+  const addRowButton = within(fishbeltForm).getByRole('button', { name: 'Add Row' })
 
-  userEvent.click(within(observationRows[1]).getByLabelText('Delete Observation'))
-  userEvent.click(within(observationRows[2]).getByLabelText('Delete Observation'))
-  userEvent.click(within(observationRows[3]).getByLabelText('Delete Observation'))
+  expect(addRowButton).toBeEnabled()
+
+  userEvent.click(addRowButton)
+  userEvent.click(addRowButton)
 
   expect(bin1Radio).toBeEnabled()
   expect(bin5Radio).toBeEnabled()

--- a/src/language.js
+++ b/src/language.js
@@ -200,6 +200,13 @@ const createNewOptionModal = {
   submit: 'Send to MERMAID for review',
 }
 
+const clearSizeValuesModal = {
+  title: `Clear Size Values`,
+  prompt: `This will clear all the size values for all observations.`,
+  yes: `Clear Size Values`,
+  no: 'Cancel',
+}
+
 const autocomplete = {
   noResultsDefault: 'No results found',
 }
@@ -477,6 +484,7 @@ const getValidationMessage = (validation, projectId = '') => {
 export default {
   apiDataTableNames,
   autocomplete,
+  clearSizeValuesModal,
   createNewOptionModal,
   deleteRecord,
   error,


### PR DESCRIPTION
[trello card](https://trello.com/b/XeUt1nb5/mermaid-dev)

Users should be able to change the fish size bin even if there are observations. Show a modal confirmation that the "Size" value will be cleared for all observations.

To test:
1. add a new fish belt record
2. select a bin size
3. add observations
4. change bin size
5. modal should appear with a warning that sizes will be cleared if they accept
6. check to see that sizes are cleared if you click ok