### PR TITLE
M369 make sure fish family name shows in fish name popover for fish belt species and genera observations

### DIFF
--- a/src/App/mermaidData/fishNameHelpers.js
+++ b/src/App/mermaidData/fishNameHelpers.js
@@ -56,7 +56,17 @@ export const getFishNameOptions = ({ species, genera, families, groupings = [] }
   return [...speciesOptions, ...generaAndFamiliesOptions]
 }
 
-export const getFishNameTable = ({ fishNameInfo, fishFamilies, choices }) => {
+export const getFishNameTable = ({
+  fishFamilies,
+  choices,
+  fishGenera,
+  fishSpecies,
+  fishNameId,
+}) => {
+  const fishNameInfo = [...fishSpecies, ...fishGenera, ...fishFamilies].find(
+    (item) => item.id === fishNameId,
+  )
+
   const tableLanguage = language.pages.collectRecord.fishNamePopover
 
   const TableContainer = styled('div')`
@@ -104,15 +114,20 @@ export const getFishNameTable = ({ fishNameInfo, fishFamilies, choices }) => {
     ? `${fishNameInfo.max_length} (${fishNameInfo.max_length_type})`
     : fishNameInfo.max_length
 
+  const fishFamilyId =
+    fishNameInfo.family ??
+    fishGenera.find((genusInfo) => genusInfo.id === fishNameInfo.genus)?.family
+  const fishFamilyName = fishFamilies.find((item) => item.id === fishFamilyId)?.name
+
   return (
     <TableContainer>
       <label htmlFor="popoverTable">{fishNameInfo.display_name ?? fishNameInfo.name}</label>
       <Table id="popoverTable">
         <tbody>
-          {fishNameInfo.family ? (
+          {fishFamilyName ? (
             <Tr>
               <Td as="th">{tableLanguage.family}</Td>
-              <Td>{fishFamilies.find((item) => item.id === fishNameInfo.family).name}</Td>
+              <Td>{fishFamilyName}</Td>
             </Tr>
           ) : null}
           <Tr>

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -166,14 +166,12 @@ const FishBeltObservationTable = ({
 
   const handlePopoverButtonClick = useCallback(
     ({ observationId, fishNameId }) => {
-      const fishNameInfo = [...fishSpecies, ...fishGenera, ...fishFamilies].find(
-        (item) => item.id === fishNameId,
-      )
-
       const popoverTable = getFishNameTable({
-        fishNameInfo,
         fishFamilies,
         choices,
+        fishGenera,
+        fishSpecies,
+        fishNameId,
       })
 
       setFishNamePopoverContent(popoverTable)


### PR DESCRIPTION
Steps to test:
- go to a fish belt
- add an observation for a species, a genus and a family. (I used Chlorurus bleekeri, Pseudanthias, and Scaridae)
- click the popover for each

Expected results:          
- for a species, and a genus,  a row with the family name will show. 

<img width="1000" alt="Screenshot 2023-12-05 at 3 49 42 PM" src="https://github.com/data-mermaid/mermaid-webapp/assets/1740152/4d0f89f4-a9d2-47fc-9fcf-0c13540d0114">

- for family, no family row will show (because the table label contains the family name already)

<img width="1000" alt="Screenshot 2023-12-05 at 3 49 58 PM" src="https://github.com/data-mermaid/mermaid-webapp/assets/1740152/ec2cab7f-f939-4483-b0f3-3f3669090e83">

