### PR TITLE
Add scroll-to-bottom when on last row of observation table autocomplete

### DIFF
--- a/src/components/generic/InputAutocomplete/InputAutocomplete.js
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.js
@@ -37,6 +37,7 @@ const InputAutocomplete = ({
   className,
   helperText,
   id,
+  isLastRow,
   noResultsAction,
   noResultsText,
   onChange,
@@ -80,12 +81,13 @@ const InputAutocomplete = ({
     (changes) => {
       const { selectedItem, inputValue } = changes
 
-      const shouldMenuBeOpen = inputValue?.length >= 3 && inputValue !== selectedValue.label
+      const shouldMenuBeOpen = inputValue?.length >= 1 && inputValue !== selectedValue.label
 
       if (selectedItem) {
         onChange(selectedItem)
         setIsMenuOpen(false)
       }
+
       if (!selectedItem && inputValue) {
         setIsMenuOpen(shouldMenuBeOpen)
       }
@@ -99,6 +101,11 @@ const InputAutocomplete = ({
 
   const handleInputValueChange = useCallback(
     (inputValueItem) => {
+      // scroll to bottom of page to show full menu contents
+      if (isLastRow && isMenuOpen) {
+        window.scrollTo(0, document.body.scrollHeight)
+      }
+
       const matchingMenuItems = inputValueItem
         ? matchSorter(options, inputValueItem, {
             keys: ['label'],
@@ -107,7 +114,7 @@ const InputAutocomplete = ({
 
       setMenuItems(matchingMenuItems)
     },
-    [options],
+    [options, isLastRow, isMenuOpen],
   )
 
   const getMenuContents = useCallback(
@@ -180,6 +187,7 @@ const InputAutocomplete = ({
 InputAutocomplete.propTypes = {
   className: PropTypes.string,
   helperText: PropTypes.string,
+  isLastRow: PropTypes.bool.isRequired,
   id: PropTypes.string.isRequired,
   noResultsAction: PropTypes.node,
   noResultsText: PropTypes.string,

--- a/src/components/generic/InputAutocomplete/InputAutocomplete.styles.js
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.styles.js
@@ -7,7 +7,7 @@ export const Menu = styled('ul')`
   background: ${theme.color.white};
   position: absolute;
   width: 100%;
-  max-height: 20rem;
+  max-height: 18rem;
   cursor: default;
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -191,6 +191,7 @@ const BenthicLitObservationsTable = ({
                 <ObservationAutocomplete
                   id={`observation-${observationId}`}
                   autoFocus={autoFocusAllowed}
+                  isLastRow={observationsState.length === rowNumber}
                   aria-labelledby="benthic-attribute-label"
                   options={benthicAttributeSelectOptions}
                   onChange={handleBenthicAttributeChange}

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -311,6 +311,7 @@ const BenthicPhotoQuadratObservationTable = ({
                 <ObservationAutocomplete
                   id={`observation-${observationId}`}
                   aria-labelledby="benthic-attribute-label"
+                  isLastRow={observationsState.length === rowNumber}
                   options={benthicAttributeOptions}
                   onChange={handleBenthicAttributeChange}
                   value={attribute}

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
@@ -197,6 +197,7 @@ const BenthicPitObservationsTable = ({
                 <ObservationAutocomplete
                   id={`observation-${observationId}`}
                   autoFocus={autoFocusAllowed}
+                  isLastRow={observationsState.length === rowNumber}
                   aria-labelledby="benthic-attribute-label"
                   options={benthicAttributeSelectOptions}
                   onChange={handleBenthicAttributeChange}

--- a/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
@@ -207,6 +207,7 @@ const ColoniesBleachedObservationTable = ({
                 <ObservationAutocomplete
                   id={`observation-${observationId}`}
                   autoFocus={autoFocusAllowed}
+                  isLastRow={observationsState.length === rowNumber}
                   aria-labelledby="benthic-attribute-label"
                   options={benthicAttributeSelectOptions}
                   onChange={handleBenthicAttributeChange}

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -342,6 +342,7 @@ const FishBeltObservationTable = ({
                   // and the logic to focus on the right one. in react autoFocus just focuses
                   // the newest element with the autoFocus tag
                   autoFocus={autoFocusAllowed}
+                  isLastRow={observationsState.length === rowNumber}
                   aria-labelledby="fish-name-label"
                   options={fishNameOptions}
                   onChange={handleFishNameChange}


### PR DESCRIPTION
[trello card](https://trello.com/c/G4VoLKkl/384-all-autocomplete-in-the-observation-table-should-detect-if-its-at-the-top-or-bottom-of-the-page-and-open-up-as-opposed-to-down-s)

Previously the autocomplete menu would get cut off when expanded. 

Added a scroll-to-bottom-of-page function when entering text into the autocomplete observation menu. Set a rule that this only happens when you are entering data in the last row of the table so it doesn't jump to the bottom of the screen at row 25/50 for example.

to test:
1. go to a collect record that has an observation table auto-complete (benthic lit/pit/BPQ/bleaching/FB)
2. scroll down to observation table
3. begin entering text to see expanded menu (try 'cli) for example
4. notice that the menu stays in viewport
5. add a bunch more rows (10 for example)
6. enter autocomplete data in row 5, notice that it does not scroll to bottom
7. enter data in last row, notice that it does scroll to bottom (after more than one character is entered)