### PR TITLE
M287 remove excessive network calls

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -36,7 +36,7 @@ import { routes } from './routes'
 
 function App({ dexieCurrentUserInstance }) {
   const { isAppOnline, setServerNotReachable } = useOnlineStatus()
-  const { isOfflineStorageHydrated, syncErrors, isSyncInProgress } = useSyncStatus()
+  const { isOfflineStorageHydrated, syncErrors } = useSyncStatus()
   const apiBaseUrl = process.env.REACT_APP_MERMAID_API
   const navigate = useNavigate()
   const isMounted = useIsMounted()
@@ -108,7 +108,6 @@ function App({ dexieCurrentUserInstance }) {
     dexieCurrentUserInstance,
     isMermaidAuthenticated,
     isAppOnline,
-    isSyncInProgress,
     handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied,
   })
 

--- a/src/App/integrationTests/managementRegime/App.managementRegimeCreateOffline.test.js
+++ b/src/App/integrationTests/managementRegime/App.managementRegimeCreateOffline.test.js
@@ -102,7 +102,7 @@ describe('Offline', () => {
     expect(screen.getByLabelText('Secondary Name')).toHaveValue('Becca')
     expect(screen.getByLabelText('Year Established')).toHaveValue(1980)
     expect(screen.getByLabelText('Area')).toHaveValue(40)
-    expect(within(screen.getByLabelText('Parties')).getByLabelText('NGO')).toBeChecked()
+    expect(await within(screen.getByLabelText('Parties')).findByLabelText('NGO')).toBeChecked()
     expect(
       within(screen.getByLabelText('Rules')).getByLabelText('Open Access', { exact: false }),
     ).toBeChecked()

--- a/src/App/mermaidData/databaseSwitchboard/ProjectsMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/ProjectsMixin.js
@@ -73,7 +73,7 @@ const ProjectsMixin = (Base) =>
       return this._isOnlineAuthenticatedAndReady
         ? axios
             .get(
-              `${this._apiBaseUrl}/projecttags`,
+              `${this._apiBaseUrl}/projecttags/`,
               await getAuthorizationHeaders(this._getAccessToken),
             )
             .then((apiResults) => apiResults.data.results)
@@ -138,7 +138,7 @@ const ProjectsMixin = (Base) =>
 
       return this._isAuthenticatedAndReady
         ? axios
-            .get(`${this._apiBaseUrl}/profiles`, {
+            .get(`${this._apiBaseUrl}/profiles/`, {
               params: {
                 email,
               },

--- a/src/App/mermaidData/databaseSwitchboard/SubmittedRecordsMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/SubmittedRecordsMixin.js
@@ -56,7 +56,7 @@ const SubmittedRecordsMixin = (Base) =>
       return this._isOnlineAuthenticatedAndReady
         ? axios
             .get(
-              `${this._apiBaseUrl}/projects/${projectId}/${sampleUnitMethod}/${id}`,
+              `${this._apiBaseUrl}/projects/${projectId}/${sampleUnitMethod}/${id}/`,
               await getAuthorizationHeaders(this._getAccessToken),
             )
             .then((apiResults) => apiResults.data)

--- a/src/App/useInitializeCurrentUser.js
+++ b/src/App/useInitializeCurrentUser.js
@@ -10,7 +10,6 @@ export const useInitializeCurrentUser = ({
   dexieCurrentUserInstance,
   isMermaidAuthenticated,
   isAppOnline,
-  isSyncInProgress,
   handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied,
 }) => {
   const [currentUser, setCurrentUser] = useState()
@@ -25,7 +24,6 @@ export const useInitializeCurrentUser = ({
         dexieCurrentUserInstance,
         isMermaidAuthenticated,
         isAppOnline,
-        isSyncInProgress,
       })
         .then((user) => {
           if (isMounted && user) {
@@ -51,7 +49,6 @@ export const useInitializeCurrentUser = ({
     dexieCurrentUserInstance,
     isMermaidAuthenticated,
     isAppOnline,
-    isSyncInProgress,
     handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied,
   ])
 

--- a/src/components/pages/ManagementRegime/ManagementRegime.test.js
+++ b/src/components/pages/ManagementRegime/ManagementRegime.test.js
@@ -132,7 +132,7 @@ test('Management Regime component - form inputs are initialized with the correct
 
   expect(within(parties).getByLabelText('NGO')).not.toBeChecked()
   expect(within(parties).getByLabelText('community/local government')).not.toBeChecked()
-  expect(within(parties).getByLabelText('government')).toBeChecked()
+  expect(await within(parties).findByLabelText('government')).toBeChecked()
   expect(within(parties).getByLabelText('private sector')).not.toBeChecked()
   expect(
     within(screen.getByLabelText('Rules')).getByLabelText('Open Access', { exact: false }),

--- a/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
+++ b/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
@@ -216,7 +216,7 @@ const SubmittedFishBelt = () => {
                 </p>
                 <ButtonSecondary
                   onClick={handleMoveToCollect}
-                  disabled={currentUserProfile.is_admin ? isMoveToButtonDisabled : 'false'}
+                  disabled={currentUserProfile.is_admin ? isMoveToButtonDisabled : false}
                 >
                   <IconPen />
                   {language.pages.submittedForm.moveSampleUnitButton}


### PR DESCRIPTION
The API is sensitive to the absence of a trailing slash and if it is missing will cause a redirect, which results in multiple calls to  `projecttags/` and
`projecttags`
for example.