### PR TITLE
[642] add sync interval start button to Benthic pit

### DIFF
--- a/src/components/generic/form.js
+++ b/src/components/generic/form.js
@@ -126,6 +126,11 @@ export const Input = styled.input`
   &[type='number'] {
     text-align: right;
   }
+  &:disabled {
+    background: ${theme.color.disabledInputBackground};
+    cursor: not-allowed;
+    color: ${theme.color.disabledTextDark};
+  }
 `
 export const Textarea = styled.textarea`
   resize: vertical;

--- a/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
@@ -46,7 +46,7 @@ const InputWithLabelAndValidation = ({
   useStopInputScrollingIncrementNumber(textFieldRef)
 
   const [isHelperTextShowing, setIsHelperTextShowing] = useState(false)
-  const [isChecked, setIsChecked] = useState(false)
+  const [isCheckboxChecked, setIsCheckboxChecked] = useState(false)
 
   const handleInfoIconClick = (event) => {
     isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
@@ -60,7 +60,7 @@ const InputWithLabelAndValidation = ({
       aria-describedby={`aria-descp${id}`}
       id={id}
       unit={unit}
-      disabled={isChecked}
+      disabled={isCheckboxChecked}
       {...restOfProps}
     />
   ) : (
@@ -73,8 +73,9 @@ const InputWithLabelAndValidation = ({
     />
   )
 
+  // example use case is in Benthic Pit Transect Inputs for Interval Start
   const handleCheckboxChange = (checked) => {
-    setIsChecked(checked)
+    setIsCheckboxChecked(checked)
     handleCheckboxUpdate(checked)
   }
 
@@ -98,7 +99,7 @@ const InputWithLabelAndValidation = ({
             <input
               id="checkbox-sync"
               type="checkbox"
-              checked={isChecked}
+              checked={isCheckboxChecked}
               onChange={(event) => handleCheckboxChange(event.target.checked)}
             />
             {checkboxLabel}

--- a/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
@@ -10,7 +10,6 @@ import InputValidationInfo from '../InputValidationInfo/InputValidationInfo'
 import mermaidInputsPropTypes from '../mermaidInputsPropTypes'
 import { IconButton } from '../../generic/buttons'
 import { IconInfo } from '../../icons'
-import language from '../../../language'
 import theme from '../../../theme'
 
 const CheckBoxLabel = styled.label`
@@ -36,8 +35,9 @@ const InputWithLabelAndValidation = ({
   unit,
   validationMessages,
   validationType,
-  addSyncCheckbox,
-  handleSyncIntervalChange,
+  addCheckbox,
+  handleCheckboxUpdate,
+  checkboxLabel,
 
   ...restOfProps
 }) => {
@@ -46,7 +46,7 @@ const InputWithLabelAndValidation = ({
   useStopInputScrollingIncrementNumber(textFieldRef)
 
   const [isHelperTextShowing, setIsHelperTextShowing] = useState(false)
-  const [isSyncItemChecked, setIsSyncItemChecked] = useState(false)
+  const [isChecked, setIsChecked] = useState(false)
 
   const handleInfoIconClick = (event) => {
     isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
@@ -60,7 +60,7 @@ const InputWithLabelAndValidation = ({
       aria-describedby={`aria-descp${id}`}
       id={id}
       unit={unit}
-      disabled={isSyncItemChecked}
+      disabled={isChecked}
       {...restOfProps}
     />
   ) : (
@@ -73,9 +73,9 @@ const InputWithLabelAndValidation = ({
     />
   )
 
-  const handleSyncChange = (checked) => {
-    setIsSyncItemChecked(checked)
-    handleSyncIntervalChange(checked)
+  const handleCheckboxChange = (checked) => {
+    setIsChecked(checked)
+    handleCheckboxUpdate(checked)
   }
 
   return (
@@ -93,15 +93,15 @@ const InputWithLabelAndValidation = ({
       </LabelContainer>
 
       <div>
-        {addSyncCheckbox ? (
+        {addCheckbox ? (
           <CheckBoxLabel>
             <input
-              id="interval-sync-toggle"
+              id="checkbox-sync"
               type="checkbox"
-              checked={isSyncItemChecked}
-              onChange={(event) => handleSyncChange(event.target.checked)}
+              checked={isChecked}
+              onChange={(event) => handleCheckboxChange(event.target.checked)}
             />
-            {language.pages.collectRecord.benthicPitSyncCheckbox}
+            {checkboxLabel}
           </CheckBoxLabel>
         ) : null}
         {inputType}
@@ -119,9 +119,10 @@ const InputWithLabelAndValidation = ({
 }
 
 InputWithLabelAndValidation.propTypes = {
-  addSyncCheckbox: PropTypes.bool,
+  addCheckbox: PropTypes.bool,
+  checkboxLabel: PropTypes.string,
   required: PropTypes.bool,
-  handleSyncIntervalChange: PropTypes.func,
+  handleCheckboxUpdate: PropTypes.func,
   helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   id: PropTypes.string.isRequired,
   ignoreNonObservationFieldValidations: PropTypes.func,
@@ -134,10 +135,11 @@ InputWithLabelAndValidation.propTypes = {
 }
 
 InputWithLabelAndValidation.defaultProps = {
-  addSyncCheckbox: false,
+  addCheckbox: false,
+  checkboxLabel: '',
   required: false,
   helperText: undefined,
-  handleSyncIntervalChange: () => {},
+  handleCheckboxUpdate: () => {},
   ignoreNonObservationFieldValidations: () => {},
   resetNonObservationFieldValidations: () => {},
   testId: undefined,

--- a/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
 
 import { Input, InputRow, HelperText, LabelContainer, RequiredIndicator } from '../../generic/form'
 import { useStopInputScrollingIncrementNumber } from '../../../library/useStopInputScrollingIncrementNumber'
@@ -9,6 +10,20 @@ import InputValidationInfo from '../InputValidationInfo/InputValidationInfo'
 import mermaidInputsPropTypes from '../mermaidInputsPropTypes'
 import { IconButton } from '../../generic/buttons'
 import { IconInfo } from '../../icons'
+import language from '../../../language'
+import theme from '../../../theme'
+
+const CheckBoxLabel = styled.label`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-bottom: ${theme.spacing.small};
+
+  input {
+    margin: 0 ${theme.spacing.small} 0 0;
+    cursor: pointer;
+  }
+`
 
 const InputWithLabelAndValidation = ({
   required,
@@ -21,6 +36,9 @@ const InputWithLabelAndValidation = ({
   unit,
   validationMessages,
   validationType,
+  addSyncCheckbox,
+  handleSyncIntervalChange,
+
   ...restOfProps
 }) => {
   const textFieldRef = useRef()
@@ -28,6 +46,7 @@ const InputWithLabelAndValidation = ({
   useStopInputScrollingIncrementNumber(textFieldRef)
 
   const [isHelperTextShowing, setIsHelperTextShowing] = useState(false)
+  const [isSyncItemChecked, setIsSyncItemChecked] = useState(false)
 
   const handleInfoIconClick = (event) => {
     isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
@@ -41,6 +60,7 @@ const InputWithLabelAndValidation = ({
       aria-describedby={`aria-descp${id}`}
       id={id}
       unit={unit}
+      disabled={isSyncItemChecked}
       {...restOfProps}
     />
   ) : (
@@ -52,6 +72,11 @@ const InputWithLabelAndValidation = ({
       ref={textFieldRef}
     />
   )
+
+  const handleSyncChange = (checked) => {
+    setIsSyncItemChecked(checked)
+    handleSyncIntervalChange(checked)
+  }
 
   return (
     <InputRow required={required} validationType={validationType} data-testid={testId}>
@@ -68,9 +93,21 @@ const InputWithLabelAndValidation = ({
       </LabelContainer>
 
       <div>
+        {addSyncCheckbox ? (
+          <CheckBoxLabel>
+            <input
+              id="interval-sync-toggle"
+              type="checkbox"
+              checked={isSyncItemChecked}
+              onChange={(event) => handleSyncChange(event.target.checked)}
+            />
+            {language.pages.collectRecord.benthicPitSyncCheckbox}
+          </CheckBoxLabel>
+        ) : null}
         {inputType}
         {isHelperTextShowing ? <HelperText id={`aria-descp${id}`}>{helperText}</HelperText> : null}
       </div>
+
       <InputValidationInfo
         validationType={validationType}
         validationMessages={validationMessages}
@@ -82,7 +119,9 @@ const InputWithLabelAndValidation = ({
 }
 
 InputWithLabelAndValidation.propTypes = {
+  addSyncCheckbox: PropTypes.bool,
   required: PropTypes.bool,
+  handleSyncIntervalChange: PropTypes.func,
   helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   id: PropTypes.string.isRequired,
   ignoreNonObservationFieldValidations: PropTypes.func,
@@ -95,8 +134,10 @@ InputWithLabelAndValidation.propTypes = {
 }
 
 InputWithLabelAndValidation.defaultProps = {
+  addSyncCheckbox: false,
   required: false,
   helperText: undefined,
+  handleSyncIntervalChange: () => {},
   ignoreNonObservationFieldValidations: () => {},
   resetNonObservationFieldValidations: () => {},
   testId: undefined,

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitTransectInputs.js
@@ -360,8 +360,9 @@ const BenthicPitTransectInputs = ({
           onChange={handleIntervalStartChange}
           unit="m"
           helperText={language.helperText.intervalStart}
-          addSyncCheckbox={true}
-          handleSyncIntervalChange={handleSyncIntervalChange}
+          addCheckbox={true}
+          handleCheckboxUpdate={handleSyncIntervalChange}
+          checkboxLabel={language.pages.collectRecord.benthicPitSyncCheckbox}
         />
         <InputSelectWithLabelAndValidation
           label="Reef Slope"

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitTransectInputs.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 
 import {
@@ -46,6 +46,8 @@ const BenthicPitTransectInputs = ({
   const currentOptions = getOptions(currents.data)
   const tideOptions = getOptions(tides.data)
   const benthic_transect = validationsApiData?.benthic_transect
+
+  const [isSyncIntervalStart, setIsSyncIntervalStart] = useState(false)
 
   const transectNumberValidationProperties = getValidationPropertiesForInput(
     benthic_transect?.number,
@@ -181,6 +183,9 @@ const BenthicPitTransectInputs = ({
   }
 
   const handleIntervalSizeChange = (event) => {
+    if (isSyncIntervalStart) {
+      formik.setFieldValue('interval_start', event.target.value)
+    }
     formik.handleChange(event)
     resetNonObservationFieldValidations({
       validationPath: INTERVAL_SIZE_VALIDATION_PATH,
@@ -192,6 +197,15 @@ const BenthicPitTransectInputs = ({
     resetNonObservationFieldValidations({
       validationPath: INTERVAL_START_VALIDATION_PATH,
     })
+  }
+
+  const handleSyncIntervalChange = (checked) => {
+    if (checked) {
+      setIsSyncIntervalStart(true)
+      formik.setFieldValue('interval_start', formik.values.interval_size)
+    } else {
+      setIsSyncIntervalStart(false)
+    }
   }
 
   return (
@@ -346,6 +360,8 @@ const BenthicPitTransectInputs = ({
           onChange={handleIntervalStartChange}
           unit="m"
           helperText={language.helperText.intervalStart}
+          addSyncCheckbox={true}
+          handleSyncIntervalChange={handleSyncIntervalChange}
         />
         <InputSelectWithLabelAndValidation
           label="Reef Slope"

--- a/src/components/pages/collectRecordFormPages/collectRecordFormInitialValues.js
+++ b/src/components/pages/collectRecordFormPages/collectRecordFormInitialValues.js
@@ -53,7 +53,7 @@ const getBenthicPhotoQuadratAdditionalValues = (collectRecord) => {
 
 const getBenthicPitAdditionalValues = (collectRecord) => {
   return {
-    interval_start: collectRecord?.data?.interval_start ?? 1,
+    interval_start: collectRecord?.data?.interval_start ?? '',
     interval_size: collectRecord?.data?.interval_size ?? '',
   }
 }

--- a/src/language.js
+++ b/src/language.js
@@ -331,6 +331,7 @@ const pages = {
       functionalGroup: 'Functional Group',
       trophicGroup: 'Trophic Group',
     },
+    benthicPitSyncCheckbox: 'Use Interval Size as Interval Start',
   },
   projectInfo: {
     createOrganizationTitle: 'Suggest a new organization',
@@ -568,7 +569,7 @@ const helperText = {
   intervalSize:
     'Distance between observations on a transect, in meters. May include decimal (e.g. 0.5).',
   intervalStart:
-    'Interval counted as the first observation on a transect, in meters. May include decimal (e.g. 0.5). Default is interval size (i.e. not counting 0).',
+    'Interval counted as the first observation on a transect, in meters. May include decimal (e.g. 0.5). Default is 1 (i.e. not counting 0).',
   label:
     'Arbitrary text to distinguish sample units that are distinct but should be combined analytically (i.e. all other properties are identical). For example: Long swim. Rarely used.',
   getLatitude: () => (

--- a/src/language.js
+++ b/src/language.js
@@ -569,7 +569,7 @@ const helperText = {
   intervalSize:
     'Distance between observations on a transect, in meters. May include decimal (e.g. 0.5).',
   intervalStart:
-    'Interval counted as the first observation on a transect, in meters. May include decimal (e.g. 0.5). Default is 1 (i.e. not counting 0).',
+    'Interval counted as the first observation on a transect, in meters. May include decimal (e.g. 0.5).',
   label:
     'Arbitrary text to distinguish sample units that are distinct but should be combined analytically (i.e. all other properties are identical). For example: Long swim. Rarely used.',
   getLatitude: () => (


### PR DESCRIPTION
[trello card](https://trello.com/c/z70S6wyM/642-help-text-for-interval-start-in-pit-is-incomplete)

to test:

1. add new collect record
2. ensure interval start has no default value
3. add interval size number input
4. check "Use Interval Size as Interval Start"
5. notice interval start sync to interval size value and change to a disabled field
6. if unchecked, you can update both inputs individually
