### PR TITLE
[496] disable observations if bin size not selected

### DIFF
--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -135,7 +135,7 @@ const FishBeltObservationTable = ({
       const isEnterKey = event.code === 'Enter'
       const isLastRow = index === observationsState.length - 1
 
-      if (isTabKey && isLastRow && isCount) {
+      if (isTabKey && isLastRow && isCount && fishBinSelectedLabel) {
         event.preventDefault()
         setAutoFocusAllowed(true)
         observationsDispatch({
@@ -145,7 +145,7 @@ const FishBeltObservationTable = ({
         setAreObservationsInputsDirty(true)
       }
 
-      if (isEnterKey) {
+      if (isEnterKey && fishBinSelectedLabel) {
         event.preventDefault()
         setAutoFocusAllowed(true)
         observationsDispatch({
@@ -224,6 +224,7 @@ const FishBeltObservationTable = ({
         <InputNumberNumericCharactersOnly
           value={sizeOrEmptyStringToAvoidInputValueErrors}
           step="any"
+          disabled={!fishBinSelectedLabel}
           aria-labelledby="fish-size-label"
           onChange={handleUpdateSizeEvent}
           onKeyDown={handleObservationKeyDown}
@@ -288,6 +289,7 @@ const FishBeltObservationTable = ({
               <InputAutocompleteContainer>
                 <ObservationAutocomplete
                   id={`observation-${observationId}`}
+                  disabled={!fishBinSelectedLabel}
                   // we only want autofocus to take over focus after the user adds
                   // new observations, not before. Otherwise initial page load focus
                   // is on the most recently painted observation instead of default focus.
@@ -317,6 +319,7 @@ const FishBeltObservationTable = ({
               step="any"
               aria-labelledby="fish-count-label"
               onChange={handleUpdateCount}
+              disabled={!fishBinSelectedLabel}
               onKeyDown={(event) => {
                 handleKeyDown({ event, index, observation, isCount: true })
               }}


### PR DESCRIPTION
[trello ticket ](https://trello.com/c/aqNCQdit/496-still-able-to-add-observations-to-a-fish-belt-if-fish-size-bin-isnt-selected)

to test:

1. add a fish belt collect record
2. try and add an observation without selecting a bin size
3. add-row should be disabled, in addition to any text inputs
4. tab and enter should also be disabled to add a new row