### PR TITLE
[632] bug fix for lng/lat swap errors

### DIFF
--- a/src/components/pages/Site/Site.js
+++ b/src/components/pages/Site/Site.js
@@ -140,7 +140,7 @@ const SiteForm = ({
   useEffect(() => {
     formik.validateForm()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formik.getFieldProps('latitude').value, formik.getFieldProps('longitude').value])
+  }, [formik.values.latitude, formik.values.longitude])
 
   return (
     <form id="site-form" onSubmit={formik.handleSubmit}>


### PR DESCRIPTION
[ticket here](https://trello.com/c/RddqoivR/632-provide-a-button-to-switch-lat-and-long-when-creating-or-updating-a-site-map)

Tiela added a video in the ticket on how to test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved latitude and longitude swap functionality in the site form to ensure correct value placement and enhanced form validation.
	- Added a useEffect hook to trigger form validation after updating form values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->