### PR TITLE
[632] add long lat swap button to site form

### DIFF
--- a/src/components/generic/buttons.js
+++ b/src/components/generic/buttons.js
@@ -156,23 +156,6 @@ export const IconButton = styled.button`
   border-style: none;
 `
 
-// export const ViewLink = styled.button`
-//   display: flex;
-//   justify-content: center;
-//   align-items: center;
-//   font-size: small;
-//   padding: ${theme.spacing.small};
-//   border: solid ${theme.spacing.borderSmall} ${theme.color.border};
-//   background-color: ${theme.color.inputBackground};
-//   text-align: inherit;
-//   cursor: pointer;
-//   &:disabled {
-//     color: ${theme.color.secondaryDisabledText};
-//     background-color: ${theme.color.secondaryDisabledColor};
-//     cursor: not-allowed;
-//   }
-// `
-
 export const ViewLink = styled.a`
   display: flex;
   justify-content: center;
@@ -188,5 +171,36 @@ export const ViewLink = styled.a`
     background-color: ${theme.color.secondaryDisabledColor};
     cursor: not-allowed;
     pointer-events: none;
+  }
+`
+
+export const CheckBoxLabel = styled.label`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-bottom: ${theme.spacing.small};
+
+  input {
+    margin: 0 ${theme.spacing.small} 0 0;
+    cursor: pointer;
+  }
+`
+
+export const SwapButton = styled('button')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  cursor: pointer;
+  border: solid ${theme.spacing.borderSmall} ${theme.color.border};
+  background-color: ${theme.color.inputBackground};
+
+  p {
+    font-size: ${theme.typography.smallFontSize};
+  }
+
+  &:disabled {
+    color: ${theme.color.secondaryDisabledText};
+    background-color: ${theme.color.secondaryDisabledColor};
+    cursor: not-allowed;
   }
 `

--- a/src/components/generic/buttons.js
+++ b/src/components/generic/buttons.js
@@ -174,7 +174,7 @@ export const ViewLink = styled.a`
   }
 `
 
-export const CheckBoxLabel = styled.label`
+export const CheckBoxContainer = styled.label`
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/src/components/generic/buttons.js
+++ b/src/components/generic/buttons.js
@@ -186,7 +186,7 @@ export const CheckBoxLabel = styled.label`
   }
 `
 
-export const SwapButton = styled('button')`
+export const InputButton = styled('button')`
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -194,7 +194,7 @@ export const SwapButton = styled('button')`
   border: solid ${theme.spacing.borderSmall} ${theme.color.border};
   background-color: ${theme.color.inputBackground};
 
-  p {
+  span {
     font-size: ${theme.typography.smallFontSize};
   }
 

--- a/src/components/generic/form.js
+++ b/src/components/generic/form.js
@@ -140,7 +140,7 @@ export const LabelContainer = styled.div`
   display: flex;
   flex-direction: row;
 `
-export const InputLinkContainer = styled.div`
+export const InputContainer = styled.div`
   display: flex;
   flex-direction: row;
 `

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -47,6 +47,7 @@ import shareVariantOutline from '@iconify-icons/mdi/share-variant-outline'
 import sortAscending from '@iconify-icons/mdi/sort-ascending'
 import sortDescending from '@iconify-icons/mdi/sort-descending'
 import styled from 'styled-components/macro'
+import swap from '@iconify-icons/mdi/swap-vertical'
 import sync from '@iconify-icons/mdi/sync'
 import upload from '@iconify-icons/mdi/upload'
 import user from '@iconify-icons/mdi/user'
@@ -102,6 +103,7 @@ export const IconSites = (props) => <InlineIcon icon={mapMarkerRadiusOutline} {.
 export const IconMapMarker = (props) => <InlineIcon icon={mapMarker} {...props} />
 export const IconSortDown = (props) => <InlineIcon icon={sortDescending} {...props} />
 export const IconSortUp = (props) => <InlineIcon icon={sortAscending} {...props} />
+export const IconSwap = (props) => <InlineIcon icon={swap} {...props} />
 export const IconUp = (props) => <InlineIcon icon={menuUp} {...props} />
 export const IconUpload = (props) => <InlineIcon icon={upload} {...props} />
 export const IconUser = (props) => <InlineIcon icon={user} {...props} />

--- a/src/components/mermaidInputs/InputSelectWithLabelAndValidation/InputSelectWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputSelectWithLabelAndValidation/InputSelectWithLabelAndValidation.js
@@ -7,7 +7,7 @@ import {
   InputRow,
   Select,
   HelperText,
-  InputLinkContainer,
+  InputContainer,
   LabelContainer,
   RequiredIndicator,
 } from '../../generic/form'
@@ -73,7 +73,7 @@ const InputSelectWithLabelAndValidation = ({
       </LabelContainer>
 
       <div>
-        <InputLinkContainer>
+        <InputContainer>
           <Select
             aria-labelledby={`aria-label${id}`}
             aria-describedby={`aria-descp${id}`}
@@ -91,7 +91,7 @@ const InputSelectWithLabelAndValidation = ({
               {language.pages.collectRecord.viewLink}
             </ViewLink>
           ) : null}
-        </InputLinkContainer>
+        </InputContainer>
         {isHelperTextShowing ? <HelperText id={`aria-descp${id}`}>{helperText}</HelperText> : null}
       </div>
       <InputValidationInfo

--- a/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
@@ -14,7 +14,7 @@ import InputNumberNoScrollWithUnit from '../../generic/InputNumberNoScrollWithUn
 
 import InputValidationInfo from '../InputValidationInfo/InputValidationInfo'
 import mermaidInputsPropTypes from '../mermaidInputsPropTypes'
-import { IconButton, CheckBoxLabel } from '../../generic/buttons'
+import { IconButton } from '../../generic/buttons'
 import { IconInfo } from '../../icons'
 
 const InputWithLabelAndValidation = ({
@@ -28,10 +28,9 @@ const InputWithLabelAndValidation = ({
   unit,
   validationMessages,
   validationType,
-  addCheckbox,
-  handleCheckboxUpdate,
-  checkboxLabel,
   renderItemWithinInput,
+  renderItemAboveInput,
+  isInputDisabled,
 
   ...restOfProps
 }) => {
@@ -40,7 +39,6 @@ const InputWithLabelAndValidation = ({
   useStopInputScrollingIncrementNumber(textFieldRef)
 
   const [isHelperTextShowing, setIsHelperTextShowing] = useState(false)
-  const [isCheckboxChecked, setIsCheckboxChecked] = useState(false)
 
   const handleInfoIconClick = (event) => {
     isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
@@ -54,7 +52,7 @@ const InputWithLabelAndValidation = ({
       aria-describedby={`aria-descp${id}`}
       id={id}
       unit={unit}
-      disabled={isCheckboxChecked}
+      disabled={isInputDisabled}
       {...restOfProps}
     />
   ) : (
@@ -66,12 +64,6 @@ const InputWithLabelAndValidation = ({
       ref={textFieldRef}
     />
   )
-
-  // example use case is in Benthic Pit Transect Inputs for Interval Start
-  const handleCheckboxChange = (checked) => {
-    setIsCheckboxChecked(checked)
-    handleCheckboxUpdate(checked)
-  }
 
   return (
     <InputRow required={required} validationType={validationType} data-testid={testId}>
@@ -88,18 +80,7 @@ const InputWithLabelAndValidation = ({
       </LabelContainer>
 
       <div>
-        {addCheckbox ? (
-          <CheckBoxLabel>
-            <input
-              id="checkbox-sync"
-              type="checkbox"
-              checked={isCheckboxChecked}
-              onChange={(event) => handleCheckboxChange(event.target.checked)}
-            />
-
-            {checkboxLabel}
-          </CheckBoxLabel>
-        ) : null}
+        {renderItemAboveInput || null}
         <InputContainer>
           {inputType}
 
@@ -119,14 +100,13 @@ const InputWithLabelAndValidation = ({
 }
 
 InputWithLabelAndValidation.propTypes = {
-  addCheckbox: PropTypes.bool,
-  checkboxLabel: PropTypes.string,
   required: PropTypes.bool,
-  handleCheckboxUpdate: PropTypes.func,
   helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   id: PropTypes.string.isRequired,
+  isInputDisabled: PropTypes.bool,
   ignoreNonObservationFieldValidations: PropTypes.func,
   label: PropTypes.string.isRequired,
+  renderItemAboveInput: PropTypes.node,
   renderItemWithinInput: PropTypes.node,
   resetNonObservationFieldValidations: PropTypes.func,
   testId: PropTypes.string,
@@ -136,12 +116,11 @@ InputWithLabelAndValidation.propTypes = {
 }
 
 InputWithLabelAndValidation.defaultProps = {
-  addCheckbox: false,
-  checkboxLabel: '',
   required: false,
   helperText: undefined,
-  handleCheckboxUpdate: () => {},
   ignoreNonObservationFieldValidations: () => {},
+  isInputDisabled: false,
+  renderItemAboveInput: undefined,
   renderItemWithinInput: undefined,
   resetNonObservationFieldValidations: () => {},
   testId: undefined,

--- a/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
@@ -14,8 +14,9 @@ import InputNumberNoScrollWithUnit from '../../generic/InputNumberNoScrollWithUn
 
 import InputValidationInfo from '../InputValidationInfo/InputValidationInfo'
 import mermaidInputsPropTypes from '../mermaidInputsPropTypes'
-import { IconButton, CheckBoxLabel, SwapButton } from '../../generic/buttons'
+import { IconButton, CheckBoxLabel, InputButton } from '../../generic/buttons'
 import { IconInfo, IconSwap } from '../../icons'
+import language from '../../../language'
 
 const InputWithLabelAndValidation = ({
   required,
@@ -33,6 +34,7 @@ const InputWithLabelAndValidation = ({
   checkboxLabel,
   addInputButton,
   isInputButtonDisabled,
+  handleInputButtonClick,
 
   ...restOfProps
 }) => {
@@ -105,10 +107,14 @@ const InputWithLabelAndValidation = ({
           {inputType}
 
           {addInputButton ? (
-            <SwapButton disabled={isInputButtonDisabled}>
+            <InputButton
+              type="button"
+              disabled={isInputButtonDisabled}
+              onClick={handleInputButtonClick}
+            >
               <IconSwap />
-              <p>Swap</p>
-            </SwapButton>
+              <span>{language.pages.siteForm.swapButton}</span>
+            </InputButton>
           ) : null}
         </InputContainer>
         {isHelperTextShowing ? <HelperText id={`aria-descp${id}`}>{helperText}</HelperText> : null}
@@ -130,6 +136,7 @@ InputWithLabelAndValidation.propTypes = {
   checkboxLabel: PropTypes.string,
   required: PropTypes.bool,
   handleCheckboxUpdate: PropTypes.func,
+  handleInputButtonClick: PropTypes.func,
   helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   id: PropTypes.string.isRequired,
   ignoreNonObservationFieldValidations: PropTypes.func,
@@ -149,6 +156,7 @@ InputWithLabelAndValidation.defaultProps = {
   required: false,
   helperText: undefined,
   handleCheckboxUpdate: () => {},
+  handleInputButtonClick: () => {},
   ignoreNonObservationFieldValidations: () => {},
   isInputButtonDisabled: false,
   resetNonObservationFieldValidations: () => {},

--- a/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
@@ -14,7 +14,7 @@ import InputNumberNoScrollWithUnit from '../../generic/InputNumberNoScrollWithUn
 
 import InputValidationInfo from '../InputValidationInfo/InputValidationInfo'
 import mermaidInputsPropTypes from '../mermaidInputsPropTypes'
-import { IconButton, CheckBoxLabel, InputButton } from '../../generic/buttons'
+import { IconButton, CheckBoxLabel } from '../../generic/buttons'
 import { IconInfo } from '../../icons'
 
 const InputWithLabelAndValidation = ({
@@ -31,11 +31,7 @@ const InputWithLabelAndValidation = ({
   addCheckbox,
   handleCheckboxUpdate,
   checkboxLabel,
-  addInputButton,
-  isInputButtonDisabled,
-  handleInputButtonClick,
-  buttonLabel,
-  buttonIcon,
+  renderItemWithinInput,
 
   ...restOfProps
 }) => {
@@ -107,16 +103,7 @@ const InputWithLabelAndValidation = ({
         <InputContainer>
           {inputType}
 
-          {addInputButton ? (
-            <InputButton
-              type="button"
-              disabled={isInputButtonDisabled}
-              onClick={handleInputButtonClick}
-            >
-              {buttonIcon || null}
-              <span>{buttonLabel}</span>
-            </InputButton>
-          ) : null}
+          {renderItemWithinInput || null}
         </InputContainer>
         {isHelperTextShowing ? <HelperText id={`aria-descp${id}`}>{helperText}</HelperText> : null}
       </div>
@@ -133,18 +120,14 @@ const InputWithLabelAndValidation = ({
 
 InputWithLabelAndValidation.propTypes = {
   addCheckbox: PropTypes.bool,
-  addInputButton: PropTypes.bool,
-  buttonIcon: PropTypes.node,
-  buttonLabel: PropTypes.string,
   checkboxLabel: PropTypes.string,
   required: PropTypes.bool,
   handleCheckboxUpdate: PropTypes.func,
-  handleInputButtonClick: PropTypes.func,
   helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   id: PropTypes.string.isRequired,
   ignoreNonObservationFieldValidations: PropTypes.func,
-  isInputButtonDisabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
+  renderItemWithinInput: PropTypes.node,
   resetNonObservationFieldValidations: PropTypes.func,
   testId: PropTypes.string,
   unit: PropTypes.string,
@@ -154,16 +137,12 @@ InputWithLabelAndValidation.propTypes = {
 
 InputWithLabelAndValidation.defaultProps = {
   addCheckbox: false,
-  addInputButton: false,
-  buttonLabel: '',
-  buttonIcon: undefined,
   checkboxLabel: '',
   required: false,
   helperText: undefined,
   handleCheckboxUpdate: () => {},
-  handleInputButtonClick: () => {},
   ignoreNonObservationFieldValidations: () => {},
-  isInputButtonDisabled: false,
+  renderItemWithinInput: undefined,
   resetNonObservationFieldValidations: () => {},
   testId: undefined,
   unit: undefined,

--- a/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
@@ -9,7 +9,7 @@ import InputNumberNoScrollWithUnit from '../../generic/InputNumberNoScrollWithUn
 import InputValidationInfo from '../InputValidationInfo/InputValidationInfo'
 import mermaidInputsPropTypes from '../mermaidInputsPropTypes'
 import { IconButton } from '../../generic/buttons'
-import { IconInfo } from '../../icons'
+import { IconInfo, IconSwap } from '../../icons'
 import theme from '../../../theme'
 
 const CheckBoxLabel = styled.label`
@@ -22,6 +22,11 @@ const CheckBoxLabel = styled.label`
     margin: 0 ${theme.spacing.small} 0 0;
     cursor: pointer;
   }
+`
+
+const SwapButton = styled.div`
+  display: flex;
+  flex-direction: row;
 `
 
 const InputWithLabelAndValidation = ({
@@ -38,6 +43,7 @@ const InputWithLabelAndValidation = ({
   addCheckbox,
   handleCheckboxUpdate,
   checkboxLabel,
+  addSwapButton,
 
   ...restOfProps
 }) => {
@@ -102,10 +108,18 @@ const InputWithLabelAndValidation = ({
               checked={isCheckboxChecked}
               onChange={(event) => handleCheckboxChange(event.target.checked)}
             />
+
             {checkboxLabel}
           </CheckBoxLabel>
         ) : null}
+
         {inputType}
+
+        {addSwapButton ? (
+          <div>
+            <IconSwap />
+          </div>
+        ) : null}
         {isHelperTextShowing ? <HelperText id={`aria-descp${id}`}>{helperText}</HelperText> : null}
       </div>
 
@@ -121,6 +135,7 @@ const InputWithLabelAndValidation = ({
 
 InputWithLabelAndValidation.propTypes = {
   addCheckbox: PropTypes.bool,
+  addSwapButton: PropTypes.bool,
   checkboxLabel: PropTypes.string,
   required: PropTypes.bool,
   handleCheckboxUpdate: PropTypes.func,
@@ -137,6 +152,7 @@ InputWithLabelAndValidation.propTypes = {
 
 InputWithLabelAndValidation.defaultProps = {
   addCheckbox: false,
+  addSwapButton: false,
   checkboxLabel: '',
   required: false,
   helperText: undefined,

--- a/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
@@ -15,8 +15,7 @@ import InputNumberNoScrollWithUnit from '../../generic/InputNumberNoScrollWithUn
 import InputValidationInfo from '../InputValidationInfo/InputValidationInfo'
 import mermaidInputsPropTypes from '../mermaidInputsPropTypes'
 import { IconButton, CheckBoxLabel, InputButton } from '../../generic/buttons'
-import { IconInfo, IconSwap } from '../../icons'
-import language from '../../../language'
+import { IconInfo } from '../../icons'
 
 const InputWithLabelAndValidation = ({
   required,
@@ -35,6 +34,8 @@ const InputWithLabelAndValidation = ({
   addInputButton,
   isInputButtonDisabled,
   handleInputButtonClick,
+  buttonLabel,
+  buttonIcon,
 
   ...restOfProps
 }) => {
@@ -112,8 +113,8 @@ const InputWithLabelAndValidation = ({
               disabled={isInputButtonDisabled}
               onClick={handleInputButtonClick}
             >
-              <IconSwap />
-              <span>{language.pages.siteForm.swapButton}</span>
+              {buttonIcon || null}
+              <span>{buttonLabel}</span>
             </InputButton>
           ) : null}
         </InputContainer>
@@ -133,6 +134,8 @@ const InputWithLabelAndValidation = ({
 InputWithLabelAndValidation.propTypes = {
   addCheckbox: PropTypes.bool,
   addInputButton: PropTypes.bool,
+  buttonIcon: PropTypes.node,
+  buttonLabel: PropTypes.string,
   checkboxLabel: PropTypes.string,
   required: PropTypes.bool,
   handleCheckboxUpdate: PropTypes.func,
@@ -152,6 +155,8 @@ InputWithLabelAndValidation.propTypes = {
 InputWithLabelAndValidation.defaultProps = {
   addCheckbox: false,
   addInputButton: false,
+  buttonLabel: '',
+  buttonIcon: undefined,
   checkboxLabel: '',
   required: false,
   helperText: undefined,

--- a/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
@@ -1,33 +1,21 @@
 import React, { useRef, useState } from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
 
-import { Input, InputRow, HelperText, LabelContainer, RequiredIndicator } from '../../generic/form'
+import {
+  Input,
+  InputContainer,
+  InputRow,
+  HelperText,
+  LabelContainer,
+  RequiredIndicator,
+} from '../../generic/form'
 import { useStopInputScrollingIncrementNumber } from '../../../library/useStopInputScrollingIncrementNumber'
 import InputNumberNoScrollWithUnit from '../../generic/InputNumberNoScrollWithUnit'
 
 import InputValidationInfo from '../InputValidationInfo/InputValidationInfo'
 import mermaidInputsPropTypes from '../mermaidInputsPropTypes'
-import { IconButton } from '../../generic/buttons'
+import { IconButton, CheckBoxLabel, SwapButton } from '../../generic/buttons'
 import { IconInfo, IconSwap } from '../../icons'
-import theme from '../../../theme'
-
-const CheckBoxLabel = styled.label`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  margin-bottom: ${theme.spacing.small};
-
-  input {
-    margin: 0 ${theme.spacing.small} 0 0;
-    cursor: pointer;
-  }
-`
-
-const SwapButton = styled.div`
-  display: flex;
-  flex-direction: row;
-`
 
 const InputWithLabelAndValidation = ({
   required,
@@ -43,7 +31,8 @@ const InputWithLabelAndValidation = ({
   addCheckbox,
   handleCheckboxUpdate,
   checkboxLabel,
-  addSwapButton,
+  addInputButton,
+  isInputButtonDisabled,
 
   ...restOfProps
 }) => {
@@ -112,14 +101,16 @@ const InputWithLabelAndValidation = ({
             {checkboxLabel}
           </CheckBoxLabel>
         ) : null}
+        <InputContainer>
+          {inputType}
 
-        {inputType}
-
-        {addSwapButton ? (
-          <div>
-            <IconSwap />
-          </div>
-        ) : null}
+          {addInputButton ? (
+            <SwapButton disabled={isInputButtonDisabled}>
+              <IconSwap />
+              <p>Swap</p>
+            </SwapButton>
+          ) : null}
+        </InputContainer>
         {isHelperTextShowing ? <HelperText id={`aria-descp${id}`}>{helperText}</HelperText> : null}
       </div>
 
@@ -135,13 +126,14 @@ const InputWithLabelAndValidation = ({
 
 InputWithLabelAndValidation.propTypes = {
   addCheckbox: PropTypes.bool,
-  addSwapButton: PropTypes.bool,
+  addInputButton: PropTypes.bool,
   checkboxLabel: PropTypes.string,
   required: PropTypes.bool,
   handleCheckboxUpdate: PropTypes.func,
   helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   id: PropTypes.string.isRequired,
   ignoreNonObservationFieldValidations: PropTypes.func,
+  isInputButtonDisabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   resetNonObservationFieldValidations: PropTypes.func,
   testId: PropTypes.string,
@@ -152,12 +144,13 @@ InputWithLabelAndValidation.propTypes = {
 
 InputWithLabelAndValidation.defaultProps = {
   addCheckbox: false,
-  addSwapButton: false,
+  addInputButton: false,
   checkboxLabel: '',
   required: false,
   helperText: undefined,
   handleCheckboxUpdate: () => {},
   ignoreNonObservationFieldValidations: () => {},
+  isInputButtonDisabled: false,
   resetNonObservationFieldValidations: () => {},
   testId: undefined,
   unit: undefined,

--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -46,6 +46,7 @@ import useDocumentTitle from '../../../library/useDocumentTitle'
 import useIsMounted from '../../../library/useIsMounted'
 import InputSelectWithLabelAndValidation from '../../mermaidInputs/InputSelectWithLabelAndValidation'
 import { DeleteRecordButtonCautionWrapper } from '../collectRecordFormPages/CollectingFormPage.Styles'
+import { IconSwap } from '../../icons'
 
 const ReadOnlySiteContent = ({
   site,
@@ -173,6 +174,8 @@ const SiteForm = ({
           addInputButton={true}
           isInputButtonDisabled={!formik.values.latitude && !formik.values.longitude}
           handleInputButtonClick={handleLngLatSwap}
+          buttonLabel={language.pages.siteForm.swapButton}
+          buttonIcon={<IconSwap />}
         />
         <InputWithLabelAndValidation
           required
@@ -190,6 +193,8 @@ const SiteForm = ({
           addInputButton={true}
           isInputButtonDisabled={!formik.values.latitude && !formik.values.longitude}
           handleInputButtonClick={handleLngLatSwap}
+          buttonLabel={language.pages.siteForm.swapButton}
+          buttonIcon={<IconSwap />}
         />
         {isAppOnline && (
           <SingleSiteMap

--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -114,6 +114,11 @@ const SiteForm = ({
   handleLatitudeChange,
   handleLongitudeChange,
 }) => {
+  const handleLngLatSwap = () => {
+    handleLatitudeChange(formik.getFieldProps('longitude').value)
+    handleLongitudeChange(formik.getFieldProps('latitude').value)
+  }
+
   return (
     <form id="site-form" onSubmit={formik.handleSubmit}>
       <InputWrapper>
@@ -167,6 +172,7 @@ const SiteForm = ({
           step="0.000001"
           addInputButton={true}
           isInputButtonDisabled={!formik.values.latitude && !formik.values.longitude}
+          handleInputButtonClick={handleLngLatSwap}
         />
         <InputWithLabelAndValidation
           required
@@ -183,6 +189,7 @@ const SiteForm = ({
           step="0.000001"
           addInputButton={true}
           isInputButtonDisabled={!formik.values.latitude && !formik.values.longitude}
+          handleInputButtonClick={handleLngLatSwap}
         />
         {isAppOnline && (
           <SingleSiteMap

--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -165,6 +165,7 @@ const SiteForm = ({
           helperText={language.helperText.getLatitude()}
           shouldShowSteps={true}
           step="0.000001"
+          addSwapButton={true}
         />
         <InputWithLabelAndValidation
           required
@@ -179,6 +180,7 @@ const SiteForm = ({
           helperText={language.helperText.getLongitude()}
           shouldShowSteps={true}
           step="0.000001"
+          addSwapButton={true}
         />
         {isAppOnline && (
           <SingleSiteMap

--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -47,6 +47,7 @@ import useIsMounted from '../../../library/useIsMounted'
 import InputSelectWithLabelAndValidation from '../../mermaidInputs/InputSelectWithLabelAndValidation'
 import { DeleteRecordButtonCautionWrapper } from '../collectRecordFormPages/CollectingFormPage.Styles'
 import { IconSwap } from '../../icons'
+import { InputButton } from '../../generic/buttons'
 
 const ReadOnlySiteContent = ({
   site,
@@ -80,6 +81,15 @@ const ReadOnlySiteContent = ({
         />
       )}
     </>
+  )
+}
+
+const SwapButton = ({ isDisabled, handleSwapClick, swapLabel }) => {
+  return (
+    <InputButton type="button" disabled={isDisabled} onClick={handleSwapClick}>
+      <IconSwap />
+      <span>{swapLabel}</span>
+    </InputButton>
   )
 }
 
@@ -171,11 +181,13 @@ const SiteForm = ({
           helperText={language.helperText.getLatitude()}
           shouldShowSteps={true}
           step="0.000001"
-          addInputButton={true}
-          isInputButtonDisabled={!formik.values.latitude && !formik.values.longitude}
-          handleInputButtonClick={handleLngLatSwap}
-          buttonLabel={language.pages.siteForm.swapButton}
-          buttonIcon={<IconSwap />}
+          renderItemWithinInput={
+            <SwapButton
+              isDisabled={!formik.values.latitude && !formik.values.longitude}
+              handleSwapClick={handleLngLatSwap}
+              swapLabel={language.pages.siteForm.swapButton}
+            />
+          }
         />
         <InputWithLabelAndValidation
           required
@@ -190,11 +202,13 @@ const SiteForm = ({
           helperText={language.helperText.getLongitude()}
           shouldShowSteps={true}
           step="0.000001"
-          addInputButton={true}
-          isInputButtonDisabled={!formik.values.latitude && !formik.values.longitude}
-          handleInputButtonClick={handleLngLatSwap}
-          buttonLabel={language.pages.siteForm.swapButton}
-          buttonIcon={<IconSwap />}
+          renderItemWithinInput={
+            <SwapButton
+              isDisabled={!formik.values.latitude && !formik.values.longitude}
+              handleSwapClick={handleLngLatSwap}
+              swapLabel={language.pages.siteForm.swapButton}
+            />
+          }
         />
         {isAppOnline && (
           <SingleSiteMap
@@ -627,6 +641,12 @@ SiteForm.propTypes = {
   reefZoneOptions: inputOptionsPropTypes.isRequired,
   handleLatitudeChange: PropTypes.func.isRequired,
   handleLongitudeChange: PropTypes.func.isRequired,
+}
+
+SwapButton.propTypes = {
+  isDisabled: PropTypes.bool.isRequired,
+  handleSwapClick: PropTypes.func.isRequired,
+  swapLabel: PropTypes.string.isRequired,
 }
 
 Site.propTypes = { isNewSite: PropTypes.bool.isRequired }

--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -165,7 +165,8 @@ const SiteForm = ({
           helperText={language.helperText.getLatitude()}
           shouldShowSteps={true}
           step="0.000001"
-          addSwapButton={true}
+          addInputButton={true}
+          isInputButtonDisabled={!formik.values.latitude && !formik.values.longitude}
         />
         <InputWithLabelAndValidation
           required
@@ -180,7 +181,8 @@ const SiteForm = ({
           helperText={language.helperText.getLongitude()}
           shouldShowSteps={true}
           step="0.000001"
-          addSwapButton={true}
+          addInputButton={true}
+          isInputButtonDisabled={!formik.values.latitude && !formik.values.longitude}
         />
         {isAppOnline && (
           <SingleSiteMap

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitTransectInputs.js
@@ -14,6 +14,7 @@ import InputWithLabelAndValidation from '../../../mermaidInputs/InputWithLabelAn
 import TextareaWithLabelAndValidation from '../../../mermaidInputs/TextareaWithLabelAndValidation'
 import InputSelectWithLabelAndValidation from '../../../mermaidInputs/InputSelectWithLabelAndValidation'
 import language from '../../../../language'
+import { CheckBoxContainer } from '../../../generic/buttons'
 
 const CURRENT_VALIDATION_PATH = 'data.benthic_transect.current'
 const DEPTH_VALIDATION_PATH = 'data.benthic_transect.depth'
@@ -28,6 +29,21 @@ const TRANSECT_NUMBER_VALIDATION_PATH = 'data.benthic_transect.number'
 const VISIBILITY_VALIDATION_PATH = 'data.benthic_transect.visibility'
 const INTERVAL_SIZE_VALIDATION_PATH = 'data.interval_size'
 const INTERVAL_START_VALIDATION_PATH = 'data.interval_start'
+
+const IntervalCheckbox = ({ isChecked, handleChange, checkboxLabel }) => {
+  return (
+    <CheckBoxContainer>
+      <input
+        id="checkbox-sync"
+        type="checkbox"
+        checked={isChecked}
+        onChange={(event) => handleChange(event.target.checked)}
+      />
+
+      {checkboxLabel}
+    </CheckBoxContainer>
+  )
+}
 
 const BenthicPitTransectInputs = ({
   areValidationsShowing,
@@ -48,6 +64,7 @@ const BenthicPitTransectInputs = ({
   const benthic_transect = validationsApiData?.benthic_transect
 
   const [isSyncIntervalStart, setIsSyncIntervalStart] = useState(false)
+  const [isCheckboxChecked, setIsCheckboxChecked] = useState(false)
 
   const transectNumberValidationProperties = getValidationPropertiesForInput(
     benthic_transect?.number,
@@ -200,6 +217,7 @@ const BenthicPitTransectInputs = ({
   }
 
   const handleSyncIntervalChange = (checked) => {
+    setIsCheckboxChecked(checked)
     if (checked) {
       setIsSyncIntervalStart(true)
       formik.setFieldValue('interval_start', formik.values.interval_size)
@@ -360,9 +378,14 @@ const BenthicPitTransectInputs = ({
           onChange={handleIntervalStartChange}
           unit="m"
           helperText={language.helperText.intervalStart}
-          addCheckbox={true}
-          handleCheckboxUpdate={handleSyncIntervalChange}
-          checkboxLabel={language.pages.collectRecord.benthicPitSyncCheckbox}
+          renderItemAboveInput={
+            <IntervalCheckbox
+              isChecked={isCheckboxChecked}
+              handleChange={handleSyncIntervalChange}
+              checkboxLabel={language.pages.collectRecord.benthicPitSyncCheckbox}
+            />
+          }
+          isInputDisabled={isCheckboxChecked}
         />
         <InputSelectWithLabelAndValidation
           label="Reef Slope"
@@ -500,6 +523,12 @@ BenthicPitTransectInputs.propTypes = {
   resetNonObservationFieldValidations: PropTypes.func.isRequired,
   validationsApiData: benthicPitValidationPropType.isRequired,
   validationPropertiesWithDirtyResetOnInputChange: PropTypes.func.isRequired,
+}
+
+IntervalCheckbox.propTypes = {
+  isChecked: PropTypes.bool.isRequired,
+  handleChange: PropTypes.func.isRequired,
+  checkboxLabel: PropTypes.string.isRequired,
 }
 
 export default BenthicPitTransectInputs

--- a/src/language.js
+++ b/src/language.js
@@ -391,6 +391,7 @@ const pages = {
     placeMarker: 'Place Site Marker',
     replaceMarker: 'Replace Site Marker',
     done: 'Done',
+    swapButton: 'Swap',
   },
   siteTable: {
     controlZoomText: 'Use Ctrl + Scroll to zoom the map',


### PR DESCRIPTION
[trello card](https://trello.com/c/RddqoivR/632-provide-a-button-to-switch-lat-and-long-when-creating-or-updating-a-site-map)

to test:

1. add a new site
2. enter long or lat value
3. press swap button
4. should swap values and update pin on map
5. buttons should be disabled if no lng or lat values (both have to be empty)