### PR TITLE
[507] Bug fix for observations persist issue 

### DIFF
--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
@@ -65,10 +65,11 @@ function loadObservationsFromCollectRecordIntoTableState({
     })
   }
 
+  const persistedUnsavedObservationsTable = getPersistedUnsavedObservationsTableData()
+
   if (collectRecordBeingEdited && !isNewRecord) {
     const observationsFromApiTable = collectRecordBeingEdited.data[observationsPropertyName] ?? []
 
-    const persistedUnsavedObservationsTable = getPersistedUnsavedObservationsTableData()
     const initialObservationsToLoadTable =
       persistedUnsavedObservationsTable ?? observationsFromApiTable
 
@@ -87,6 +88,14 @@ function loadObservationsFromCollectRecordIntoTableState({
 
   if (isNewRecord) {
     handleAddEmptyInitialObservation()
+
+    if (persistedUnsavedObservationsTable?.length) {
+      observationsTableDispatch({
+        type: 'loadObservationsFromApi',
+        payload: persistedUnsavedObservationsTable,
+      })
+    }
+
     setObservationsTableReducerInitialized(true)
   }
 }

--- a/src/library/useUnsavedDirtyFormDataUtilities.js
+++ b/src/library/useUnsavedDirtyFormDataUtilities.js
@@ -27,14 +27,6 @@ export const useUnsavedDirtyFormDataUtilities = (sessionStorageName) => {
     }
   }, [sessionStorageName])
 
-  const _clearPersistedUnsavedFormDataBeforeUnload = useEffect(() => {
-    window.addEventListener('beforeunload', clearPersistedUnsavedFormData)
-
-    return () => {
-      window.removeEventListener('beforeunload', clearPersistedUnsavedFormData)
-    }
-  }, [clearPersistedUnsavedFormData])
-
   const _clearPersistedUnsavedFormDataBeforeReactRouterChange = useEffect(() => {
     history.listen(() => {
       clearPersistedUnsavedFormData()

--- a/src/library/useUnsavedDirtyFormDataUtilities.js
+++ b/src/library/useUnsavedDirtyFormDataUtilities.js
@@ -27,6 +27,14 @@ export const useUnsavedDirtyFormDataUtilities = (sessionStorageName) => {
     }
   }, [sessionStorageName])
 
+  const _clearPersistedUnsavedFormDataBeforeUnload = useEffect(() => {
+    window.addEventListener('beforeunload', clearPersistedUnsavedFormData)
+
+    return () => {
+      window.removeEventListener('beforeunload', clearPersistedUnsavedFormData)
+    }
+  }, [clearPersistedUnsavedFormData])
+
   const _clearPersistedUnsavedFormDataBeforeReactRouterChange = useEffect(() => {
     history.listen(() => {
       clearPersistedUnsavedFormData()


### PR DESCRIPTION
[trello card](https://trello.com/c/ZT7EohIk/507-observations-disappear-when-goes-online-after-inputting-offline)

previously if you were on a new form and you entered data into observations and refreshed the page, it would get wiped out

also fixed second bug which wiped out persisted data when an observer was clicked and the page was refreshed or toggled from offline to online

to test:

// for refreshing
1. create a new collect record
2. add a few observations
3. refresh
4. observations should persist

// for offline to online
1. create a new collect record while offline
2. add observations + observer + transect inputs
3. toggle online
4. all items should persist