### PR TITLE
[487] Column tool tip

### DIFF
--- a/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
+++ b/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
@@ -5,7 +5,7 @@ import theme from '../../theme'
 
 export const TooltipPopup = styled('span')`
   display: block;
-  min-width: 26ch;
+  max-width: 18rem;
   width: 100%;
   background: ${theme.color.primaryColor};
   color: ${theme.color.white};
@@ -14,15 +14,15 @@ export const TooltipPopup = styled('span')`
   clip-path: polygon(0% 0%, 100% 0%, 100% 83%, 53% 83%, 47% 100%, 40% 83%, 0 83%);
   padding: 1em;
   padding-bottom: calc(4rem - 15px);
-  bottom: 3.5em;
-  left: -1em;
+  bottom: ${(props) => props.bottom || '3.5em'};
+  left: ${(props) => props.left || '-1em'};
   white-space: normal;
   z-index: 100;
 `
 
-const ColumnHeaderToolTip = ({ helperText }) => {
+const ColumnHeaderToolTip = ({ helperText, bottom, left }) => {
   return (
-    <TooltipPopup role="tooltip" aria-labelledby="tooltip">
+    <TooltipPopup role="tooltip" aria-labelledby="tooltip" bottom={bottom} left={left}>
       {helperText}
     </TooltipPopup>
   )
@@ -30,6 +30,13 @@ const ColumnHeaderToolTip = ({ helperText }) => {
 
 export default ColumnHeaderToolTip
 
+ColumnHeaderToolTip.defaultProps = {
+  bottom: '3.em',
+  left: '-1em',
+}
+
 ColumnHeaderToolTip.propTypes = {
   helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  bottom: PropTypes.string,
+  left: PropTypes.string,
 }

--- a/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
+++ b/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
@@ -3,25 +3,10 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components/macro'
 import theme from '../../theme'
 
-// export const Tooltip = styled('p')`
-//   white-space: nowrap;
-//   border-style: dotted;
-//   border-width: 0 0 ${theme.spacing.borderMedium} 0;
-//   position: relative;
-//   display: inline-grid;
-//   place-items: center;
-//   cursor: pointer;
-//   &:hover span,
-//   &:focus span {
-//     transition: ${theme.timing.hoverTransition};
-//     display: block;
-//   }
-// `
 export const TooltipPopup = styled('span')`
   display: block;
   min-width: 26ch;
   width: 100%;
-  //   max-width: 52ch;
   background: ${theme.color.primaryColor};
   color: ${theme.color.white};
   position: absolute;
@@ -29,11 +14,10 @@ export const TooltipPopup = styled('span')`
   clip-path: polygon(0% 0%, 100% 0%, 100% 83%, 53% 83%, 47% 100%, 40% 83%, 0 83%);
   padding: 1em;
   padding-bottom: calc(4rem - 15px);
-  top: -9rem;
+  bottom: 3.5em;
   left: -1em;
   white-space: normal;
   z-index: 100;
-  //   transition: ${theme.timing.hoverTransition};
 `
 
 const ColumnHeaderToolTip = ({ helperText }) => {

--- a/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
+++ b/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
@@ -11,9 +11,25 @@ export const TooltipPopup = styled('span')`
   color: ${theme.color.white};
   position: absolute;
   font-size: ${theme.typography.smallFontSize};
-  clip-path: polygon(0% 0%, 100% 0%, 100% 83%, 53% 83%, 47% 100%, 40% 83%, 0 83%);
+  clip-path: polygon(
+    //top left
+    0 0,
+    //top right
+    100% 0,
+    //bottom right
+    100% calc(100% - 15px),
+    // right size of arrow
+    calc(50% + 10px) calc(100% - 15px),
+    //bottom peak
+    50% 100%,
+    // left side of arrow
+    calc(50% - 10px) calc(100% - 15px),
+    //bottom left
+    0 calc(100% - 15px)
+  );
+}
   padding: 1em;
-  padding-bottom: ${(props) => props.paddingBottom || `calc(4rem - 15px)`};
+  padding-bottom: calc(1rem + 15px);
   bottom: ${(props) => props.bottom || '4em'};
   left: ${(props) => props.left || '0'};
   white-space: normal;
@@ -21,15 +37,9 @@ export const TooltipPopup = styled('span')`
   text-align: left;
 `
 
-const ColumnHeaderToolTip = ({ helperText, bottom, left, paddingBottom }) => {
+const ColumnHeaderToolTip = ({ helperText, bottom, left }) => {
   return (
-    <TooltipPopup
-      role="tooltip"
-      aria-labelledby="tooltip"
-      bottom={bottom}
-      left={left}
-      paddingBottom={paddingBottom}
-    >
+    <TooltipPopup role="tooltip" aria-labelledby="tooltip" bottom={bottom} left={left}>
       {helperText}
     </TooltipPopup>
   )
@@ -40,12 +50,10 @@ export default ColumnHeaderToolTip
 ColumnHeaderToolTip.defaultProps = {
   bottom: '4em',
   left: '0em',
-  paddingBottom: 'calc(4rem - 15px)',
 }
 
 ColumnHeaderToolTip.propTypes = {
   helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   bottom: PropTypes.string,
   left: PropTypes.string,
-  paddingBottom: PropTypes.string,
 }

--- a/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
+++ b/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
@@ -5,24 +5,31 @@ import theme from '../../theme'
 
 export const TooltipPopup = styled('span')`
   display: block;
-  max-width: 18rem;
-  width: 100%;
+  max-width: 25rem;
+  width: max-content;
   background: ${theme.color.primaryColor};
   color: ${theme.color.white};
   position: absolute;
   font-size: ${theme.typography.smallFontSize};
   clip-path: polygon(0% 0%, 100% 0%, 100% 83%, 53% 83%, 47% 100%, 40% 83%, 0 83%);
   padding: 1em;
-  padding-bottom: calc(4rem - 15px);
-  bottom: ${(props) => props.bottom || '3.5em'};
-  left: ${(props) => props.left || '-1em'};
+  padding-bottom: ${(props) => props.paddingBottom || `calc(4rem - 15px)`};
+  bottom: ${(props) => props.bottom || '4em'};
+  left: ${(props) => props.left || '0'};
   white-space: normal;
   z-index: 100;
+  text-align: left;
 `
 
-const ColumnHeaderToolTip = ({ helperText, bottom, left }) => {
+const ColumnHeaderToolTip = ({ helperText, bottom, left, paddingBottom }) => {
   return (
-    <TooltipPopup role="tooltip" aria-labelledby="tooltip" bottom={bottom} left={left}>
+    <TooltipPopup
+      role="tooltip"
+      aria-labelledby="tooltip"
+      bottom={bottom}
+      left={left}
+      paddingBottom={paddingBottom}
+    >
       {helperText}
     </TooltipPopup>
   )
@@ -31,12 +38,14 @@ const ColumnHeaderToolTip = ({ helperText, bottom, left }) => {
 export default ColumnHeaderToolTip
 
 ColumnHeaderToolTip.defaultProps = {
-  bottom: '3.em',
-  left: '-1em',
+  bottom: '4em',
+  left: '0em',
+  paddingBottom: 'calc(4rem - 15px)',
 }
 
 ColumnHeaderToolTip.propTypes = {
   helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   bottom: PropTypes.string,
   left: PropTypes.string,
+  paddingBottom: PropTypes.string,
 }

--- a/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
+++ b/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components/macro'
+import theme from '../../theme'
+
+// export const Tooltip = styled('p')`
+//   white-space: nowrap;
+//   border-style: dotted;
+//   border-width: 0 0 ${theme.spacing.borderMedium} 0;
+//   position: relative;
+//   display: inline-grid;
+//   place-items: center;
+//   cursor: pointer;
+//   &:hover span,
+//   &:focus span {
+//     transition: ${theme.timing.hoverTransition};
+//     display: block;
+//   }
+// `
+export const TooltipPopup = styled('span')`
+  display: block;
+  min-width: 26ch;
+  width: 100%;
+  //   max-width: 52ch;
+  background: ${theme.color.primaryColor};
+  color: ${theme.color.white};
+  position: absolute;
+  font-size: ${theme.typography.smallFontSize};
+  clip-path: polygon(0% 0%, 100% 0%, 100% 83%, 53% 83%, 47% 100%, 40% 83%, 0 83%);
+  padding: 1em;
+  padding-bottom: calc(4rem - 15px);
+  top: -9rem;
+  left: -1em;
+  white-space: normal;
+  z-index: 100;
+  //   transition: ${theme.timing.hoverTransition};
+`
+
+const ColumnHeaderToolTip = ({ helperText }) => {
+  return (
+    <TooltipPopup role="tooltip" aria-labelledby="tooltip">
+      {helperText}
+    </TooltipPopup>
+  )
+}
+
+export default ColumnHeaderToolTip
+
+ColumnHeaderToolTip.propTypes = {
+  helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+}

--- a/src/components/generic/Table/table.js
+++ b/src/components/generic/Table/table.js
@@ -82,7 +82,6 @@ export const Th = styled.th(
     padding: ${theme.spacing.medium};
     background: ${theme.color.white};
     vertical-align: top;
-    // pointer-events: ${props.disabledHover && 'none'};
     &::after {
       content: ${props.isSortingEnabled ? ' \u25b2' : ''};
       font-size: small;

--- a/src/components/generic/Table/table.js
+++ b/src/components/generic/Table/table.js
@@ -82,7 +82,7 @@ export const Th = styled.th(
     padding: ${theme.spacing.medium};
     background: ${theme.color.white};
     vertical-align: top;
-    pointer-events: ${props.disabledHover && 'none'};
+    // pointer-events: ${props.disabledHover && 'none'};
     &::after {
       content: ${props.isSortingEnabled ? ' \u25b2' : ''};
       font-size: small;
@@ -155,7 +155,7 @@ export const OverviewTr = styled.tr`
       position: absolute;
       background-color: hsl(0 0% 90%);
       mix-blend-mode: multiply;
-      pointer-events: none;
+      pointer-events: auto;
       top: 0;
       left: 0;
       right: 0;

--- a/src/components/generic/links.js
+++ b/src/components/generic/links.js
@@ -27,4 +27,5 @@ export const NavLinkThatLooksLikeButtonIcon = styled(NavLinkThatLooksLikeButton)
 
 export const HelperTextLink = styled('a')`
   font-size: 1.2rem;
+  color: ${(props) => props.color || '#000000'};
 `

--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -162,7 +162,7 @@ const SiteForm = ({
           validationType={formik.errors.latitude && formik.touched.latitude ? 'error' : null}
           validationMessages={formik.errors.latitude}
           testId="latitude"
-          helperText={language.helperText.latitude()}
+          helperText={language.helperText.getLatitude()}
         />
         <InputWithLabelAndValidation
           required
@@ -174,7 +174,7 @@ const SiteForm = ({
           validationType={formik.errors.longitude && formik.touched.longitude ? 'error' : null}
           validationMessages={formik.errors.longitude}
           testId="longitude"
-          helperText={language.helperText.longitude()}
+          helperText={language.helperText.getLongitude()}
         />
         {isAppOnline && (
           <SingleSiteMap
@@ -201,7 +201,7 @@ const SiteForm = ({
           {...formik.getFieldProps('reef_type')}
           validationType={formik.errors.reef_type && formik.touched.reef_type ? 'error' : null}
           validationMessages={formik.errors.reef_type}
-          helperText={language.helperText.reefType()}
+          helperText={language.helperText.getReefType()}
         />
         <InputSelectWithLabelAndValidation
           label="Reef Zone"
@@ -211,7 +211,7 @@ const SiteForm = ({
           {...formik.getFieldProps('reef_zone')}
           validationType={formik.errors.reef_zone && formik.touched.reef_zone ? 'error' : null}
           validationMessages={formik.errors.reef_zone}
-          helperText={language.helperText.reefZone()}
+          helperText={language.helperText.getReefZone()}
         />
         <TextareaWithLabelAndValidation
           label="Notes"

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -413,7 +413,7 @@ const Users = () => {
     return Promise.resolve()
   }
 
-  const _useOnClickOutsideOfRef = useEffect(() => {
+  const _useOnClickOutsideOfInfoIcon = useEffect(() => {
     document.body.addEventListener('click', () => {
       if (isHelperTextShowing === true) {
         setIsHelperTextShowing(false)

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -413,11 +413,22 @@ const Users = () => {
     return Promise.resolve()
   }
 
+  const _useOnClickOutsideOfRef = useEffect(() => {
+    document.body.addEventListener('click', () => {
+      if (isHelperTextShowing === true) {
+        setIsHelperTextShowing(false)
+      }
+    })
+  }, [isHelperTextShowing])
+
   const tableColumnsForAdmin = useMemo(() => {
     const handleInfoIconClick = (event, label) => {
-      console.log(label)
-      // if (currentHelperTextLabel === label ) {}
-      isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
+      if (currentHelperTextLabel === label) {
+        isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
+      } else {
+        setIsHelperTextShowing(true)
+        setCurrentHelperTextLabel(label)
+      }
 
       event.stopPropagation()
     }
@@ -436,12 +447,12 @@ const Users = () => {
       {
         Header: () => (
           <>
-            {isHelperTextShowing ? (
+            {isHelperTextShowing && currentHelperTextLabel === 'admin' ? (
               <ColumnHeaderToolTip helperText={language.tooltipText.admin} />
             ) : null}
             <LabelContainer>
               <div>Admin</div>
-              <IconButton type="button" onClick={(event) => handleInfoIconClick(event, 'header')}>
+              <IconButton type="button" onClick={(event) => handleInfoIconClick(event, 'admin')}>
                 <IconInfo aria-label="info" />
               </IconButton>
             </LabelContainer>
@@ -451,12 +462,40 @@ const Users = () => {
         disableSortBy: true,
       },
       {
-        Header: 'Collector',
+        Header: () => (
+          <>
+            {isHelperTextShowing && currentHelperTextLabel === 'collector' ? (
+              <ColumnHeaderToolTip helperText={language.tooltipText.collector} />
+            ) : null}
+            <LabelContainer>
+              <div>Collector</div>
+              <IconButton
+                type="button"
+                onClick={(event) => handleInfoIconClick(event, 'collector')}
+              >
+                <IconInfo aria-label="info" />
+              </IconButton>
+            </LabelContainer>
+          </>
+        ),
+
         accessor: 'collector',
         disableSortBy: true,
       },
       {
-        Header: 'Read-Only',
+        Header: () => (
+          <>
+            {isHelperTextShowing && currentHelperTextLabel === 'readOnly' ? (
+              <ColumnHeaderToolTip helperText={language.tooltipText.readOnly} />
+            ) : null}
+            <LabelContainer>
+              <div>Read-Only</div>
+              <IconButton type="button" onClick={(event) => handleInfoIconClick(event, 'readOnly')}>
+                <IconInfo aria-label="info" />
+              </IconButton>
+            </LabelContainer>
+          </>
+        ),
         accessor: 'readonly',
         disableSortBy: true,
       },
@@ -472,7 +511,7 @@ const Users = () => {
         disableSortBy: true,
       },
     ]
-  }, [isHelperTextShowing])
+  }, [isHelperTextShowing, currentHelperTextLabel])
 
   const tableColumnsForNonAdmin = useMemo(() => {
     return [
@@ -776,7 +815,7 @@ const Users = () => {
                       isSortingEnabled={!column.disableSortBy}
                       disabledHover={column.disableSortBy}
                     >
-                      <span>{column.render('Header')}</span>
+                      <span id="header-span">{column.render('Header')}</span>
                     </Th>
                   )
                 })}

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -447,11 +447,11 @@ const Users = () => {
       {
         Header: () => (
           <>
-            {isHelperTextShowing && currentHelperTextLabel === 'admin' ? (
-              <ColumnHeaderToolTip helperText={language.tooltipText.admin} />
-            ) : null}
             <LabelContainer>
               <div>Admin</div>
+              {isHelperTextShowing && currentHelperTextLabel === 'admin' ? (
+                <ColumnHeaderToolTip helperText={language.tooltipText.admin} left="-4em" />
+              ) : null}
               <IconButton type="button" onClick={(event) => handleInfoIconClick(event, 'admin')}>
                 <IconInfo aria-label="info" />
               </IconButton>
@@ -464,11 +464,11 @@ const Users = () => {
       {
         Header: () => (
           <>
-            {isHelperTextShowing && currentHelperTextLabel === 'collector' ? (
-              <ColumnHeaderToolTip helperText={language.tooltipText.collector} />
-            ) : null}
             <LabelContainer>
               <div>Collector</div>
+              {isHelperTextShowing && currentHelperTextLabel === 'collector' ? (
+                <ColumnHeaderToolTip helperText={language.tooltipText.collector} left="-2em" />
+              ) : null}
               <IconButton
                 type="button"
                 onClick={(event) => handleInfoIconClick(event, 'collector')}
@@ -485,11 +485,11 @@ const Users = () => {
       {
         Header: () => (
           <>
-            {isHelperTextShowing && currentHelperTextLabel === 'readOnly' ? (
-              <ColumnHeaderToolTip helperText={language.tooltipText.readOnly} />
-            ) : null}
             <LabelContainer>
               <div>Read-Only</div>
+              {isHelperTextShowing && currentHelperTextLabel === 'readOnly' ? (
+                <ColumnHeaderToolTip helperText={language.tooltipText.readOnly} left="-1em" />
+              ) : null}
               <IconButton type="button" onClick={(event) => handleInfoIconClick(event, 'readOnly')}>
                 <IconInfo aria-label="info" />
               </IconButton>

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -450,7 +450,7 @@ const Users = () => {
             <LabelContainer>
               <div>Admin</div>
               {isHelperTextShowing && currentHelperTextLabel === 'admin' ? (
-                <ColumnHeaderToolTip helperText={language.tooltipText.admin} left="-4em" />
+                <ColumnHeaderToolTip helperText={language.tooltipText.admin} left="-4.2em" />
               ) : null}
               <IconButton type="button" onClick={(event) => handleInfoIconClick(event, 'admin')}>
                 <IconInfo aria-label="info" />
@@ -467,7 +467,7 @@ const Users = () => {
             <LabelContainer>
               <div>Collector</div>
               {isHelperTextShowing && currentHelperTextLabel === 'collector' ? (
-                <ColumnHeaderToolTip helperText={language.tooltipText.collector} left="-2em" />
+                <ColumnHeaderToolTip helperText={language.tooltipText.collector} left="-2.5em" />
               ) : null}
               <IconButton
                 type="button"
@@ -488,7 +488,7 @@ const Users = () => {
             <LabelContainer>
               <div>Read-Only</div>
               {isHelperTextShowing && currentHelperTextLabel === 'readOnly' ? (
-                <ColumnHeaderToolTip helperText={language.tooltipText.readOnly} left="-1em" />
+                <ColumnHeaderToolTip helperText={language.tooltipText.readOnly} left="-1.8em" />
               ) : null}
               <IconButton type="button" onClick={(event) => handleInfoIconClick(event, 'readOnly')}>
                 <IconInfo aria-label="info" />

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import styled, { css } from 'styled-components/macro'
 
-import { ButtonSecondary, ButtonCaution } from '../../generic/buttons'
+import { ButtonSecondary, ButtonCaution, IconButton } from '../../generic/buttons'
 import { ContentPageLayout } from '../../Layout'
 import { getProfileNameOrEmailForPendingUser } from '../../../library/getProfileNameOrEmailForPendingUser'
 import { getTableColumnHeaderProps } from '../../../library/getTableColumnHeaderProps'
@@ -17,6 +17,7 @@ import {
   IconAccount,
   IconAccountConvert,
   IconPlus,
+  IconInfo,
   IconAlert,
   IconAccountRemove,
 } from '../../icons'
@@ -61,6 +62,8 @@ import {
 } from '../../../App/currentUserProfileHelpers'
 import { PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
 import { useHttpResponseErrorHandler } from '../../../App/HttpResponseErrorHandlerContext'
+import { LabelContainer } from '../../generic/form'
+import ColumnHeaderToolTip from '../../ColumnHeaderToolTip/ColumnHeaderToolTip'
 
 const ToolbarRowWrapper = styled('div')`
   display: grid;
@@ -146,6 +149,8 @@ const Users = () => {
     useState(false)
   const [isRemoveUserModalOpen, setIsRemoveUserModalOpen] = useState(false)
   const [isSendEmailToNewUserPromptOpen, setIsSendEmailToNewUserPromptOpen] = useState(false)
+  const [isHelperTextShowing, setIsHelperTextShowing] = useState(false)
+  const [currentHelperTextLabel, setCurrentHelperTextLabel] = useState(null)
 
   const [isTransferSampleUnitsModalOpen, setIsTransferSampleUnitsModalOpen] = useState(false)
   const [newUserEmail, setNewUserEmail] = useState('')
@@ -409,6 +414,14 @@ const Users = () => {
   }
 
   const tableColumnsForAdmin = useMemo(() => {
+    const handleInfoIconClick = (event, label) => {
+      console.log(label)
+      // if (currentHelperTextLabel === label ) {}
+      isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
+
+      event.stopPropagation()
+    }
+
     return [
       {
         Header: 'Name',
@@ -421,7 +434,19 @@ const Users = () => {
         sortType: reactTableNaturalSort,
       },
       {
-        Header: 'Admin',
+        Header: () => (
+          <>
+            {isHelperTextShowing ? (
+              <ColumnHeaderToolTip helperText={language.tooltipText.admin} />
+            ) : null}
+            <LabelContainer>
+              <div>Admin</div>
+              <IconButton type="button" onClick={(event) => handleInfoIconClick(event, 'header')}>
+                <IconInfo aria-label="info" />
+              </IconButton>
+            </LabelContainer>
+          </>
+        ),
         accessor: 'admin',
         disableSortBy: true,
       },
@@ -447,7 +472,7 @@ const Users = () => {
         disableSortBy: true,
       },
     ]
-  }, [])
+  }, [isHelperTextShowing])
 
   const tableColumnsForNonAdmin = useMemo(() => {
     return [

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -319,7 +319,7 @@ const BenthicLitObservationsTable = ({
                       </div>
                       {isHelperTextShowing && currentHelperTextLabel === 'benthicAttribute' ? (
                         <ColumnHeaderToolTip
-                          helperText={language.tooltipText.benthicAttribute()}
+                          helperText={language.tooltipText.getBenthicAttribute()}
                           left="4.2em"
                         />
                       ) : null}

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -320,8 +320,7 @@ const BenthicLitObservationsTable = ({
                       {isHelperTextShowing && currentHelperTextLabel === 'benthicAttribute' ? (
                         <ColumnHeaderToolTip
                           helperText={language.tooltipText.benthicAttribute()}
-                          paddingBottom="3.5em"
-                          left="4.8em"
+                          left="4.2em"
                         />
                       ) : null}
                       <IconButton

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useState, useEffect } from 'react'
 import styled from 'styled-components'
 
 import {
@@ -16,13 +16,13 @@ import {
   observationsReducerPropType,
   benthicPitRecordPropType,
 } from '../../../../App/mermaidData/mermaidDataProptypes'
-import { ButtonPrimary } from '../../../generic/buttons'
+import { ButtonPrimary, IconButton } from '../../../generic/buttons'
 import { getObservationsPropertyNames } from '../../../../App/mermaidData/recordProtocolHelpers'
 import { getOptions } from '../../../../library/getOptions'
 import { H2 } from '../../../generic/text'
-import { IconClose, IconPlus } from '../../../icons'
+import { IconClose, IconPlus, IconInfo } from '../../../icons'
 import { inputOptionsPropTypes } from '../../../../library/miscPropTypes'
-import { InputWrapper, RequiredIndicator, Select } from '../../../generic/form'
+import { InputWrapper, LabelContainer, RequiredIndicator, Select } from '../../../generic/form'
 import { Tr, Td, Th } from '../../../generic/Table/table'
 import BenthicPitLitObservationSummaryStats from '../../../BenthicPitLitObservationSummaryStats/BenthicPitLitObservationSummaryStats'
 import getObservationValidationInfo from '../CollectRecordFormPage/getObservationValidationInfo'
@@ -30,6 +30,7 @@ import InputNumberNumericCharactersOnly from '../../../generic/InputNumberNumeri
 import language from '../../../../language'
 import ObservationValidationInfo from '../ObservationValidationInfo'
 import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
+import ColumnHeaderToolTip from '../../../ColumnHeaderToolTip/ColumnHeaderToolTip'
 
 const StyledColgroup = styled('colgroup')`
   col {
@@ -57,12 +58,33 @@ const BenthicLitObservationsTable = ({
 }) => {
   const [observationsState, observationsDispatch] = observationsReducer
   const [autoFocusAllowed, setAutoFocusAllowed] = useState(false)
+  const [isHelperTextShowing, setIsHelperTextShowing] = useState(false)
+  const [currentHelperTextLabel, setCurrentHelperTextLabel] = useState(null)
 
   const handleAddObservation = () => {
     setAreObservationsInputsDirty(true)
     setAutoFocusAllowed(true)
 
     observationsDispatch({ type: 'addObservation' })
+  }
+
+  const _useOnClickOutsideOfInfoIcon = useEffect(() => {
+    document.body.addEventListener('click', () => {
+      if (isHelperTextShowing === true) {
+        setIsHelperTextShowing(false)
+      }
+    })
+  }, [isHelperTextShowing])
+
+  const handleInfoIconClick = (event, label) => {
+    if (currentHelperTextLabel === label) {
+      isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
+    } else {
+      setIsHelperTextShowing(true)
+      setCurrentHelperTextLabel(label)
+    }
+
+    event.stopPropagation()
   }
 
   const observationsRows = useMemo(() => {
@@ -291,8 +313,24 @@ const BenthicLitObservationsTable = ({
                   <Th> </Th>
 
                   <Th align="left" id="benthic-attribute-label">
-                    Benthic Attribute
-                    <RequiredIndicator />
+                    <LabelContainer>
+                      <div>
+                        Benthic Attribute <RequiredIndicator />
+                      </div>
+                      {isHelperTextShowing && currentHelperTextLabel === 'benthicAttribute' ? (
+                        <ColumnHeaderToolTip
+                          helperText={language.tooltipText.benthicAttribute()}
+                          paddingBottom="3.5em"
+                          left="4.8em"
+                        />
+                      ) : null}
+                      <IconButton
+                        type="button"
+                        onClick={(event) => handleInfoIconClick(event, 'benthicAttribute')}
+                      >
+                        <IconInfo aria-label="info" />
+                      </IconButton>
+                    </LabelContainer>
                   </Th>
                   <Th align="right" id="growth-form-label">
                     Growth Form

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitTransectInputs.js
@@ -306,7 +306,7 @@ const BenthicLitTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.reef_slope}
           onChange={handleReefSlopeChange}
-          helperText={language.helperText.reefSlope()}
+          helperText={language.helperText.getReefSlope()}
         />
         <InputSelectWithLabelAndValidation
           label="Visibility"
@@ -372,7 +372,7 @@ const BenthicLitTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.relative_depth}
           onChange={handleRelativeDepthChange}
-          helperText={language.helperText.relativeDepth()}
+          helperText={language.helperText.getRelativeDepth()}
         />
         <InputSelectWithLabelAndValidation
           label="Tide"
@@ -391,7 +391,7 @@ const BenthicLitTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.tide}
           onChange={handleTideChange}
-          helperText={language.helperText.tide()}
+          helperText={language.helperText.getTide()}
         />
         <TextareaWithLabelAndValidation
           label="Notes"

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -409,7 +409,7 @@ const BenthicPhotoQuadratObservationTable = ({
                   </div>
                   {isHelperTextShowing && currentHelperTextLabel === 'benthicAttribute' ? (
                     <ColumnHeaderToolTip
-                      helperText={language.tooltipText.benthicAttribute()}
+                      helperText={language.tooltipText.getBenthicAttribute()}
                       left="4.2em"
                     />
                   ) : null}

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -392,7 +392,7 @@ const BenthicPhotoQuadratObservationTable = ({
                     Quadrat <RequiredIndicator />
                   </div>
                   {isHelperTextShowing && currentHelperTextLabel === 'quadrat' ? (
-                    <ColumnHeaderToolTip helperText={language.tooltipText.quadrat} left="-1.2em" />
+                    <ColumnHeaderToolTip helperText={language.tooltipText.quadrat} left="-2em" />
                   ) : null}
                   <IconButton
                     type="button"
@@ -410,8 +410,7 @@ const BenthicPhotoQuadratObservationTable = ({
                   {isHelperTextShowing && currentHelperTextLabel === 'benthicAttribute' ? (
                     <ColumnHeaderToolTip
                       helperText={language.tooltipText.benthicAttribute()}
-                      paddingBottom="3.5em"
-                      left="4.8em"
+                      left="4.2em"
                     />
                   ) : null}
                   <IconButton
@@ -431,10 +430,7 @@ const BenthicPhotoQuadratObservationTable = ({
                     Number of Points <RequiredIndicator />
                   </div>
                   {isHelperTextShowing && currentHelperTextLabel === 'numberOfPoints' ? (
-                    <ColumnHeaderToolTip
-                      helperText={language.tooltipText.numberOfPoints}
-                      paddingBottom="3em"
-                    />
+                    <ColumnHeaderToolTip helperText={language.tooltipText.numberOfPoints} />
                   ) : null}
                   <IconButton
                     type="button"

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -28,10 +28,11 @@ import { summarizeArrayObjectValuesByProperty } from '../../../../library/summar
 import { ObservationsSummaryStats, Tr, Td, Th } from '../../../generic/Table/table'
 import getObservationValidationInfo from '../CollectRecordFormPage/getObservationValidationInfo'
 import InputNumberNumericCharactersOnly from '../../../generic/InputNumberNumericCharctersOnly/InputNumberNumericCharactersOnly'
-import language from '../../../../language'
+
 import ObservationValidationInfo from '../ObservationValidationInfo'
 import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
 import ColumnHeaderToolTip from '../../../ColumnHeaderToolTip/ColumnHeaderToolTip'
+import language from '../../../../language'
 
 const StyledColgroup = styled('colgroup')`
   col {
@@ -386,7 +387,20 @@ const BenthicPhotoQuadratObservationTable = ({
             <Tr>
               <Th> </Th>
               <Th align="right" id="quadrat-number-label">
-                Quadrat <RequiredIndicator />
+                <LabelContainer>
+                  <div>
+                    Quadrat <RequiredIndicator />
+                  </div>
+                  {isHelperTextShowing && currentHelperTextLabel === 'quadrat' ? (
+                    <ColumnHeaderToolTip helperText={language.tooltipText.quadrat} left="-1.2em" />
+                  ) : null}
+                  <IconButton
+                    type="button"
+                    onClick={(event) => handleInfoIconClick(event, 'quadrat')}
+                  >
+                    <IconInfo aria-label="info" />
+                  </IconButton>
+                </LabelContainer>
               </Th>
               <Th align="left" id="benthic-attribute-label">
                 <LabelContainer>
@@ -412,7 +426,23 @@ const BenthicPhotoQuadratObservationTable = ({
                 Growth Form
               </Th>
               <Th align="right" id="number-of-points-label">
-                Number of Points <RequiredIndicator />
+                <LabelContainer>
+                  <div>
+                    Number of Points <RequiredIndicator />
+                  </div>
+                  {isHelperTextShowing && currentHelperTextLabel === 'numberOfPoints' ? (
+                    <ColumnHeaderToolTip
+                      helperText={language.tooltipText.numberOfPoints}
+                      paddingBottom="3em"
+                    />
+                  ) : null}
+                  <IconButton
+                    type="button"
+                    onClick={(event) => handleInfoIconClick(event, 'numberOfPoints')}
+                  >
+                    <IconInfo aria-label="info" />
+                  </IconButton>
+                </LabelContainer>
               </Th>
               {areValidationsShowing ? <Th align="center">Validations</Th> : null}
               <Th> </Th>

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useState, useEffect } from 'react'
 import styled from 'styled-components'
 
 import {
@@ -11,7 +11,7 @@ import {
   StickyObservationTable,
   UnderTableRow,
 } from '../CollectingFormPage.Styles'
-import { ButtonPrimary } from '../../../generic/buttons'
+import { ButtonPrimary, IconButton } from '../../../generic/buttons'
 import {
   choicesPropType,
   benthicPhotoQuadratPropType,
@@ -20,9 +20,9 @@ import {
 import { getObservationsPropertyNames } from '../../../../App/mermaidData/recordProtocolHelpers'
 import { getOptions } from '../../../../library/getOptions'
 import { H2 } from '../../../generic/text'
-import { IconClose, IconPlus } from '../../../icons'
+import { IconClose, IconPlus, IconInfo } from '../../../icons'
 import { inputOptionsPropTypes } from '../../../../library/miscPropTypes'
-import { InputWrapper, RequiredIndicator, Select } from '../../../generic/form'
+import { InputWrapper, LabelContainer, RequiredIndicator, Select } from '../../../generic/form'
 import { roundToOneDecimal } from '../../../../library/numbers/roundToOneDecimal'
 import { summarizeArrayObjectValuesByProperty } from '../../../../library/summarizeArrayObjectValuesByProperty'
 import { ObservationsSummaryStats, Tr, Td, Th } from '../../../generic/Table/table'
@@ -31,6 +31,7 @@ import InputNumberNumericCharactersOnly from '../../../generic/InputNumberNumeri
 import language from '../../../../language'
 import ObservationValidationInfo from '../ObservationValidationInfo'
 import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
+import ColumnHeaderToolTip from '../../../ColumnHeaderToolTip/ColumnHeaderToolTip'
 
 const StyledColgroup = styled('colgroup')`
   col {
@@ -73,11 +74,32 @@ const BenthicPhotoQuadratObservationTable = ({
 }) => {
   const [autoFocusAllowed, setAutoFocusAllowed] = useState(false)
   const [observationsState, observationsDispatch] = observationsReducer
+  const [isHelperTextShowing, setIsHelperTextShowing] = useState(false)
+  const [currentHelperTextLabel, setCurrentHelperTextLabel] = useState(null)
 
   const handleAddObservation = () => {
     setAreObservationsInputsDirty(true)
     setAutoFocusAllowed(true)
     observationsDispatch({ type: 'addObservation' })
+  }
+
+  const _useOnClickOutsideOfInfoIcon = useEffect(() => {
+    document.body.addEventListener('click', () => {
+      if (isHelperTextShowing === true) {
+        setIsHelperTextShowing(false)
+      }
+    })
+  }, [isHelperTextShowing])
+
+  const handleInfoIconClick = (event, label) => {
+    if (currentHelperTextLabel === label) {
+      isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
+    } else {
+      setIsHelperTextShowing(true)
+      setCurrentHelperTextLabel(label)
+    }
+
+    event.stopPropagation()
   }
 
   const observationCategoryPercentages = useMemo(() => {
@@ -367,7 +389,24 @@ const BenthicPhotoQuadratObservationTable = ({
                 Quadrat <RequiredIndicator />
               </Th>
               <Th align="left" id="benthic-attribute-label">
-                Benthic Attribute <RequiredIndicator />
+                <LabelContainer>
+                  <div>
+                    Benthic Attribute <RequiredIndicator />
+                  </div>
+                  {isHelperTextShowing && currentHelperTextLabel === 'benthicAttribute' ? (
+                    <ColumnHeaderToolTip
+                      helperText={language.tooltipText.benthicAttribute()}
+                      paddingBottom="3.5em"
+                      left="4.8em"
+                    />
+                  ) : null}
+                  <IconButton
+                    type="button"
+                    onClick={(event) => handleInfoIconClick(event, 'benthicAttribute')}
+                  >
+                    <IconInfo aria-label="info" />
+                  </IconButton>
+                </LabelContainer>
               </Th>
               <Th align="right" id="growth-form-label">
                 Growth Form

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratTransectInputs.js
@@ -459,7 +459,7 @@ const BenthicPhotoQuadratTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.relative_depth}
           onChange={handleRelativeDepthChange}
-          helperText={language.helperText.relativeDepth()}
+          helperText={language.helperText.getRelativeDepth()}
         />
         <InputSelectWithLabelAndValidation
           label="Tide"
@@ -478,7 +478,7 @@ const BenthicPhotoQuadratTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.tide}
           onChange={handleTideChange}
-          helperText={language.helperText.tide()}
+          helperText={language.helperText.getTide()}
         />
         <TextareaWithLabelAndValidation
           label="Notes"

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
@@ -16,12 +16,12 @@ import {
   observationsReducerPropType,
   benthicPitRecordPropType,
 } from '../../../../App/mermaidData/mermaidDataProptypes'
-import { ButtonPrimary } from '../../../generic/buttons'
+import { ButtonPrimary, IconButton } from '../../../generic/buttons'
 import { getOptions } from '../../../../library/getOptions'
 import { H2 } from '../../../generic/text'
-import { IconClose, IconPlus } from '../../../icons'
+import { IconClose, IconPlus, IconInfo } from '../../../icons'
 import { inputOptionsPropTypes } from '../../../../library/miscPropTypes'
-import { InputWrapper, RequiredIndicator, Select } from '../../../generic/form'
+import { InputWrapper, LabelContainer, RequiredIndicator, Select } from '../../../generic/form'
 import { Tr, Td, Th } from '../../../generic/Table/table'
 import getObservationValidationInfo from '../CollectRecordFormPage/getObservationValidationInfo'
 import language from '../../../../language'
@@ -29,6 +29,7 @@ import BenthicPitLitObservationSummaryStats from '../../../BenthicPitLitObservat
 import { getObservationsPropertyNames } from '../../../../App/mermaidData/recordProtocolHelpers'
 import ObservationValidationInfo from '../ObservationValidationInfo'
 import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
+import ColumnHeaderToolTip from '../../../ColumnHeaderToolTip/ColumnHeaderToolTip'
 
 const StyledColgroup = styled('colgroup')`
   col {
@@ -69,6 +70,8 @@ const BenthicPitObservationsTable = ({
 }) => {
   const [observationsState, observationsDispatch] = observationsReducer
   const [autoFocusAllowed, setAutoFocusAllowed] = useState(false)
+  const [isHelperTextShowing, setIsHelperTextShowing] = useState(false)
+  const [currentHelperTextLabel, setCurrentHelperTextLabel] = useState(null)
 
   const { interval_start: intervalStart, interval_size: intervalSize } = formik.values
 
@@ -87,6 +90,25 @@ const BenthicPitObservationsTable = ({
     },
     [intervalSize, intervalStart, observationsDispatch],
   )
+
+  const _useOnClickOutsideOfInfoIcon = useEffect(() => {
+    document.body.addEventListener('click', () => {
+      if (isHelperTextShowing === true) {
+        setIsHelperTextShowing(false)
+      }
+    })
+  }, [isHelperTextShowing])
+
+  const handleInfoIconClick = (event, label) => {
+    if (currentHelperTextLabel === label) {
+      isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
+    } else {
+      setIsHelperTextShowing(true)
+      setCurrentHelperTextLabel(label)
+    }
+
+    event.stopPropagation()
+  }
 
   const observationsRows = useMemo(() => {
     const growthFormOptions = getOptions(choices.growthforms.data)
@@ -295,7 +317,24 @@ const BenthicPitObservationsTable = ({
                     Interval
                   </Th>
                   <Th align="left" id="benthic-attribute-label">
-                    Benthic Attribute <RequiredIndicator />
+                    <LabelContainer>
+                      <div>
+                        Benthic Attribute <RequiredIndicator />
+                      </div>
+                      {isHelperTextShowing && currentHelperTextLabel === 'benthicAttribute' ? (
+                        <ColumnHeaderToolTip
+                          helperText={language.tooltipText.benthicAttribute()}
+                          paddingBottom="3.5em"
+                          left="4.8em"
+                        />
+                      ) : null}
+                      <IconButton
+                        type="button"
+                        onClick={(event) => handleInfoIconClick(event, 'benthicAttribute')}
+                      >
+                        <IconInfo aria-label="info" />
+                      </IconButton>
+                    </LabelContainer>
                   </Th>
                   <Th align="right" id="growth-form-label">
                     Growth Form

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
@@ -323,7 +323,7 @@ const BenthicPitObservationsTable = ({
                       </div>
                       {isHelperTextShowing && currentHelperTextLabel === 'benthicAttribute' ? (
                         <ColumnHeaderToolTip
-                          helperText={language.tooltipText.benthicAttribute()}
+                          helperText={language.tooltipText.getBenthicAttribute()}
                           left="4.2em"
                         />
                       ) : null}

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
@@ -324,8 +324,7 @@ const BenthicPitObservationsTable = ({
                       {isHelperTextShowing && currentHelperTextLabel === 'benthicAttribute' ? (
                         <ColumnHeaderToolTip
                           helperText={language.tooltipText.benthicAttribute()}
-                          paddingBottom="3.5em"
-                          left="4.8em"
+                          left="4.2em"
                         />
                       ) : null}
                       <IconButton

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitTransectInputs.js
@@ -367,7 +367,7 @@ const BenthicPitTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.reef_slope}
           onChange={handleReefSlopeChange}
-          helperText={language.helperText.reefSlope()}
+          helperText={language.helperText.getReefSlope()}
         />
         <InputSelectWithLabelAndValidation
           label="Visibility"
@@ -433,7 +433,7 @@ const BenthicPitTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.relative_depth}
           onChange={handleRelativeDepthChange}
-          helperText={language.helperText.relativeDepth()}
+          helperText={language.helperText.getRelativeDepth()}
         />
         <InputSelectWithLabelAndValidation
           label="Tide"
@@ -452,7 +452,7 @@ const BenthicPitTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.tide}
           onChange={handleTideChange}
-          helperText={language.helperText.tide()}
+          helperText={language.helperText.getTide()}
         />
         <TextareaWithLabelAndValidation
           label="Notes"

--- a/src/components/pages/collectRecordFormPages/BleachingForm/BleachingTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/BleachingTransectInputs.js
@@ -301,7 +301,7 @@ const BleachingTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.relative_depth}
           onChange={handleRelativeDepthChange}
-          helperText={language.helperText.relativeDepth()}
+          helperText={language.helperText.getRelativeDepth()}
         />
         <InputSelectWithLabelAndValidation
           label="Tide"
@@ -320,7 +320,7 @@ const BleachingTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.tide}
           onChange={handleTideChange}
-          helperText={language.helperText.tide()}
+          helperText={language.helperText.getTide()}
         />
         <TextareaWithLabelAndValidation
           label="Notes"

--- a/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
@@ -278,7 +278,7 @@ const PercentCoverObservationTable = ({
                       {isHelperTextShowing && currentHelperTextLabel === 'hardCoralPercentage' ? (
                         <ColumnHeaderToolTip
                           helperText={language.tooltipText.hardCoralPercentage}
-                          left="5.5em"
+                          left="5em"
                         />
                       ) : null}
                       <IconButton
@@ -297,7 +297,7 @@ const PercentCoverObservationTable = ({
                       {isHelperTextShowing && currentHelperTextLabel === 'softCoralPercentage' ? (
                         <ColumnHeaderToolTip
                           helperText={language.tooltipText.softCoralPercentage}
-                          left="5em"
+                          left="4.5em"
                         />
                       ) : null}
                       <IconButton
@@ -316,7 +316,7 @@ const PercentCoverObservationTable = ({
                       {isHelperTextShowing && currentHelperTextLabel === 'microalgaePercentage' ? (
                         <ColumnHeaderToolTip
                           helperText={language.tooltipText.microalgaePercentage}
-                          left="6em"
+                          left="5.3em"
                         />
                       ) : null}
                       <IconButton

--- a/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useState, useEffect } from 'react'
 import styled from 'styled-components'
 
 import {
@@ -13,16 +13,18 @@ import {
   bleachingRecordPropType,
   observationsReducerPropType,
 } from '../../../../App/mermaidData/mermaidDataProptypes'
-import { ButtonPrimary } from '../../../generic/buttons'
+import { ButtonPrimary, IconButton } from '../../../generic/buttons'
 import { H2 } from '../../../generic/text'
-import { IconClose, IconPlus } from '../../../icons'
-import { InputWrapper, RequiredIndicator } from '../../../generic/form'
+import { IconClose, IconPlus, IconInfo } from '../../../icons'
+import { InputWrapper, LabelContainer, RequiredIndicator } from '../../../generic/form'
 import { Tr, Td, Th } from '../../../generic/Table/table'
 import getObservationValidationInfo from '../CollectRecordFormPage/getObservationValidationInfo'
 import InputNumberNumericCharactersOnly from '../../../generic/InputNumberNumericCharctersOnly/InputNumberNumericCharactersOnly'
 import { getObservationsPropertyNames } from '../../../../App/mermaidData/recordProtocolHelpers'
 import BleachingPercentCoverSummaryStats from '../../../BleachingPercentCoverSummaryStats/BleachingPercentCoverSummaryStats'
 import ObservationValidationInfo from '../ObservationValidationInfo'
+import ColumnHeaderToolTip from '../../../ColumnHeaderToolTip/ColumnHeaderToolTip'
+import language from '../../../../language'
 
 const StyledColgroup = styled('colgroup')`
   col {
@@ -52,12 +54,33 @@ const PercentCoverObservationTable = ({
 }) => {
   const [observationsState, observationsDispatch] = observationsReducer
   const [autoFocusAllowed, setAutoFocusAllowed] = useState(false)
+  const [isHelperTextShowing, setIsHelperTextShowing] = useState(false)
+  const [currentHelperTextLabel, setCurrentHelperTextLabel] = useState(null)
 
   const handleAddObservation = () => {
     setAreObservationsInputsDirty(true)
     setAutoFocusAllowed(true)
 
     observationsDispatch({ type: 'addObservation' })
+  }
+
+  const _useOnClickOutsideOfInfoIcon = useEffect(() => {
+    document.body.addEventListener('click', () => {
+      if (isHelperTextShowing === true) {
+        setIsHelperTextShowing(false)
+      }
+    })
+  }, [isHelperTextShowing])
+
+  const handleInfoIconClick = (event, label) => {
+    if (currentHelperTextLabel === label) {
+      isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
+    } else {
+      setIsHelperTextShowing(true)
+      setCurrentHelperTextLabel(label)
+    }
+
+    event.stopPropagation()
   }
 
   const observationRows = useMemo(() => {
@@ -248,13 +271,61 @@ const PercentCoverObservationTable = ({
                     Quadrat
                   </Th>
                   <Th align="center" id="hard-coral-percent-cover-label">
-                    Hard coral % cover <RequiredIndicator />
+                    <LabelContainer>
+                      <div>
+                        Hard coral % cover <RequiredIndicator />
+                      </div>
+                      {isHelperTextShowing && currentHelperTextLabel === 'hardCoralPercentage' ? (
+                        <ColumnHeaderToolTip
+                          helperText={language.tooltipText.hardCoralPercentage}
+                          left="5.5em"
+                        />
+                      ) : null}
+                      <IconButton
+                        type="button"
+                        onClick={(event) => handleInfoIconClick(event, 'hardCoralPercentage')}
+                      >
+                        <IconInfo aria-label="info" />
+                      </IconButton>
+                    </LabelContainer>
                   </Th>
                   <Th align="center" id="soft-coral-percent-cover-label">
-                    Soft coral % cover <RequiredIndicator />
+                    <LabelContainer>
+                      <div>
+                        Soft coral % cover <RequiredIndicator />
+                      </div>
+                      {isHelperTextShowing && currentHelperTextLabel === 'softCoralPercentage' ? (
+                        <ColumnHeaderToolTip
+                          helperText={language.tooltipText.softCoralPercentage}
+                          left="5em"
+                        />
+                      ) : null}
+                      <IconButton
+                        type="button"
+                        onClick={(event) => handleInfoIconClick(event, 'softCoralPercentage')}
+                      >
+                        <IconInfo aria-label="info" />
+                      </IconButton>
+                    </LabelContainer>
                   </Th>
                   <Th align="center" id="microalgae-percent-cover-label">
-                    Microalgae % cover <RequiredIndicator />
+                    <LabelContainer>
+                      <div>
+                        Microalgae % cover <RequiredIndicator />
+                      </div>
+                      {isHelperTextShowing && currentHelperTextLabel === 'microalgaePercentage' ? (
+                        <ColumnHeaderToolTip
+                          helperText={language.tooltipText.microalgaePercentage}
+                          left="6em"
+                        />
+                      ) : null}
+                      <IconButton
+                        type="button"
+                        onClick={(event) => handleInfoIconClick(event, 'microalgaePercentage')}
+                      >
+                        <IconInfo aria-label="info" />
+                      </IconButton>
+                    </LabelContainer>
                   </Th>
                   {areValidationsShowing ? <Th align="center">Validations</Th> : null}
                   <Th />

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -408,17 +408,17 @@ const FishBeltObservationTable = ({
             <Tr>
               <Th> </Th>
               <Th align="left" id="fish-name-label">
-                {isHelperTextShowing && currentHelperTextLabel === 'fishName' ? (
-                  <ColumnHeaderToolTip
-                    helperText={language.tooltipText.fishName}
-                    bottom="5em"
-                    left="2.8em"
-                  />
-                ) : null}
                 <LabelContainer>
                   <div>
                     Fish Name <RequiredIndicator />
                   </div>
+                  {isHelperTextShowing && currentHelperTextLabel === 'fishName' ? (
+                    <ColumnHeaderToolTip
+                      helperText={language.tooltipText.fishName()}
+                      bottom="5.8em"
+                      paddingBottom="3.5em"
+                    />
+                  ) : null}
                   <IconButton
                     type="button"
                     onClick={(event) => handleInfoIconClick(event, 'fishName')}
@@ -428,10 +428,45 @@ const FishBeltObservationTable = ({
                 </LabelContainer>
               </Th>
               <Th align="right" id="fish-size-label">
-                Size (cm) <RequiredIndicator />
+                <LabelContainer>
+                  <div>
+                    Size (cm) <RequiredIndicator />
+                  </div>
+                  {isHelperTextShowing && currentHelperTextLabel === 'fishSize' ? (
+                    <ColumnHeaderToolTip
+                      helperText={language.tooltipText.fishSize}
+                      bottom="5.8em"
+                      left="-1em"
+                    />
+                  ) : null}
+
+                  <IconButton
+                    type="button"
+                    onClick={(event) => handleInfoIconClick(event, 'fishSize')}
+                  >
+                    <IconInfo aria-label="info" />
+                  </IconButton>
+                </LabelContainer>
               </Th>
               <Th align="right" id="fish-count-label">
-                Count <RequiredIndicator />
+                <LabelContainer>
+                  <div>
+                    Count <RequiredIndicator />
+                  </div>
+                  {isHelperTextShowing && currentHelperTextLabel === 'fishCount' ? (
+                    <ColumnHeaderToolTip
+                      helperText={language.tooltipText.fishCount}
+                      bottom="5.8em"
+                      left="-3em"
+                    />
+                  ) : null}
+                  <IconButton
+                    type="button"
+                    onClick={(event) => handleInfoIconClick(event, 'fishCount')}
+                  >
+                    <IconInfo aria-label="info" />
+                  </IconButton>
+                </LabelContainer>
               </Th>
               <Th align="right">
                 Biomass

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import {
@@ -18,15 +18,15 @@ import {
   UnderTableRow,
   UnderTableRowButtonArea,
 } from '../CollectingFormPage.Styles'
-import { ButtonPrimary } from '../../../generic/buttons'
+import { ButtonPrimary, IconButton } from '../../../generic/buttons'
 import { FishBeltObservationSizeSelect } from './FishBeltObservationSizeSelect'
 import { getFishBinLabel } from './fishBeltBins'
 import { getObservationBiomass } from './fishBeltBiomass'
 import { getObservationsPropertyNames } from '../../../../App/mermaidData/recordProtocolHelpers'
 import { H2 } from '../../../generic/text'
-import { IconClose, IconPlus } from '../../../icons'
+import { IconClose, IconPlus, IconInfo } from '../../../icons'
 import { inputOptionsPropTypes } from '../../../../library/miscPropTypes'
-import { InputWrapper, RequiredIndicator } from '../../../generic/form'
+import { InputWrapper, LabelContainer, RequiredIndicator } from '../../../generic/form'
 import { roundToOneDecimal } from '../../../../library/numbers/roundToOneDecimal'
 import { summarizeArrayObjectValuesByProperty } from '../../../../library/summarizeArrayObjectValuesByProperty'
 import { ObservationsSummaryStats, Tr, Td, Th } from '../../../generic/Table/table'
@@ -36,6 +36,7 @@ import InputNumberNumericCharactersOnly from '../../../generic/InputNumberNumeri
 import language from '../../../../language'
 import ObservationValidationInfo from '../ObservationValidationInfo'
 import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
+import ColumnHeaderToolTip from '../../../ColumnHeaderToolTip/ColumnHeaderToolTip'
 
 const StyledColgroup = styled('colgroup')`
   col {
@@ -97,6 +98,8 @@ const FishBeltObservationTable = ({
   const [autoFocusAllowed, setAutoFocusAllowed] = useState(false)
   const [observationsState, observationsDispatch] = observationsReducer
   const fishBinSelectedLabel = getFishBinLabel(choices, fishBinSelected)
+  const [isHelperTextShowing, setIsHelperTextShowing] = useState(false)
+  const [currentHelperTextLabel, setCurrentHelperTextLabel] = useState(null)
 
   const handleAddObservation = () => {
     setAreObservationsInputsDirty(true)
@@ -128,6 +131,25 @@ const FishBeltObservationTable = ({
     () => summarizeArrayObjectValuesByProperty(observationsState, 'count'),
     [observationsState],
   )
+
+  const _useOnClickOutsideOfInfoIcon = useEffect(() => {
+    document.body.addEventListener('click', () => {
+      if (isHelperTextShowing === true) {
+        setIsHelperTextShowing(false)
+      }
+    })
+  }, [isHelperTextShowing])
+
+  const handleInfoIconClick = (event, label) => {
+    if (currentHelperTextLabel === label) {
+      isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
+    } else {
+      setIsHelperTextShowing(true)
+      setCurrentHelperTextLabel(label)
+    }
+
+    event.stopPropagation()
+  }
 
   const observationsRows = useMemo(() => {
     const handleKeyDown = ({ event, index, observation, isCount }) => {
@@ -386,7 +408,24 @@ const FishBeltObservationTable = ({
             <Tr>
               <Th> </Th>
               <Th align="left" id="fish-name-label">
-                Fish Name <RequiredIndicator />
+                {isHelperTextShowing && currentHelperTextLabel === 'fishName' ? (
+                  <ColumnHeaderToolTip
+                    helperText={language.tooltipText.fishName}
+                    bottom="5em"
+                    left="2.8em"
+                  />
+                ) : null}
+                <LabelContainer>
+                  <div>
+                    Fish Name <RequiredIndicator />
+                  </div>
+                  <IconButton
+                    type="button"
+                    onClick={(event) => handleInfoIconClick(event, 'fishName')}
+                  >
+                    <IconInfo aria-label="info" />
+                  </IconButton>
+                </LabelContainer>
               </Th>
               <Th align="right" id="fish-size-label">
                 Size (cm) <RequiredIndicator />

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -414,7 +414,7 @@ const FishBeltObservationTable = ({
                   </div>
                   {isHelperTextShowing && currentHelperTextLabel === 'fishName' ? (
                     <ColumnHeaderToolTip
-                      helperText={language.tooltipText.fishName()}
+                      helperText={language.tooltipText.getFishName()}
                       bottom="5.8em"
                       paddingBottom="3.5em"
                     />

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
@@ -429,7 +429,7 @@ const FishBeltTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.reef_slope}
           onChange={handleReefSlopeChange}
-          helperText={language.helperText.reefSlope()}
+          helperText={language.helperText.getReefSlope()}
         />
         <InputSelectWithLabelAndValidation
           label="Visibility"
@@ -495,7 +495,7 @@ const FishBeltTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.relative_depth}
           onChange={handleRelativeDepthChange}
-          helperText={language.helperText.relativeDepth()}
+          helperText={language.helperText.getRelativeDepth()}
         />
         <InputSelectWithLabelAndValidation
           label="Tide"
@@ -514,7 +514,7 @@ const FishBeltTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.tide}
           onChange={handleTideChange}
-          helperText={language.helperText.tide()}
+          helperText={language.helperText.getTide()}
         />
         <TextareaWithLabelAndValidation
           label="Notes"

--- a/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityTransectInputs.js
@@ -342,7 +342,7 @@ const HabitatComplexityTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.reef_slope}
           onChange={handleReefSlopeChange}
-          helperText={language.helperText.reefSlope()}
+          helperText={language.helperText.getReefSlope()}
         />
         <InputSelectWithLabelAndValidation
           label="Visibility"
@@ -408,7 +408,7 @@ const HabitatComplexityTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.relative_depth}
           onChange={handleRelativeDepthChange}
-          helperText={language.helperText.relativeDepth()}
+          helperText={language.helperText.getRelativeDepth()}
         />
         <InputSelectWithLabelAndValidation
           label="Tide"
@@ -427,7 +427,7 @@ const HabitatComplexityTransectInputs = ({
           onBlur={formik.handleBlur}
           value={formik.values.tide}
           onChange={handleTideChange}
-          helperText={language.helperText.tide()}
+          helperText={language.helperText.getTide()}
         />
         <TextareaWithLabelAndValidation
           label="Notes"

--- a/src/language.js
+++ b/src/language.js
@@ -626,6 +626,16 @@ const helperText = {
 
 const tooltipText = {
   admin: 'An admin can manage users, data sharing, and edit submitted data',
+  benthicAttribute: () => (
+    <>
+      Benthic attribute observed. A benthic attribute can be a taxonomic name for a coral or other
+      sessile organism, or an abiotic classification. MERMAID benthic attributes are organized
+      hierarchically and are consistent with{' '}
+      <HelperTextLink href="https://www.marinespecies.org/" target="_blank" color="#fff">
+        WoRMS.
+      </HelperTextLink>
+    </>
+  ),
   collector: 'A collector can only create and submit data',
   fishName: () => (
     <>

--- a/src/language.js
+++ b/src/language.js
@@ -649,7 +649,13 @@ const tooltipText = {
   ),
   fishSize: 'Size of fish observed, in cm (e.g. 4.5 or 5-10).',
   fishCount: 'Number of fish observed, of the same species/genus/family and size.',
+  hardCoralPercentage: 'Hard coral cover as decimal percentage of quadrat total area (e.g. 33.3).',
+  microalgaePercentage: 'Macroalgae cover as decimal percentage of quadrat total area (e.g. 33.3).',
+  numberOfPoints:
+    'Number of points with unique benthic attribute (/growth form) for the quadrat. The sum of points for all benthic attributes in a quadrat must equal the value set above.',
+  quadrat: 'Quadrat size used per transect, in square meters (e.g. 1).',
   readOnly: 'A read-only user can only view and download the data',
+  softCoralPercentage: 'Soft coral cover as decimal percentage of quadrat total area (e.g. 33.3).',
 }
 
 export default {

--- a/src/language.js
+++ b/src/language.js
@@ -627,18 +627,18 @@ const helperText = {
 const tooltipText = {
   admin: 'An admin can manage users, data sharing, and edit submitted data',
   collector: 'A collector can only create and submit data',
-  fishCount: () => (
+  fishName: () => (
     <>
       Name of the fish species, genus, or family observed. For genus-level observations or an
       unknown species, enter the genus rather than proposing a new species with &lsquo;spp&lsquo;.
       All fish names in MERMAID are consistent with{' '}
-      <HelperTextLink href="https://fishbase.mnhn.fr/search.php" target="_blank">
+      <HelperTextLink href="https://fishbase.mnhn.fr/search.php" target="_blank" color="#fff">
         fishbase.
       </HelperTextLink>
     </>
   ),
-  fishName: 'Size of fish observed, in cm (e.g. 4.5 or 5-10).',
-  fishSize: 'Number of fish observed, of the same species/genus/family and size.',
+  fishSize: 'Size of fish observed, in cm (e.g. 4.5 or 5-10).',
+  fishCount: 'Number of fish observed, of the same species/genus/family and size.',
   readOnly: 'A read-only user can only view and download the data',
 }
 

--- a/src/language.js
+++ b/src/language.js
@@ -627,6 +627,18 @@ const helperText = {
 const tooltipText = {
   admin: 'An admin can manage users, data sharing, and edit submitted data',
   collector: 'A collector can only create and submit data',
+  fishCount: () => (
+    <>
+      Name of the fish species, genus, or family observed. For genus-level observations or an
+      unknown species, enter the genus rather than proposing a new species with &lsquo;spp&lsquo;.
+      All fish names in MERMAID are consistent with{' '}
+      <HelperTextLink href="https://fishbase.mnhn.fr/search.php" target="_blank">
+        fishbase.
+      </HelperTextLink>
+    </>
+  ),
+  fishName: 'Size of fish observed, in cm (e.g. 4.5 or 5-10).',
+  fishSize: 'Number of fish observed, of the same species/genus/family and size.',
   readOnly: 'A read-only user can only view and download the data',
 }
 

--- a/src/language.js
+++ b/src/language.js
@@ -503,7 +503,7 @@ const helperText = {
     'Interval counted as the first observation on a transect, in meters. May include decimal (e.g. 0.5). Default is interval size (i.e. not counting 0).',
   label:
     'Arbitrary text to distinguish sample units that are distinct but should be combined analytically (i.e. all other properties are identical). For example: Long swim. Rarely used.',
-  latitude: () => (
+  getLatitude: () => (
     <>
       Latitude in decimal degrees. Should be a number between -90 and 90, representing the
       north-south position on the Earth&apos;s surface. A positive value indicates a location north
@@ -517,7 +517,7 @@ const helperText = {
       </HelperTextLink>
     </>
   ),
-  longitude: () => (
+  getLongitude: () => (
     <>
       Latitude in decimal degrees. Should be a number between -90 and 90, representing the
       north-south position on the Earth&#39;s surface. A positive value indicates a location north
@@ -533,7 +533,7 @@ const helperText = {
   ),
   management:
     'The management designation at the time of survey, e.g., no-take zone, partial restrictions, or open access.',
-  managementRegimeName: () => (
+  getManagementRegimeName: () => (
     <>
       Name of the MPA, OECM, or other relevant managed area. Can be an official name defined by a
       governmental or standardized source such as{' '}
@@ -557,7 +557,7 @@ const helperText = {
   periodicCloser:
     'The area is open and closed as a fisheries management strategy, e.g., rotating octopus closures',
   quadratSize: 'Quadrat size used per transect, in square meters (e.g. 1).',
-  reefSlope: () => (
+  getReefSlope: () => (
     <>
       An indication of coral reef profile of the survey location. See definitions{' '}
       <HelperTextLink
@@ -568,7 +568,7 @@ const helperText = {
       </HelperTextLink>
     </>
   ),
-  reefType: () => (
+  getReefType: () => (
     <>
       The geomorpholgy of a reef and its relation to land. See definitions{' '}
       <HelperTextLink
@@ -579,7 +579,7 @@ const helperText = {
       </HelperTextLink>
     </>
   ),
-  reefZone: () => (
+  getReefZone: () => (
     <>
       Location and abiotic factors that characterize the location within the reef. See definitions{' '}
       <HelperTextLink
@@ -590,7 +590,7 @@ const helperText = {
       </HelperTextLink>
     </>
   ),
-  relativeDepth: () => (
+  getRelativeDepth: () => (
     <>
       Whether the survey is &#39;deep&#39; or &#39;shallow&#39; relative to other transects
       surveyed, regardless of numerical depth in meters.
@@ -604,7 +604,7 @@ const helperText = {
     'Name or ID used to refer to this site. A name can be any label useful to the project; often, projects will use a systematic naming scheme that includes indication of reef zone/type and a numbering system. Using the same name consistently across projects and years will facilitate temporal analyses.',
   sizeLimits: 'There are restrictions on the size of certain target species',
   speciesRestrictions: 'There are restrictions on what types of species can be caught',
-  tide: () => (
+  getTide: () => (
     <>
       Tide characteristics during the survey{' '}
       <HelperTextLink
@@ -626,7 +626,7 @@ const helperText = {
 
 const tooltipText = {
   admin: 'An admin can manage users, data sharing, and edit submitted data',
-  benthicAttribute: () => (
+  getBenthicAttribute: () => (
     <>
       Benthic attribute observed. A benthic attribute can be a taxonomic name for a coral or other
       sessile organism, or an abiotic classification. MERMAID benthic attributes are organized
@@ -637,7 +637,7 @@ const tooltipText = {
     </>
   ),
   collector: 'A collector can only create and submit data',
-  fishName: () => (
+  getFishName: () => (
     <>
       Name of the fish species, genus, or family observed. For genus-level observations or an
       unknown species, enter the genus rather than proposing a new species with &lsquo;spp&lsquo;.

--- a/src/language.js
+++ b/src/language.js
@@ -624,6 +624,12 @@ const helperText = {
     'The total width (NOT width to one side of the tape) of the fish belt transect, in meters.',
 }
 
+const tooltipText = {
+  admin: 'An admin can manage users, data sharing, and edit submitted data',
+  collector: 'A collector can only create and submit data',
+  readOnly: 'A read-only user can only view and download the data',
+}
+
 export default {
   apiDataTableNames,
   autocomplete,
@@ -646,4 +652,5 @@ export default {
   success,
   table,
   title,
+  tooltipText,
 }


### PR DESCRIPTION
[trello card](https://trello.com/c/qRpY0zIj/487-column-header-tool-tip)

summary:

add info icon to some column headers to provide more context to users

to test:
1. refer to [mermaid terms list](https://docs.google.com/spreadsheets/d/1CpGEMW_qF7XeI52H-gvZZKM8cwhHDg6yV7eUbnyFE6M/edit?pli=1#gid=2048735771) to check out which items have added tool tips
2. go to users page (for example)
3. click on admin/collector/read-only info icon
4. observe pop up text
5. click away from tool tip to close it