### PR TITLE
[508] only add new observation empty row when its a new record

### DIFF
--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitForm.js
@@ -70,7 +70,6 @@ const BenthicLitform = ({ isNewRecord }) => {
               if (!isNewRecord && !collectRecordResponse && recordId) {
                 setIdsNotAssociatedWithData((previousState) => [...previousState, recordId])
               }
-
               setSubNavNode(
                 getDataForSubNavNode({
                   isNewRecord,

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
@@ -79,7 +79,8 @@ function loadObservationsFromCollectRecordIntoTableState({
         payload: initialObservationsToLoadTable,
       })
     }
-    if (!initialObservationsToLoadTable.length) {
+
+    if (isNewRecord && !initialObservationsToLoadTable.length) {
       handleAddEmptyInitialObservation()
     }
 


### PR DESCRIPTION
[trello card](https://trello.com/c/jFN2k6dg/508-observation-row-re-appear-after-saving-a-fishbelt-su)