### PR TITLE
[531] improve duplicate observation row validation errors

### DIFF
--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.js
@@ -204,7 +204,7 @@ const BenthicLitObservationsTable = ({
       }
 
       return (
-        <ObservationTr key={observationId}>
+        <ObservationTr key={observationId} messageType={observationValidationType}>
           <Td align="center">{rowNumber}</Td>
 
           <Td align="left">

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratObservationTable.js
@@ -267,7 +267,7 @@ const BenthicPhotoQuadratObservationTable = ({
       }
 
       return (
-        <ObservationTr key={observationId}>
+        <ObservationTr key={observationId} messageType={observationValidationType}>
           <Td align="center">{rowNumber}</Td>
           <Td align="right">
             <InputNumberNumericCharactersOnly

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.js
@@ -208,7 +208,7 @@ const BenthicPitObservationsTable = ({
       }
 
       return (
-        <ObservationTr key={observationId}>
+        <ObservationTr key={observationId} messageType={observationValidationType}>
           <Td align="center">{rowNumber}</Td>
           <Td align="right" aria-labelledby="interval-label">
             {interval}m

--- a/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
@@ -197,7 +197,7 @@ const ColoniesBleachedObservationTable = ({
       }
 
       return (
-        <ObservationTr key={observationId}>
+        <ObservationTr key={observationId} messageType={observationValidationType}>
           <Td align="center">{rowNumber}</Td>
 
           <Td align="left">

--- a/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/PercentCoverObservationsTable.js
@@ -167,7 +167,7 @@ const PercentCoverObservationTable = ({
       }
 
       return (
-        <ObservationTr key={observationId}>
+        <ObservationTr key={observationId} messageType={observationValidationType}>
           <Td align="center">{rowNumber}</Td>
           <Td align="center">{quadrat_number}</Td>
 

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/getObservationValidationInfo.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/getObservationValidationInfo.js
@@ -3,6 +3,16 @@ import getValidationPropertiesForInput from '../getValidationPropertiesForInput'
 const getObservationValidations = ({ observationId, collectRecord, observationsPropertyName }) => {
   const allObservationsValidations =
     collectRecord?.validations?.results?.data?.[observationsPropertyName] ?? []
+
+  const duplicateRecordValidator = collectRecord?.validations?.results?.$record?.filter(
+    (record) => record?.code === 'duplicate_values',
+  )
+
+  const isObservationIdIncludedInDuplicateRecordValidator =
+    !!duplicateRecordValidator?.[0]?.context?.duplicates[0]?.filter(
+      (obs) => obs.id === observationId,
+    ).length
+
   const justThisObservationsValidations = allObservationsValidations.flat().filter((validation) => {
     // api is inconsistent between id and observation_id
     return (
@@ -10,6 +20,18 @@ const getObservationValidations = ({ observationId, collectRecord, observationsP
       validation.context?.id === observationId
     )
   })
+
+  // if there are duplicate values, in context, there is an array of objects with the duplicate observations ids
+  // here we add an id property to the context object so that we can use the same function to get the validation properties for the input
+
+  if (isObservationIdIncludedInDuplicateRecordValidator) {
+    duplicateRecordValidator[0].context.id = observationId
+
+    const observationValidationsWithDuplicateValidator =
+      justThisObservationsValidations.concat(duplicateRecordValidator)
+
+    return observationValidationsWithDuplicateValidator
+  }
 
   return justThisObservationsValidations
 }
@@ -25,6 +47,7 @@ const getObservationValidationInfo = ({
     collectRecord,
     observationsPropertyName,
   })
+
   const observationValidationsToDisplay = getValidationPropertiesForInput(
     observationValidations,
     areValidationsShowing,

--- a/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/HabitatComplexityForm/HabitatComplexityObservationTable.js
@@ -170,7 +170,7 @@ const HabitatComplexityObservationsTable = ({
       }
 
       return (
-        <ObservationTr key={observationId}>
+        <ObservationTr key={observationId} messageType={observationValidationType}>
           <Td align="center">{rowNumber}</Td>
           <Td align="right" aria-labelledby="interval-label">
             {interval}m

--- a/src/components/pages/collectRecordFormPages/RecordLevelValidationInfo/RecordLevelValidationInfo.js
+++ b/src/components/pages/collectRecordFormPages/RecordLevelValidationInfo/RecordLevelValidationInfo.js
@@ -39,6 +39,7 @@ const ScrollToButton = styled(ButtonThatLooksLikeLink)`
 const checkScrollToObservation = (validationInfo) => {
   const validationStatusNotOkay = validationInfo.status !== 'ok'
   const observationTableValidationMessages = [
+    'data.obs_colonies_bleached',
     'data.obs_benthic_photo_quadrats',
     'data.obs_belt_fishes',
   ].some((obs) => validationInfo?.fields?.includes(obs))

--- a/src/language.js
+++ b/src/language.js
@@ -494,7 +494,10 @@ const getValidationMessage = (validation, projectId = '') => {
     duplicate_quadrat_transect: () =>
       getDuplicateSampleUnitLink(context?.duplicate_transect_method, projectId),
     duplicate_transect: () => 'Transect already exists',
-    duplicate_values: () => getDuplicateValuesValidationMessage(fields[0], context?.duplicates[0]),
+    duplicate_values: () =>
+      fields?.length
+        ? getDuplicateValuesValidationMessage(fields[0], context?.duplicates?.[0])
+        : '',
     exceed_total_colonies: () => 'Maximum number of colonies exceeded',
     future_sample_date: () => 'Sample date is in the future',
     high_density: () => `Fish biomass greater than ${context?.biomass_range[1]} kg/ha`,

--- a/src/language.js
+++ b/src/language.js
@@ -496,7 +496,7 @@ const getValidationMessage = (validation, projectId = '') => {
     duplicate_transect: () => 'Transect already exists',
     duplicate_values: () =>
       fields?.length
-        ? getDuplicateValuesValidationMessage(fields[0], context?.duplicates?.[0])
+        ? getDuplicateValuesValidationMessage(fields[0], context?.duplicates)
         : 'Duplicate',
     exceed_total_colonies: () => 'Maximum number of colonies exceeded',
     future_sample_date: () => 'Sample date is in the future',

--- a/src/language.js
+++ b/src/language.js
@@ -6,6 +6,7 @@ import {
   getSystemValidationErrorMessage,
   getDuplicateSampleUnitLink,
   goToManagementOverviewPageLink,
+  getDuplicateIndexes,
 } from './library/validationMessageHelpers'
 import { HelperTextLink } from './components/generic/links'
 
@@ -493,7 +494,8 @@ const getValidationMessage = (validation, projectId = '') => {
     duplicate_quadrat_transect: () =>
       getDuplicateSampleUnitLink(context?.duplicate_transect_method, projectId),
     duplicate_transect: () => 'Transect already exists',
-    duplicate_values: () => 'Duplicate',
+    duplicate_values: () =>
+      `Duplicate colonies bleached observations: ${getDuplicateIndexes(context?.duplicates[0])}`,
     exceed_total_colonies: () => 'Maximum number of colonies exceeded',
     future_sample_date: () => 'Sample date is in the future',
     high_density: () => `Fish biomass greater than ${context?.biomass_range[1]} kg/ha`,

--- a/src/language.js
+++ b/src/language.js
@@ -497,7 +497,7 @@ const getValidationMessage = (validation, projectId = '') => {
     duplicate_values: () =>
       fields?.length
         ? getDuplicateValuesValidationMessage(fields[0], context?.duplicates?.[0])
-        : '',
+        : 'Duplicate',
     exceed_total_colonies: () => 'Maximum number of colonies exceeded',
     future_sample_date: () => 'Sample date is in the future',
     high_density: () => `Fish biomass greater than ${context?.biomass_range[1]} kg/ha`,

--- a/src/language.js
+++ b/src/language.js
@@ -6,7 +6,7 @@ import {
   getSystemValidationErrorMessage,
   getDuplicateSampleUnitLink,
   goToManagementOverviewPageLink,
-  getDuplicateIndexes,
+  getDuplicateValuesValidationMessage,
 } from './library/validationMessageHelpers'
 import { HelperTextLink } from './components/generic/links'
 
@@ -479,7 +479,7 @@ const getResolveModalLanguage = (siteOrManagementRegime) => {
 }
 
 const getValidationMessage = (validation, projectId = '') => {
-  const { code, context, name } = validation
+  const { code, context, fields, name } = validation
 
   const validationMessages = {
     all_attributes_same_category: () => `All benthic attributes are ${context?.category}`,
@@ -494,8 +494,7 @@ const getValidationMessage = (validation, projectId = '') => {
     duplicate_quadrat_transect: () =>
       getDuplicateSampleUnitLink(context?.duplicate_transect_method, projectId),
     duplicate_transect: () => 'Transect already exists',
-    duplicate_values: () =>
-      `Duplicate colonies bleached observations: ${getDuplicateIndexes(context?.duplicates[0])}`,
+    duplicate_values: () => getDuplicateValuesValidationMessage(fields[0], context?.duplicates[0]),
     exceed_total_colonies: () => 'Maximum number of colonies exceeded',
     future_sample_date: () => 'Sample date is in the future',
     high_density: () => `Fish biomass greater than ${context?.biomass_range[1]} kg/ha`,

--- a/src/library/validationMessageHelpers.js
+++ b/src/library/validationMessageHelpers.js
@@ -44,8 +44,28 @@ export const goToManagementOverviewPageLink = (projectId) => {
   )
 }
 
-export const getDuplicateIndexes = (duplicateIndexes) => {
+const getDuplicateIndexes = (duplicateIndexes) => {
   const indexList = duplicateIndexes.map((duplicate) => duplicate.index + 1)
 
   return indexList.join(', ')
+}
+
+const getObservationFieldName = (fieldName) => {
+  // fieldName is a string 'data.obs_colonies_bleached' as an example
+  // since the api does not give us the name, 'Colonies Bleached', we have to map this ourselves and also remove 'data.' from the field name
+
+  const cleanFieldName = fieldName.slice(5)
+
+  const observationFieldNameMapping = {
+    obs_colonies_bleached: 'colonies bleached',
+    benthic_photo_quadrats: 'Benthic Photo Quadrats',
+  }
+
+  return observationFieldNameMapping[cleanFieldName]
+    ? observationFieldNameMapping[cleanFieldName]
+    : ''
+}
+
+export const getDuplicateValuesValidationMessage = (field, context) => {
+  return `Duplicate ${getObservationFieldName(field)} observations: ${getDuplicateIndexes(context)}`
 }

--- a/src/library/validationMessageHelpers.js
+++ b/src/library/validationMessageHelpers.js
@@ -43,3 +43,9 @@ export const goToManagementOverviewPageLink = (projectId) => {
     </span>
   )
 }
+
+export const getDuplicateIndexes = (duplicateIndexes) => {
+  const indexList = duplicateIndexes.map((duplicate) => duplicate.index + 1)
+
+  return indexList.join(', ')
+}

--- a/src/library/validationMessageHelpers.js
+++ b/src/library/validationMessageHelpers.js
@@ -45,7 +45,7 @@ export const goToManagementOverviewPageLink = (projectId) => {
 }
 
 const getDuplicateIndexes = (duplicateIndexes) => {
-  const indexList = duplicateIndexes.map((duplicate) => duplicate.index + 1)
+  const indexList = duplicateIndexes.flatMap((array) => array.map((item) => item.index + 1))
 
   return indexList.join(', ')
 }


### PR DESCRIPTION
[trello card](https://trello.com/c/Dzh9Ah6a/531-improve-duplicate-validation-error-for-bleaching-quadrat-collection)

currently a draft as it is dependent on an api adjustment - all duplicates need to be included. So if rows 1 & 2 are the same, and 3 & 4 are the same, but different from 1 & 2, all 4 rows get added to the duplicate list (not just 1 & 2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced observation tables across various forms to include validation messages, improving user feedback on data entry accuracy.
	- Improved duplicate record validation logic to ensure data integrity and user guidance.
- **Refactor**
	- Updated validation message handling for better clarity and specificity in error feedback to users.
- **Bug Fixes**
	- Fixed issues related to duplicate values handling, ensuring more reliable data validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->