### PR TITLE
M588 store only 6 decimal places for a site's lat and lng (unless the user types more).

### DIFF
--- a/src/components/generic/form.js
+++ b/src/components/generic/form.js
@@ -68,7 +68,7 @@ export const inputTextareaSelectStyles = css`
   }
   &::-webkit-outer-spin-button,
   &::-webkit-inner-spin-button {
-    -webkit-appearance: none;
+    -webkit-appearance: ${(props) => (props.shouldShowSteps ? 'auto' : 'none')};
   }
   -moz-appearance: textfield;
   &:disabled {

--- a/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
+++ b/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
@@ -16,6 +16,7 @@ import { ButtonSecondary } from '../../generic/buttons'
 import { IconMapMarker } from '../../icons'
 import { MapInputRow, MapContainer, MapWrapper, MapZoomHelpMessage } from '../Map.styles'
 import theme from '../../../theme'
+import { roundToSixDecimalPlaces } from '../../../library/numbers/roundToSixDecimalPlaces'
 
 const StyledPlaceMarkerButton = styled(ButtonSecondary)`
   padding: 0 5px;
@@ -45,7 +46,7 @@ const SingleSiteMap = ({
   const map = useRef(null)
   const recordMarker = useRef(null)
   const [displayHelpText, setDisplayHelpText] = useState(false)
-  const [isMarkerBeingPlaced, setIsMarkerBeingPlaces] = useState(false)
+  const [isMarkerBeingPlaced, setIsMarkerBeingPlaced] = useState(false)
 
   const handleZoomDisplayHelpText = (displayValue) => setDisplayHelpText(displayValue)
   const handleMarkerLocationChange = useCallback(
@@ -59,8 +60,8 @@ const SingleSiteMap = ({
         adjustedLng = lngLat.lng - 360
       }
 
-      handleLatitudeChange(lngLat.lat)
-      handleLongitudeChange(adjustedLng)
+      handleLatitudeChange(roundToSixDecimalPlaces(lngLat.lat))
+      handleLongitudeChange(roundToSixDecimalPlaces(adjustedLng))
     },
     [handleLatitudeChange, handleLongitudeChange],
   )
@@ -174,7 +175,7 @@ const SingleSiteMap = ({
       : language.pages.siteForm.placeMarker
 
   const handlePlaceMarkerClick = () => {
-    setIsMarkerBeingPlaces(!isMarkerBeingPlaced)
+    setIsMarkerBeingPlaced(!isMarkerBeingPlaced)
   }
 
   const placeMarkerButton = (

--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -166,6 +166,8 @@ const SiteForm = ({
           validationMessages={formik.errors.latitude}
           testId="latitude"
           helperText={language.helperText.getLatitude()}
+          shouldShowSteps={true}
+          step="0.000001"
         />
         <InputWithLabelAndValidation
           required
@@ -178,6 +180,8 @@ const SiteForm = ({
           validationMessages={formik.errors.longitude}
           testId="longitude"
           helperText={language.helperText.getLongitude()}
+          shouldShowSteps={true}
+          step="0.000001"
         />
         {isAppOnline && (
           <SingleSiteMap

--- a/src/library/numbers/roundToSixDecimalPlaces.js
+++ b/src/library/numbers/roundToSixDecimalPlaces.js
@@ -1,0 +1,1 @@
+export const roundToSixDecimalPlaces = (number) => Number(Number(number).toFixed(6))


### PR DESCRIPTION
[Ticket](https://trello.com/c/1ly7Aigw/588-round-lat-and-long-to-6-digits-of-precision-to-right-of-decimal)