### PR TITLE
[495] fix save prompt for observation inputs on collect record pages

### DIFF
--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
@@ -616,7 +616,7 @@ const CollectRecordFormPage = ({
       />
 
       {displayLoadingModal && <LoadingModal />}
-      <EnhancedPrompt shouldPromptTrigger={formik.dirty} />
+      <EnhancedPrompt shouldPromptTrigger={formik.dirty || areObservationsInputsDirty} />
     </>
   )
 }


### PR DESCRIPTION
[trello card](https://trello.com/c/b68S3yEH/495-collect-records-dont-prompt-to-save-when-navigating-away-when-theres-only-observations)

to test:
1. go to a collect record page
2. add an observation input
3. navigate away from page
4. ensure save prompt shows up