### PR TITLE
M622 bleaching observation table jumping bug fix

### DIFF
--- a/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
@@ -207,7 +207,6 @@ const ColoniesBleachedObservationTable = ({
                 <ObservationAutocomplete
                   id={`observation-${observationId}`}
                   autoFocus={autoFocusAllowed}
-                  isLastRow={observationsState.length === rowNumber}
                   aria-labelledby="benthic-attribute-label"
                   options={benthicAttributeSelectOptions}
                   onChange={handleBenthicAttributeChange}

--- a/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
@@ -77,9 +77,8 @@ const ColoniesBleachedObservationTable = ({
     const handleKeyDown = ({ event, index, observation, isLastCell }) => {
       const isTabKey = event.code === 'Tab' && !event.shiftKey
       const isEnterKey = event.code === 'Enter'
-      const isLastRow = index === observationsState.length - 1
 
-      if (isTabKey && isLastRow && isLastCell) {
+      if (isTabKey && isLastCell) {
         event.preventDefault()
         setAutoFocusAllowed(true)
         observationsDispatch({


### PR DESCRIPTION
[trello card](https://trello.com/c/2dmq0XSL/622-bleaching-observation-table-automatically-move-up-when-typing-ba)

removed `isLastRow` for Colonies Bleached table. Left the check on Percentage Cover, since it is the last table on the page (in which case, we don't mind that it scrolls to bottom).