### PR TITLE
[648] Jumping carat bug fix in filter search

### DIFF
--- a/src/components/CopyManagementRegimesModal/CopyManagementRegimesModal.js
+++ b/src/components/CopyManagementRegimesModal/CopyManagementRegimesModal.js
@@ -387,7 +387,6 @@ const CopyManagementRegimesModal = ({ isOpen, onDismiss, addCopiedMRsToManagemen
     <CopyModalToolbarWrapper>
       <FilterSearchToolbar
         name={language.pages.copyManagementRegimeTable.filterToolbarText}
-        value={tableUserPrefs.globalFilter}
         handleGlobalFilterChange={handleGlobalFilterChange}
         id="copy-management-regimes-filter"
       />

--- a/src/components/FilterSearchToolbar/FilterSearchToolbar.js
+++ b/src/components/FilterSearchToolbar/FilterSearchToolbar.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components/macro'
 import { Input, inputStyles } from '../generic/form'
@@ -14,10 +14,13 @@ const FilterInput = styled(Input)`
   ${inputStyles};
 `
 
-const FilterSearchToolbar = ({ name, handleGlobalFilterChange, value, id, disabled }) => {
-  const handleFilterChange = (event) => {
-    const { value: eventValue } = event.target
+const FilterSearchToolbar = ({ name, handleGlobalFilterChange, id, disabled }) => {
+  const [searchText, setSearchText] = useState([])
 
+  const handleFilterChange = (event) => {
+    const eventValue = event.target.value
+
+    setSearchText(eventValue)
     handleGlobalFilterChange(eventValue)
   }
 
@@ -27,7 +30,7 @@ const FilterSearchToolbar = ({ name, handleGlobalFilterChange, value, id, disabl
       <FilterInput
         type="text"
         id={id}
-        value={value}
+        value={searchText}
         onChange={handleFilterChange}
         disabled={disabled}
       />
@@ -37,7 +40,6 @@ const FilterSearchToolbar = ({ name, handleGlobalFilterChange, value, id, disabl
 
 FilterSearchToolbar.defaultProps = {
   id: 'filter-search',
-  value: undefined,
   disabled: false,
 }
 
@@ -45,7 +47,6 @@ FilterSearchToolbar.propTypes = {
   handleGlobalFilterChange: PropTypes.func.isRequired,
   id: PropTypes.string,
   name: PropTypes.string.isRequired,
-  value: PropTypes.string,
   disabled: PropTypes.bool,
 }
 

--- a/src/components/pages/Collect/Collect.js
+++ b/src/components/pages/Collect/Collect.js
@@ -396,7 +396,6 @@ const Collect = () => {
               <FilterItems>
                 <FilterSearchToolbar
                   name={language.pages.collectTable.filterToolbarText}
-                  value={tableUserPrefs.globalFilter}
                   handleGlobalFilterChange={handleGlobalFilterChange}
                   disabled={collectRecordsForUiDisplay.length === 0}
                 />

--- a/src/components/pages/ManagementRegimes/ManagementRegimes.js
+++ b/src/components/pages/ManagementRegimes/ManagementRegimes.js
@@ -458,7 +458,6 @@ const ManagementRegimes = () => {
           <ToolBarRow>
             <FilterSearchToolbar
               name={language.pages.managementRegimeTable.filterToolbarText}
-              value={tableUserPrefs.globalFilter}
               handleGlobalFilterChange={handleGlobalFilterChange}
               disabled={managementRegimeRecordsForUiDisplay.length === 0}
             />

--- a/src/components/pages/ManagementRegimesOverview/ManagementRegimesOverview.js
+++ b/src/components/pages/ManagementRegimesOverview/ManagementRegimesOverview.js
@@ -467,7 +467,6 @@ const ManagementRegimesOverview = () => {
           <FilterItems>
             <FilterSearchToolbar
               name={language.pages.usersAndTransectsTable.filterToolbarText}
-              value={tableUserPrefs.globalFilter}
               handleGlobalFilterChange={handleGlobalFilterChange}
               disabled={sampleUnitWithManagementRegimeRecords.length === 0}
             />

--- a/src/components/pages/Sites/Sites.js
+++ b/src/components/pages/Sites/Sites.js
@@ -413,7 +413,6 @@ const Sites = () => {
           <ToolBarRow>
             <FilterSearchToolbar
               name={language.pages.siteTable.filterToolbarText}
-              value={tableUserPrefs.globalFilter}
               handleGlobalFilterChange={handleGlobalFilterChange}
               disabled={siteRecordsForUiDisplay.length === 0}
             />

--- a/src/components/pages/Submitted/SubmittedToolbarSection.js
+++ b/src/components/pages/Submitted/SubmittedToolbarSection.js
@@ -29,7 +29,6 @@ const SubmittedToolbarSection = ({
   name,
   handleGlobalFilterChange,
   handleMethodsColumnFilterChange,
-  searchFilterValue,
   methodFilterValue,
   disabled,
   unfilteredRowLength,
@@ -67,7 +66,6 @@ const SubmittedToolbarSection = ({
           <FilterSearchToolbar
             name={name}
             handleGlobalFilterChange={handleGlobalFilterChange}
-            value={searchFilterValue}
             disabled={disabled}
           />
           <MethodsFilterDropDown
@@ -117,7 +115,6 @@ const SubmittedToolbarSection = ({
 }
 
 SubmittedToolbarSection.defaultProps = {
-  searchFilterValue: undefined,
   methodFilterValue: [],
   disabled: false,
   methodFilteredRowLength: null,
@@ -130,7 +127,6 @@ SubmittedToolbarSection.propTypes = {
   name: PropTypes.string.isRequired,
   handleGlobalFilterChange: PropTypes.func.isRequired,
   handleMethodsColumnFilterChange: PropTypes.func.isRequired,
-  searchFilterValue: PropTypes.string,
   methodFilterValue: PropTypes.arrayOf(string),
   disabled: PropTypes.bool,
   unfilteredRowLength: PropTypes.number.isRequired,

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -919,7 +919,6 @@ const Users = () => {
                   : language.pages.userTable.filterToolbarTextForNonAdmin
               }
               handleGlobalFilterChange={handleGlobalFilterChange}
-              value={tableUserPrefs.globalFilter}
             />
             {isAdminUser && (
               <InputAndButton

--- a/src/components/pages/UsersAndTransects/UsersAndTransects.js
+++ b/src/components/pages/UsersAndTransects/UsersAndTransects.js
@@ -603,7 +603,6 @@ const UsersAndTransects = () => {
           <FilterItems>
             <FilterSearchToolbar
               name={language.pages.usersAndTransectsTable.filterToolbarText}
-              value={tableUserPrefs.globalFilter}
               handleGlobalFilterChange={handleGlobalFilterChange}
               disabled={submittedRecords.length === 0}
             />


### PR DESCRIPTION
[trello card](https://trello.com/c/TROqoAds/648-caret-jumps-to-end-of-field-in-table-filters)

Made search text var local to `FilterSearchToolbar` instead of passing the value back from a complex object from a different component.

to test :

1. go to any page with filter search (Sites for example)
2. add text to filter
3. move carat back a few characters
4. type new characters
5. ensure carat doesn't jump to end of string