### PR TITLE
[575] fix missing benthinc photo quadrat values

### DIFF
--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
@@ -7,6 +7,7 @@ import {
   getCollectRecordDataInitialValues,
   getTransectInitialValues,
   getSampleInfoInitialValues,
+  getBenthicPhotoQuadratAdditionalValues,
 } from '../collectRecordFormInitialValues'
 
 import { getBenthicOptions } from '../../../../library/getOptions'
@@ -123,7 +124,7 @@ const BenthicPhotoQuadratForm = ({ isNewRecord }) => {
         ...getCollectRecordDataInitialValues(collectRecordBeingEdited),
         ...getSampleInfoInitialValues(collectRecordBeingEdited),
         ...getTransectInitialValues(collectRecordBeingEdited, 'quadrat_transect'),
-        // ...getBenthicPhotoQuadratAdditionalValues(collectRecordBeingEdited),
+        ...getBenthicPhotoQuadratAdditionalValues(collectRecordBeingEdited),
       }
     )
   }, [collectRecordBeingEdited, getPersistedUnsavedFormikData])


### PR DESCRIPTION
Steps to test:

- Make a new benthic photo quadrat collect record
- fill out the entire form
- click save

Expected results
- on the saved page, all the values are as they were entered prior to clicking the save button