### PR TITLE
[657] prevent map from recentering when dragging marker pin

### DIFF
--- a/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
+++ b/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
@@ -157,17 +157,6 @@ const SingleSiteMap = ({
       } else {
         recordMarker.current.setLngLat([formLongitudeValue, formLatitudeValue]).addTo(map.current)
       }
-
-      if (
-        formLatitudeValue !== undefined &&
-        formLongitudeValue !== undefined &&
-        !outOfRangeLatitude
-      ) {
-        map.current.jumpTo({
-          center: [formLongitudeValue, formLatitudeValue],
-          zoom: map.current.getZoom(),
-        })
-      }
     },
     [formLatitudeValue, formLongitudeValue, nullishLatitudeOrLongitude, outOfRangeLatitude],
   )


### PR DESCRIPTION
remove jumpTo function call when moving map pin to avoid re-centering

[trello card](https://trello.com/c/aIfLnoMV/657-dont-recenter-the-map-when-the-pin-is-placed-by-clicking)

to test:
1. go to single site map
2. enable drag marker on map
3. drag marker
4. ensure that map doesn't re-center

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed the automatic centering feature on the map for specific conditions to enhance user control and map stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->