### PR TITLE
M292 - have preview links use the dev version of dashboard

### DIFF
--- a/.github/workflows/_cdk.yml
+++ b/.github/workflows/_cdk.yml
@@ -8,15 +8,15 @@ on:
         type: string
 
 env:
-  # defaults
+  # dev and prod
   REACT_APP_AUTH0_DOMAIN: datamermaid.auth0.com
-  REACT_APP_MERMAID_DASHBOARD_LINK: https://dashboard.datamermaid.org
   REACT_APP_CORAL_ATLAS_APP_ID: v8nkxznp3m
   REACT_APP_MERMAID_WHATS_NEW_LINK: https://datamermaid.org/reef-stories/mermaid-v2-what-s-new
-  # dev specific
+  # dev specific; set prod versions in step below
   REACT_APP_AUTH0_CLIENT_ID: 4AHcVFcwxHb7p1VFB9sFWG52WL7pdNm5
   REACT_APP_AUTH0_AUDIENCE: https://dev-api.datamermaid.org
   REACT_APP_MERMAID_API: https://dev-api.datamermaid.org/v1
+  REACT_APP_MERMAID_DASHBOARD_LINK: https://dev-dashboard.datamermaid.org
   REACT_APP_MERMAID_REFERENCE_LINK: https://dev-public.datamermaid.org/mermaid_attributes.xlsx
   TARGET: dev
 
@@ -51,9 +51,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags')
         run: |
           echo "TARGET=prod" >> "$GITHUB_ENV"
-          echo "REACT_APP_AUTH0_CLIENT_ID=Yahf5mGpQDyYOqbvQlaKE1WqBnUeFPj0" >> "$GITHUB_ENV"
           echo "REACT_APP_AUTH0_AUDIENCE=https://api.datamermaid.org" >> "$GITHUB_ENV"
+          echo "REACT_APP_AUTH0_CLIENT_ID=Yahf5mGpQDyYOqbvQlaKE1WqBnUeFPj0" >> "$GITHUB_ENV"
           echo "REACT_APP_MERMAID_API=https://api.datamermaid.org/v1" >> "$GITHUB_ENV"
+          echo "REACT_APP_MERMAID_DASHBOARD_LINK=https://dashboard.datamermaid.org" >> "$GITHUB_ENV"
           echo "REACT_APP_MERMAID_REFERENCE_LINK=https://public.datamermaid.org/mermaid_attributes.xlsx" >> "$GITHUB_ENV"
           echo "export const versionNumber = '${{ github.ref_name }}'" > src/version.js
           cat src/version.js

--- a/.github/workflows/_preview-create.yml
+++ b/.github/workflows/_preview-create.yml
@@ -15,7 +15,7 @@ env:
   REACT_APP_AUTH0_DOMAIN: datamermaid.auth0.com
   REACT_APP_MERMAID_API: https://dev-api.datamermaid.org/v1
   REACT_APP_MERMAID_REFERENCE_LINK: https://dev-public.datamermaid.org/mermaid_attributes.xlsx
-  REACT_APP_MERMAID_DASHBOARD_LINK: https://dashboard.datamermaid.org
+  REACT_APP_MERMAID_DASHBOARD_LINK: https://dev-dashboard.datamermaid.org
   REACT_APP_CORAL_ATLAS_APP_ID: v8nkxznp3m
   REACT_APP_MERMAID_WHATS_NEW_LINK: https://datamermaid.org/reef-stories/mermaid-v2-what-s-new
 


### PR DESCRIPTION
Im assuming `_cdk.yml` default env values are what are used in production and have left the dashboard link env var there untouched (pointing to `https://dashboard.datamermaid.org`), but this should be confirmed.