### PR TITLE
[360] Cursor fix for table on users page

### DIFF
--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -111,7 +111,7 @@ const TableRadioLabel = styled.label(
   (props) => css`
     top: 0;
     right: 0;
-    cursor: ${props.disabled ? 'auto' : 'pointer'};
+    cursor: ${props.cursor};
     bottom: 0;
     left: 0;
     position: absolute;
@@ -125,7 +125,7 @@ const TableRadioLabel = styled.label(
 
 const TableRadioInput = styled.input(
   (props) => css`
-    cursor: ${props.disabled ? 'auto' : 'pointer'};
+    cursor: ${props.cursor};
   `,
 )
 
@@ -533,6 +533,17 @@ const Users = () => {
       const isCurrentUser = userId === currentUser.id
       const isActiveSampleUnitsWarningShowing = userHasActiveSampleUnits && isUserRoleReadOnly
 
+      const getCursorType = () => {
+        if (isCurrentUser) {
+          return 'not-allowed'
+        }
+        if (isTableUpdating) {
+          return 'wait'
+        }
+
+        return 'pointer'
+      }
+
       return {
         name: (
           <NameCellStyle>
@@ -542,11 +553,9 @@ const Users = () => {
         ),
         email,
         admin: (
-          <TableRadioLabel
-            htmlFor={`admin-${projectProfileId}`}
-            disabled={isCurrentUser || isTableUpdating}
-          >
+          <TableRadioLabel htmlFor={`admin-${projectProfileId}`} cursor={getCursorType()}>
             <TableRadioInput
+              cursor={getCursorType()}
               type="radio"
               value={userRole.admin}
               name={projectProfileId}
@@ -560,11 +569,9 @@ const Users = () => {
           </TableRadioLabel>
         ),
         collector: (
-          <TableRadioLabel
-            htmlFor={`collector-${projectProfileId}`}
-            disabled={isCurrentUser || isTableUpdating}
-          >
+          <TableRadioLabel htmlFor={`collector-${projectProfileId}`} cursor={getCursorType()}>
             <TableRadioInput
+              cursor={getCursorType()}
               type="radio"
               value={userRole.collector}
               name={projectProfileId}
@@ -578,11 +585,9 @@ const Users = () => {
           </TableRadioLabel>
         ),
         readonly: (
-          <TableRadioLabel
-            htmlFor={`readonly-${projectProfileId}`}
-            disabled={isCurrentUser || isTableUpdating}
-          >
-            <input
+          <TableRadioLabel htmlFor={`readonly-${projectProfileId}`} cursor={getCursorType()}>
+            <TableRadioInput
+              cursor={getCursorType()}
               type="radio"
               value={userRole.read_only}
               name={projectProfileId}

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -107,18 +107,27 @@ const NameCellStyle = styled('div')`
 const UserTableTd = styled(Td)`
   position: relative;
 `
-const TableRadioLabel = styled('label')`
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  display: grid;
-  place-items: center;
-  ${hoverState(css`
-    border: solid 1px ${theme.color.primaryColor};
-  `)}
-`
+const TableRadioLabel = styled.label(
+  (props) => css`
+    top: 0;
+    right: 0;
+    cursor: ${props.disabled ? 'auto' : 'pointer'};
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    display: grid;
+    place-items: center;
+    ${hoverState(css`
+      border: solid 1px ${theme.color.primaryColor};
+    `)}
+  `,
+)
+
+const TableRadioInput = styled.input(
+  (props) => css`
+    cursor: ${props.disabled ? 'auto' : 'pointer'};
+  `,
+)
 
 const getRoleLabel = (roleCode) => {
   return {
@@ -533,8 +542,11 @@ const Users = () => {
         ),
         email,
         admin: (
-          <TableRadioLabel htmlFor={`admin-${projectProfileId}`}>
-            <input
+          <TableRadioLabel
+            htmlFor={`admin-${projectProfileId}`}
+            disabled={isCurrentUser || isTableUpdating}
+          >
+            <TableRadioInput
               type="radio"
               value={userRole.admin}
               name={projectProfileId}
@@ -548,8 +560,11 @@ const Users = () => {
           </TableRadioLabel>
         ),
         collector: (
-          <TableRadioLabel htmlFor={`collector-${projectProfileId}`}>
-            <input
+          <TableRadioLabel
+            htmlFor={`collector-${projectProfileId}`}
+            disabled={isCurrentUser || isTableUpdating}
+          >
+            <TableRadioInput
               type="radio"
               value={userRole.collector}
               name={projectProfileId}
@@ -563,7 +578,10 @@ const Users = () => {
           </TableRadioLabel>
         ),
         readonly: (
-          <TableRadioLabel htmlFor={`readonly-${projectProfileId}`}>
+          <TableRadioLabel
+            htmlFor={`readonly-${projectProfileId}`}
+            disabled={isCurrentUser || isTableUpdating}
+          >
             <input
               type="radio"
               value={userRole.read_only}

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -120,12 +120,10 @@ const TableRadioLabel = styled.label(
     ${hoverState(css`
       border: solid 1px ${theme.color.primaryColor};
     `)}
-  `,
-)
 
-const TableRadioInput = styled.input(
-  (props) => css`
-    cursor: ${props.cursor};
+    input {
+      cursor: ${props.cursor};
+    }
   `,
 )
 
@@ -554,8 +552,7 @@ const Users = () => {
         email,
         admin: (
           <TableRadioLabel htmlFor={`admin-${projectProfileId}`} cursor={getCursorType()}>
-            <TableRadioInput
-              cursor={getCursorType()}
+            <input
               type="radio"
               value={userRole.admin}
               name={projectProfileId}
@@ -570,8 +567,7 @@ const Users = () => {
         ),
         collector: (
           <TableRadioLabel htmlFor={`collector-${projectProfileId}`} cursor={getCursorType()}>
-            <TableRadioInput
-              cursor={getCursorType()}
+            <input
               type="radio"
               value={userRole.collector}
               name={projectProfileId}
@@ -586,8 +582,7 @@ const Users = () => {
         ),
         readonly: (
           <TableRadioLabel htmlFor={`readonly-${projectProfileId}`} cursor={getCursorType()}>
-            <TableRadioInput
-              cursor={getCursorType()}
+            <input
               type="radio"
               value={userRole.read_only}
               name={projectProfileId}


### PR DESCRIPTION
[trello ticket](https://trello.com/c/XwCyweuS/360-mouse-shows-clickable-anywhere-on-submitted-row-but-clicking-only-goes-to-su-in-the-method-column)

note: other tables were fixed in a separate pr - but good to cross check just incase:

collecting
submitted
Sites
MRs
Users
Observations

to test:
1. go to users page table
2. hover over radio buttons
3. pointer cursor shows over labels/inputs
4. auto cursor shows when button is disabled 
5. wait cursor shows when updating