### PR TITLE
M272 Control if the app captures Google Analytics data with environment variables.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,3 +7,4 @@ REACT_APP_MERMAID_REFERENCE_LINK=
 REACT_APP_MERMAID_DASHBOARD_LINK=
 REACT_APP_CORAL_ATLAS_APP_ID=
 REACT_APP_MERMAID_WHATS_NEW_LINK=
+REACT_APP_CAPTURE_GOOGLE_ANALYTICS=false (if unset, treated as false. Possible to exclude unless you want to opt in to analytics tracking)

--- a/.github/workflows/_cdk.yml
+++ b/.github/workflows/_cdk.yml
@@ -18,6 +18,7 @@ env:
   REACT_APP_MERMAID_API: https://dev-api.datamermaid.org/v1
   REACT_APP_MERMAID_DASHBOARD_LINK: https://dev-dashboard.datamermaid.org
   REACT_APP_MERMAID_REFERENCE_LINK: https://dev-public.datamermaid.org/mermaid_attributes.xlsx
+  REACT_APP_CAPTURE_GOOGLE_ANALYTICS: false
   TARGET: dev
 
 jobs:
@@ -56,6 +57,7 @@ jobs:
           echo "REACT_APP_MERMAID_API=https://api.datamermaid.org/v1" >> "$GITHUB_ENV"
           echo "REACT_APP_MERMAID_DASHBOARD_LINK=https://dashboard.datamermaid.org" >> "$GITHUB_ENV"
           echo "REACT_APP_MERMAID_REFERENCE_LINK=https://public.datamermaid.org/mermaid_attributes.xlsx" >> "$GITHUB_ENV"
+          echo "REACT_APP_CAPTURE_GOOGLE_ANALYTICS=true"
           echo "export const versionNumber = '${{ github.ref_name }}'" > src/version.js
           cat src/version.js
 

--- a/.github/workflows/_preview-create.yml
+++ b/.github/workflows/_preview-create.yml
@@ -18,6 +18,7 @@ env:
   REACT_APP_MERMAID_DASHBOARD_LINK: https://dev-dashboard.datamermaid.org
   REACT_APP_CORAL_ATLAS_APP_ID: v8nkxznp3m
   REACT_APP_MERMAID_WHATS_NEW_LINK: https://datamermaid.org/reef-stories/mermaid-v2-what-s-new
+  REACT_APP_CAPTURE_GOOGLE_ANALYTICS: false
 
 jobs:
   build-and-push-to-s3:

--- a/Readme.md
+++ b/Readme.md
@@ -99,3 +99,7 @@ Since this app can exist in multiple states (online, offline, various states of 
 ### Infrastructure as Code (IaC)
 
 - see `iac/README.md`
+
+### Google Analytics
+
+To opt into tracking with Google Analytics, add the following to a deployment's environment variables: `REACT_APP_CAPTURE_GOOGLE_ANALYTICS=true`. Currently we only want to track activity in our production deployment, so this value to true should only be done for production deploys. This value will default to false.

--- a/public/index.html
+++ b/public/index.html
@@ -43,13 +43,17 @@
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NG1KXL2TSG"></script>
     <script>
-      window.dataLayer = window.dataLayer || []
-      function gtag() {
-        dataLayer.push(arguments)
-      }
-      gtag('js', new Date())
+      const shouldCaptureGoogleAnalytics =
+        '%REACT_APP_CAPTURE_GOOGLE_ANALYTICS%'.toLowerCase() === 'true' // defaults to false
+      if (shouldCaptureGoogleAnalytics) {
+        window.dataLayer = window.dataLayer || []
+        function gtag() {
+          dataLayer.push(arguments)
+        }
+        gtag('js', new Date())
 
-      gtag('config', 'G-NG1KXL2TSG')
+        gtag('config', 'G-NG1KXL2TSG')
+      }
     </script>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.


### PR DESCRIPTION
Opt into tracking with an environment variable. `REACT_APP_CAPTURE_GOOGLE_ANALYTICS=true`. If this environment variable is not present and set explicitly to true, no tracking will occur. (our secure note for env vars has been updated)

Other options considered:
- Hostname filters within Google Analytics interface. (requires learning the nuances of that process with Google Analytics, which less of us will be able to do. Most of us can reason easily about environment vars).
- front end code to check host name and only implement analytics for `app.datamermaid.org` (which is less explicit, and tightly couples GA tracking logic to a particular host name, which feels more fragile)