### PR TITLE
[505] Update pagination count

### DIFF
--- a/src/components/generic/Table/PageSizeSelector/PageSizeSelector.js
+++ b/src/components/generic/Table/PageSizeSelector/PageSizeSelector.js
@@ -8,7 +8,14 @@ const PageSizeSelect = styled(Select)`
   min-width: auto;
 `
 
-const PageSizeSelector = ({ pageSize, pageType, pageSizeOptions, onChange, rowLength }) => {
+const PageSizeSelector = ({
+  pageSize,
+  pageType,
+  pageSizeOptions,
+  onChange,
+  rowLength,
+  filteredRowLength,
+}) => {
   const [pageOptionsToDisplay, setPageOptionsToDisplay] = useState([])
 
   const _findPageOptionsToDisplay = useEffect(() => {
@@ -24,6 +31,8 @@ const PageSizeSelector = ({ pageSize, pageType, pageSizeOptions, onChange, rowLe
 
     setPageOptionsToDisplay(pageOptionsLessThanRowLength)
   }, [pageSizeOptions, rowLength])
+
+  console.log({ filteredRowLength })
 
   return (
     <label htmlFor="page-size-selector">
@@ -45,8 +54,13 @@ const PageSizeSelector = ({ pageSize, pageType, pageSizeOptions, onChange, rowLe
   )
 }
 
+PageSizeSelector.defaultProps = {
+  filteredRowLength: null,
+}
+
 PageSizeSelector.propTypes = {
   rowLength: PropTypes.number.isRequired,
+  filteredRowLength: PropTypes.number,
   pageType: PropTypes.string.isRequired,
   pageSize: PropTypes.number.isRequired,
   pageSizeOptions: PropTypes.arrayOf(PropTypes.number).isRequired,

--- a/src/components/generic/Table/PageSizeSelector/PageSizeSelector.js
+++ b/src/components/generic/Table/PageSizeSelector/PageSizeSelector.js
@@ -13,26 +13,54 @@ const PageSizeSelector = ({
   pageType,
   pageSizeOptions,
   onChange,
-  rowLength,
-  filteredRowLength,
+  unfilteredRowLength,
+  methodFilteredRowLength,
+  searchFilteredRowLength,
+  isMethodFilterEnabled,
+  isSearchFilterEnabled,
 }) => {
   const [pageOptionsToDisplay, setPageOptionsToDisplay] = useState([])
+  const [filteredAmountToDisplay, setFilteredAmountToDisplay] = useState(null)
+
+  const _findFilteredAmountToDisplay = useEffect(() => {
+    // the search results will be method filtered already, which is not the case the opposite way around
+    if (isSearchFilterEnabled && isMethodFilterEnabled) {
+      return setFilteredAmountToDisplay(searchFilteredRowLength)
+    }
+    if (!isSearchFilterEnabled && isMethodFilterEnabled) {
+      return setFilteredAmountToDisplay(methodFilteredRowLength)
+    }
+    if (isSearchFilterEnabled && !isMethodFilterEnabled) {
+      return setFilteredAmountToDisplay(searchFilteredRowLength)
+    }
+
+    return setFilteredAmountToDisplay(unfilteredRowLength)
+  }, [
+    isMethodFilterEnabled,
+    isSearchFilterEnabled,
+    methodFilteredRowLength,
+    searchFilteredRowLength,
+    unfilteredRowLength,
+  ])
 
   const _findPageOptionsToDisplay = useEffect(() => {
-    let pageOptionsLessThanRowLength = pageSizeOptions.filter((option) => option < rowLength)
+    let pageOptionsLessThanRowLength = pageSizeOptions.filter(
+      (option) => option < filteredAmountToDisplay,
+    )
 
     if (pageOptionsLessThanRowLength.length === 0) {
       // show the exact number of items as the only selection in the drop down
-      pageOptionsLessThanRowLength = [rowLength]
-    } else if (pageOptionsLessThanRowLength[pageOptionsLessThanRowLength.length - 1] < rowLength) {
+      pageOptionsLessThanRowLength = [filteredAmountToDisplay]
+    } else if (
+      pageOptionsLessThanRowLength[pageOptionsLessThanRowLength.length - 1] <
+      filteredAmountToDisplay
+    ) {
       // show the exact number of items as the last selection in the drop down
-      pageOptionsLessThanRowLength.push(rowLength)
+      pageOptionsLessThanRowLength.push(filteredAmountToDisplay)
     }
 
     setPageOptionsToDisplay(pageOptionsLessThanRowLength)
-  }, [pageSizeOptions, rowLength])
-
-  console.log({ filteredRowLength })
+  }, [pageSizeOptions, filteredAmountToDisplay])
 
   return (
     <label htmlFor="page-size-selector">
@@ -49,18 +77,27 @@ const PageSizeSelector = ({
           </option>
         ))}
       </PageSizeSelect>{' '}
-      of {rowLength} {pageType}
+      of {filteredAmountToDisplay} {pageType}{' '}
+      {isSearchFilterEnabled || isMethodFilterEnabled
+        ? `(filtered from ${unfilteredRowLength})`
+        : null}
     </label>
   )
 }
 
 PageSizeSelector.defaultProps = {
-  filteredRowLength: null,
+  methodFilteredRowLength: null,
+  searchFilteredRowLength: null,
+  isMethodFilterEnabled: false,
+  isSearchFilterEnabled: false,
 }
 
 PageSizeSelector.propTypes = {
-  rowLength: PropTypes.number.isRequired,
-  filteredRowLength: PropTypes.number,
+  unfilteredRowLength: PropTypes.number.isRequired,
+  methodFilteredRowLength: PropTypes.number,
+  searchFilteredRowLength: PropTypes.number,
+  isMethodFilterEnabled: PropTypes.bool,
+  isSearchFilterEnabled: PropTypes.bool,
   pageType: PropTypes.string.isRequired,
   pageSize: PropTypes.number.isRequired,
   pageSizeOptions: PropTypes.arrayOf(PropTypes.number).isRequired,

--- a/src/components/pages/Collect/Collect.js
+++ b/src/components/pages/Collect/Collect.js
@@ -59,6 +59,7 @@ const Collect = () => {
   const [methodsFilteredTableCellData, setMethodsFilteredTableCellData] = useState([])
   const [methodsFilter, setMethodsFilter] = useState([])
   const isMethodFilterInitializedWithPersistedTablePreferences = useRef(false)
+  const [searchFilteredRowsLength, setSearchFilteredRowsLength] = useState(null)
 
   useDocumentTitle(`${language.pages.collectTable.title} - ${language.title.mermaid}`)
 
@@ -232,7 +233,11 @@ const Collect = () => {
       return rows
     }
 
-    return getTableFilteredRows(rows, keys, queryTerms)
+    const tableFilteredRows = getTableFilteredRows(rows, keys, queryTerms)
+
+    setSearchFilteredRowsLength(tableFilteredRows.length)
+
+    return tableFilteredRows
   }, [])
 
   const {
@@ -347,12 +352,11 @@ const Collect = () => {
           pageSize={pageSize}
           pageSizeOptions={[15, 50, 100]}
           pageType="sample units"
-          rowLength={
-            methodsFilter.length
-              ? methodsFilteredTableCellData.length
-              : collectRecordsForUiDisplay.length
-          }
-          // filteredRowLength={}
+          unfilteredRowLength={collectRecordsForUiDisplay.length}
+          methodFilteredRowLength={methodsFilteredTableCellData.length}
+          searchFilteredRowLength={searchFilteredRowsLength}
+          isSearchFilterEnabled={!!globalFilter?.length}
+          isMethodFilterEnabled={!!methodsFilter.length}
         />
         <PageSelector
           onPreviousClick={previousPage}

--- a/src/components/pages/Collect/Collect.js
+++ b/src/components/pages/Collect/Collect.js
@@ -347,7 +347,12 @@ const Collect = () => {
           pageSize={pageSize}
           pageSizeOptions={[15, 50, 100]}
           pageType="sample units"
-          rowLength={collectRecordsForUiDisplay.length}
+          rowLength={
+            methodsFilter.length
+              ? methodsFilteredTableCellData.length
+              : collectRecordsForUiDisplay.length
+          }
+          // filteredRowLength={}
         />
         <PageSelector
           onPreviousClick={previousPage}

--- a/src/components/pages/ManagementRegimes/ManagementRegimes.js
+++ b/src/components/pages/ManagementRegimes/ManagementRegimes.js
@@ -412,7 +412,7 @@ const ManagementRegimes = () => {
           pageSize={pageSize}
           pageSizeOptions={[15, 50, 100]}
           pageType="management regimes"
-          rowLength={managementRegimeRecordsForUiDisplay.length}
+          unfilteredRowLength={managementRegimeRecordsForUiDisplay.length}
         />
         <PageSelector
           onPreviousClick={previousPage}

--- a/src/components/pages/ManagementRegimes/ManagementRegimes.js
+++ b/src/components/pages/ManagementRegimes/ManagementRegimes.js
@@ -70,6 +70,7 @@ const ManagementRegimes = () => {
   const isReadOnlyUser = getIsUserReadOnlyForProject(currentUser, projectId)
   const closeCopyManagementRegimesModal = () => setIsCopyManagementRegimesModalOpen(false)
   const openCopyManagementRegimesModal = () => setIsCopyManagementRegimesModalOpen(true)
+  const [searchFilteredRowsLength, setSearchFilteredRowsLength] = useState(null)
 
   useDocumentTitle(`${language.pages.managementRegimeTable.title} - ${language.title.mermaid}`)
 
@@ -227,7 +228,11 @@ const ManagementRegimes = () => {
       return rows
     }
 
-    return getTableFilteredRows(rows, keys, queryTerms)
+    const tableFilteredRows = getTableFilteredRows(rows, keys, queryTerms)
+
+    setSearchFilteredRowsLength(tableFilteredRows.length)
+
+    return tableFilteredRows
   }, [])
 
   const getDataForCSV = useMemo(() => {
@@ -413,6 +418,8 @@ const ManagementRegimes = () => {
           pageSizeOptions={[15, 50, 100]}
           pageType="management regimes"
           unfilteredRowLength={managementRegimeRecordsForUiDisplay.length}
+          searchFilteredRowLength={searchFilteredRowsLength}
+          isSearchFilterEnabled={!!globalFilter?.length}
         />
         <PageSelector
           onPreviousClick={previousPage}

--- a/src/components/pages/ManagementRegimesOverview/ManagementRegimesOverview.js
+++ b/src/components/pages/ManagementRegimesOverview/ManagementRegimesOverview.js
@@ -418,7 +418,7 @@ const ManagementRegimesOverview = () => {
           pageSize={pageSize}
           pageSizeOptions={[15, 50, 100]}
           pageType="records"
-          rowLength={sampleUnitWithManagementRegimeRecords.length}
+          unfilteredRowLength={sampleUnitWithManagementRegimeRecords.length}
         />
         <PageSelector
           onPreviousClick={previousPage}

--- a/src/components/pages/ManagementRegimesOverview/ManagementRegimesOverview.js
+++ b/src/components/pages/ManagementRegimesOverview/ManagementRegimesOverview.js
@@ -70,6 +70,7 @@ const ManagementRegimesOverview = () => {
   const [methodsFilteredTableCellData, setMethodsFilteredTableCellData] = useState([])
   const [methodsFilter, setMethodsFilter] = useState([])
   const isMethodFilterInitializedWithPersistedTablePreferences = useRef(false)
+  const [searchFilteredRowsLength, setSearchFilteredRowsLength] = useState(null)
 
   const _getSupportingData = useEffect(() => {
     if (!isAppOnline) {
@@ -240,7 +241,11 @@ const ManagementRegimesOverview = () => {
       return rows
     }
 
-    return getTableFilteredRows(rows, keys, queryTerms)
+    const tableFilteredRows = getTableFilteredRows(rows, keys, queryTerms)
+
+    setSearchFilteredRowsLength(tableFilteredRows.length)
+
+    return tableFilteredRows
   }, [])
 
   const {
@@ -419,6 +424,10 @@ const ManagementRegimesOverview = () => {
           pageSizeOptions={[15, 50, 100]}
           pageType="records"
           unfilteredRowLength={sampleUnitWithManagementRegimeRecords.length}
+          methodFilteredRowLength={methodsFilteredTableCellData.length}
+          searchFilteredRowLength={searchFilteredRowsLength}
+          isSearchFilterEnabled={!!globalFilter?.length}
+          isMethodFilterEnabled={!!methodsFilter.length}
         />
         <PageSelector
           onPreviousClick={previousPage}

--- a/src/components/pages/Sites/Sites.js
+++ b/src/components/pages/Sites/Sites.js
@@ -369,7 +369,7 @@ const Sites = () => {
           pageSize={pageSize}
           pageSizeOptions={[15, 50, 100]}
           pageType="sites"
-          rowLength={siteRecordsForUiDisplay.length}
+          unfilteredRowLength={siteRecordsForUiDisplay.length}
         />
         <PageSelector
           onPreviousClick={previousPage}

--- a/src/components/pages/Sites/Sites.js
+++ b/src/components/pages/Sites/Sites.js
@@ -72,6 +72,7 @@ const Sites = () => {
   const [isCopySitesModalOpen, setIsCopySitesModalOpen] = useState(false)
   const openCopySitesModal = () => setIsCopySitesModalOpen(true)
   const closeCopySitesModal = () => setIsCopySitesModalOpen(false)
+  const [searchFilteredRowsLength, setSearchFilteredRowsLength] = useState(null)
 
   useDocumentTitle(`${language.pages.siteTable.title} - ${language.title.mermaid}`)
 
@@ -196,6 +197,7 @@ const Sites = () => {
       )
 
       setSitesForMapMarkers(filteredSiteRecords)
+      setSearchFilteredRowsLength(filteredSiteRecords.length)
 
       return filteredRows
     },
@@ -370,6 +372,8 @@ const Sites = () => {
           pageSizeOptions={[15, 50, 100]}
           pageType="sites"
           unfilteredRowLength={siteRecordsForUiDisplay.length}
+          searchFilteredRowLength={searchFilteredRowsLength}
+          isSearchFilterEnabled={!!globalFilter?.length}
         />
         <PageSelector
           onPreviousClick={previousPage}

--- a/src/components/pages/Submitted/Submitted.js
+++ b/src/components/pages/Submitted/Submitted.js
@@ -51,6 +51,7 @@ const Submitted = () => {
   const [methodsFilteredTableCellData, setMethodsFilteredTableCellData] = useState([])
   const [methodsFilter, setMethodsFilter] = useState([])
   const isMethodFilterInitializedWithPersistedTablePreferences = useRef(false)
+  const [searchFilteredRowsLength, setSearchFilteredRowsLength] = useState(null)
 
   useDocumentTitle(`${language.pages.submittedTable.title} - ${language.title.mermaid}`)
 
@@ -209,7 +210,11 @@ const Submitted = () => {
       return rows
     }
 
-    return getTableFilteredRows(rows, keys, queryTerms)
+    const tableFilteredRows = getTableFilteredRows(rows, keys, queryTerms)
+
+    setSearchFilteredRowsLength(tableFilteredRows.length)
+
+    return tableFilteredRows
   }, [])
 
   const {
@@ -323,7 +328,11 @@ const Submitted = () => {
           pageSize={pageSize}
           pageSizeOptions={[15, 50, 100]}
           pageType="sample units"
-          rowLength={submittedRecordsForUiDisplay.length}
+          unfilteredRowLength={submittedRecordsForUiDisplay.length}
+          methodFilteredRowLength={methodsFilteredTableCellData.length}
+          searchFilteredRowLength={searchFilteredRowsLength}
+          isSearchFilterEnabled={!!globalFilter?.length}
+          isMethodFilterEnabled={!!methodsFilter.length}
         />
         <PageSelector
           onPreviousClick={previousPage}

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -168,6 +168,7 @@ const Users = () => {
   const { setIsSyncInProgress } = useSyncStatus()
   const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
   const isMounted = useIsMounted()
+  const [searchFilteredRowsLength, setSearchFilteredRowsLength] = useState(null)
 
   const handleHttpResponseError = useHttpResponseErrorHandler()
 
@@ -740,7 +741,11 @@ const Users = () => {
         return rows
       }
 
-      return getTableFilteredRows(rows, keys, queryTerms)
+      const tableFilteredRows = getTableFilteredRows(rows, keys, queryTerms)
+
+      setSearchFilteredRowsLength(tableFilteredRows.length)
+
+      return tableFilteredRows
     },
     [isAdminUser],
   )
@@ -848,6 +853,8 @@ const Users = () => {
           pageType="users"
           pageSizeOptions={[15, 50, 100]}
           unfilteredRowLength={observerProfiles.length}
+          searchFilteredRowLength={searchFilteredRowsLength}
+          isSearchFilterEnabled={!!globalFilter?.length}
         />
         <PageSelector
           onPreviousClick={previousPage}

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -847,7 +847,7 @@ const Users = () => {
           pageSize={pageSize}
           pageType="users"
           pageSizeOptions={[15, 50, 100]}
-          rowLength={observerProfiles.length}
+          unfilteredRowLength={observerProfiles.length}
         />
         <PageSelector
           onPreviousClick={previousPage}

--- a/src/components/pages/UsersAndTransects/UsersAndTransects.js
+++ b/src/components/pages/UsersAndTransects/UsersAndTransects.js
@@ -113,6 +113,7 @@ const UsersAndTransects = () => {
   const [methodsFilteredTableCellData, setMethodsFilteredTableCellData] = useState([])
   const [methodsFilter, setMethodsFilter] = useState([])
   const isMethodFilterInitializedWithPersistedTablePreferences = useRef(false)
+  const [searchFilteredRowsLength, setSearchFilteredRowsLength] = useState(null)
 
   const _getSupportingData = useEffect(() => {
     if (!isAppOnline) {
@@ -365,7 +366,11 @@ const UsersAndTransects = () => {
       return rows
     }
 
-    return getTableFilteredRows(rows, keys, queryTerms)
+    const tableFilteredRows = getTableFilteredRows(rows, keys, queryTerms)
+
+    setSearchFilteredRowsLength(tableFilteredRows.length)
+
+    return tableFilteredRows
   }, [])
 
   const {
@@ -557,6 +562,10 @@ const UsersAndTransects = () => {
           pageSizeOptions={[15, 50, 100]}
           pageType="records"
           unfilteredRowLength={submittedRecords.length}
+          methodFilteredRowLength={methodsFilteredTableCellData.length}
+          searchFilteredRowLength={searchFilteredRowsLength}
+          isSearchFilterEnabled={!!globalFilter?.length}
+          isMethodFilterEnabled={!!methodsFilter.length}
         />
         <PageSelector
           onPreviousClick={previousPage}

--- a/src/components/pages/UsersAndTransects/UsersAndTransects.js
+++ b/src/components/pages/UsersAndTransects/UsersAndTransects.js
@@ -556,7 +556,7 @@ const UsersAndTransects = () => {
           pageSize={pageSize}
           pageSizeOptions={[15, 50, 100]}
           pageType="records"
-          rowLength={submittedRecords.length}
+          unfilteredRowLength={submittedRecords.length}
         />
         <PageSelector
           onPreviousClick={previousPage}


### PR DESCRIPTION
[trello card](https://trello.com/c/Ozx70QNw/505-update-pagination-count-for-filtering)

updates pagination count at the bottom of a table when any filters are applied (search or methods filtering)

tables updated: MRO, MR, users, collecting, submitted, users & transects, sites

to test:
1. go to any of the tables listed above
2. add text into the search field
3. pagination should be updated to include filtering text, as well as the amount of rows that are currently in the table