### PR TITLE
[653] add inset map

### DIFF
--- a/src/components/mermaidMap/CopySitesMap/CopySitesMap.js
+++ b/src/components/mermaidMap/CopySitesMap/CopySitesMap.js
@@ -10,7 +10,8 @@ import {
   handleMapOnWheel,
 } from '../mapService'
 import { copySitePropType } from '../../../App/mermaidData/mermaidDataProptypes'
-import { MapContainer, MapZoomHelpMessage, MapWrapper } from '../Map.styles'
+import { MapContainer, MapZoomHelpMessage, MapWrapper, MiniMapContainer } from '../Map.styles'
+import MiniMap from '../MiniMap'
 import usePrevious from '../../../library/usePrevious'
 
 const defaultCenter = [20, 20]
@@ -83,6 +84,11 @@ const CopySitesMap = ({ sitesForMapMarkers }) => {
   return (
     <MapContainer>
       <MapWrapper ref={mapContainer} minHeight="30vh" />
+      {map.current ? (
+        <MiniMapContainer>
+          <MiniMap mainMap={map.current} />
+        </MiniMapContainer>
+      ) : null}
       {displayHelpText && (
         <MapZoomHelpMessage>{language.pages.siteTable.controlZoomText}</MapZoomHelpMessage>
       )}

--- a/src/components/mermaidMap/Map.styles.js
+++ b/src/components/mermaidMap/Map.styles.js
@@ -44,3 +44,10 @@ export const MapZoomHelpMessage = styled('div')`
   color: #ffffff;
   font-size: 2rem;
 `
+export const MiniMapContainer = styled.div`
+  position: absolute;
+  bottom: 5px;
+  left: 15px;
+  width: 200px;
+  height: 150px;
+`

--- a/src/components/mermaidMap/MiniMap/MiniMap.js
+++ b/src/components/mermaidMap/MiniMap/MiniMap.js
@@ -9,23 +9,22 @@ const MiniMapWrapper = styled.div`
   width: 200px;
   height: 150px;
   border: 2px solid white;
+  // chose opacity instead of display: none to avoid reflow
   opacity: ${({ visible }) => (visible ? 1 : 0)};
 `
 
 const MiniMap = ({ mainMap }) => {
   const miniMapContainer = useRef(null)
   const miniMap = useRef(null)
-  const trackingRectSource = useRef(null)
-  const defaultZoom = 2
-  const zoomAdjustment = 5
+  const trackingRectangleSource = useRef(null)
+  const DEFAULT_ZOOM = 2
+  const ZOOM_ADJUSTMENT = 5
 
-  const getIsMiniMapVisible = () => mainMap.getZoom() > defaultZoom
+  const [isVisible, setIsVisible] = useState(mainMap.getZoom() > DEFAULT_ZOOM)
 
-  const [isVisible, setIsVisible] = useState(getIsMiniMapVisible())
-
-  const updateTrackingRectGeometry = (bounds) => {
-    if (trackingRectSource.current) {
-      trackingRectSource.current.setData({
+  const updateTrackingRectangleGeometry = (bounds) => {
+    if (trackingRectangleSource.current) {
+      trackingRectangleSource.current.setData({
         type: 'Feature',
         properties: {},
         geometry: {
@@ -44,11 +43,11 @@ const MiniMap = ({ mainMap }) => {
     }
   }
 
-  const addTrackingRectLayers = () => {
+  const addTrackingRectangleLayers = () => {
     miniMap.current.addLayer({
       id: 'trackingRectOutline',
       type: 'line',
-      source: 'trackingRect',
+      source: 'trackingRectangle',
       paint: {
         'line-color': '#FF0000',
         'line-width': 2,
@@ -58,7 +57,7 @@ const MiniMap = ({ mainMap }) => {
     miniMap.current.addLayer({
       id: 'trackingRectFill',
       type: 'fill',
-      source: 'trackingRect',
+      source: 'trackingRectangle',
       paint: {
         'fill-color': '#FF0000',
         'fill-opacity': 0.3,
@@ -66,54 +65,56 @@ const MiniMap = ({ mainMap }) => {
     })
   }
 
-  const onMapLoad = () => {
-    miniMap.current.addSource('trackingRect', {
-      type: 'geojson',
-      data: {
-        type: 'Feature',
-        properties: {},
-        geometry: { type: 'Polygon', coordinates: [[]] },
-      },
-    })
-
-    setIsVisible(getIsMiniMapVisible())
-
-    addTrackingRectLayers()
-
-    miniMap.current.jumpTo({
-      center: mainMap.getCenter(),
-      zoom: mainMap.getZoom() - zoomAdjustment,
-    })
-
-    trackingRectSource.current = miniMap.current.getSource('trackingRect')
-    updateTrackingRectGeometry(mainMap.getBounds())
-  }
-
-  const initializeMap = () => {
-    miniMap.current = new maplibregl.Map({
-      container: miniMapContainer.current,
-      style: lightBaseMap,
-      center: mainMap.getCenter(),
-      zoom: defaultZoom,
-      interactive: false,
-    })
-
-    miniMap.current.on('load', onMapLoad)
-  }
-
-  const handleMapMove = () => {
-    miniMap.current.jumpTo({
-      center: mainMap.getCenter(),
-      zoom: mainMap.getZoom() - zoomAdjustment,
-    })
-
-    setIsVisible(getIsMiniMapVisible())
-    updateTrackingRectGeometry(mainMap.getBounds())
-  }
-
   useEffect(() => {
     if (!miniMapContainer.current || !mainMap) {
       return
+    }
+
+    const getIsMiniMapVisible = () => mainMap.getZoom() > DEFAULT_ZOOM
+
+    const onMapLoad = () => {
+      miniMap.current.addSource('trackingRectangle', {
+        type: 'geojson',
+        data: {
+          type: 'Feature',
+          properties: {},
+          geometry: { type: 'Polygon', coordinates: [[]] },
+        },
+      })
+
+      setIsVisible(getIsMiniMapVisible())
+
+      addTrackingRectangleLayers()
+
+      miniMap.current.jumpTo({
+        center: mainMap.getCenter(),
+        zoom: mainMap.getZoom() - ZOOM_ADJUSTMENT,
+      })
+
+      trackingRectangleSource.current = miniMap.current.getSource('trackingRectangle')
+      updateTrackingRectangleGeometry(mainMap.getBounds())
+    }
+
+    const initializeMap = () => {
+      miniMap.current = new maplibregl.Map({
+        container: miniMapContainer.current,
+        style: lightBaseMap,
+        center: mainMap.getCenter(),
+        zoom: DEFAULT_ZOOM,
+        interactive: false,
+      })
+
+      miniMap.current.on('load', onMapLoad)
+    }
+
+    const handleMapMove = () => {
+      miniMap.current.jumpTo({
+        center: mainMap.getCenter(),
+        zoom: mainMap.getZoom() - ZOOM_ADJUSTMENT,
+      })
+
+      setIsVisible(getIsMiniMapVisible())
+      updateTrackingRectangleGeometry(mainMap.getBounds())
     }
 
     initializeMap()
@@ -121,8 +122,6 @@ const MiniMap = ({ mainMap }) => {
 
     // eslint-disable-next-line consistent-return
     return () => miniMap.current.remove()
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mainMap])
 
   return <MiniMapWrapper ref={miniMapContainer} visible={isVisible} />

--- a/src/components/mermaidMap/MiniMap/MiniMap.js
+++ b/src/components/mermaidMap/MiniMap/MiniMap.js
@@ -103,13 +103,13 @@ const MiniMap = ({ mainMap }) => {
   }
 
   const handleMapMove = () => {
-    setIsVisible(getIsMiniMapVisible())
     miniMap.current.jumpTo({
       center: mainMap.getCenter(),
       zoom: mainMap.getZoom() - zoomAdjustment,
     })
-    updateTrackingRectGeometry(mainMap.getBounds())
+
     setIsVisible(getIsMiniMapVisible())
+    updateTrackingRectGeometry(mainMap.getBounds())
   }
 
   useEffect(() => {

--- a/src/components/mermaidMap/MiniMap/MiniMap.js
+++ b/src/components/mermaidMap/MiniMap/MiniMap.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import maplibregl from 'maplibre-gl'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { satelliteBaseMap } from '../mapService'
+import { lightBaseMap } from '../mapService'
 
 const MiniMapWrapper = styled.div`
   position: absolute;
@@ -46,7 +46,7 @@ const MiniMap = ({ mainMap }) => {
 
     miniMap.current = new maplibregl.Map({
       container: miniMapContainer.current,
-      style: satelliteBaseMap,
+      style: lightBaseMap,
       center: mainMap.getCenter(),
       zoom: defaultZoom,
       interactive: false,

--- a/src/components/mermaidMap/MiniMap/MiniMap.js
+++ b/src/components/mermaidMap/MiniMap/MiniMap.js
@@ -17,8 +17,9 @@ const MiniMap = ({ mainMap }) => {
   const trackingRectSource = useRef(null)
   const defaultZoom = 2
   const zoomAdjustment = 5
+  const minZoomLevelForTrackingRectToDisplay = 2
 
-  const updateTrackingRectangle = (bounds) => {
+  const updateTrackingRectGeometry = (bounds) => {
     if (trackingRectSource.current) {
       trackingRectSource.current.setData({
         type: 'Feature',
@@ -42,6 +43,14 @@ const MiniMap = ({ mainMap }) => {
   const _initializeMap = useEffect(() => {
     if (!miniMapContainer.current || !mainMap) {
       return
+    }
+
+    const updateTrackingRectVisibility = () => {
+      const isVisible =
+        mainMap.getZoom() > minZoomLevelForTrackingRectToDisplay ? 'visible' : 'none'
+
+      miniMap.current.setLayoutProperty('trackingRectOutline', 'visibility', isVisible)
+      miniMap.current.setLayoutProperty('trackingRectFill', 'visibility', isVisible)
     }
 
     miniMap.current = new maplibregl.Map({
@@ -73,6 +82,9 @@ const MiniMap = ({ mainMap }) => {
           'line-color': '#FF0000',
           'line-width': 2,
         },
+        layout: {
+          visibility: mainMap.getZoom() > minZoomLevelForTrackingRectToDisplay ? 'visible' : 'none',
+        },
       })
 
       miniMap.current.addLayer({
@@ -83,6 +95,9 @@ const MiniMap = ({ mainMap }) => {
           'fill-color': '#FF0000',
           'fill-opacity': 0.3,
         },
+        layout: {
+          visibility: mainMap.getZoom() > minZoomLevelForTrackingRectToDisplay ? 'visible' : 'none',
+        },
       })
 
       miniMap.current.jumpTo({
@@ -91,7 +106,7 @@ const MiniMap = ({ mainMap }) => {
       })
 
       trackingRectSource.current = miniMap.current.getSource('trackingRect')
-      updateTrackingRectangle(mainMap.getBounds())
+      updateTrackingRectGeometry(mainMap.getBounds())
     })
 
     mainMap.on('move', () => {
@@ -99,7 +114,8 @@ const MiniMap = ({ mainMap }) => {
         center: mainMap.getCenter(),
         zoom: mainMap.getZoom() - zoomAdjustment,
       })
-      updateTrackingRectangle(mainMap.getBounds())
+      updateTrackingRectGeometry(mainMap.getBounds())
+      updateTrackingRectVisibility()
     })
 
     // eslint-disable-next-line consistent-return

--- a/src/components/mermaidMap/MiniMap/MiniMap.js
+++ b/src/components/mermaidMap/MiniMap/MiniMap.js
@@ -11,12 +11,12 @@ const MiniMapWrapper = styled.div`
   border: 2px solid white;
 `
 
-const defaultZoom = 2
-
 const MiniMap = ({ mainMap }) => {
   const miniMapContainer = useRef(null)
   const miniMap = useRef(null)
   const trackingRectSource = useRef(null)
+  const defaultZoom = 2
+  const zoomAdjustment = 5
 
   const updateTrackingRectangle = (bounds) => {
     if (trackingRectSource.current) {
@@ -50,20 +50,6 @@ const MiniMap = ({ mainMap }) => {
       center: mainMap.getCenter(),
       zoom: defaultZoom,
       interactive: false,
-    })
-
-    mainMap.on('move', () => {
-      const mainMapZoom = mainMap.getZoom()
-
-      let zoomDiff = Math.max(0, mainMapZoom - 5)
-
-      // Clamp zoom difference to prevent going below 0
-      zoomDiff = Math.min(zoomDiff, mainMapZoom)
-
-      miniMap.current.jumpTo({
-        center: mainMap.getCenter(),
-        zoom: zoomDiff,
-      })
     })
 
     miniMap.current.on('load', () => {
@@ -101,7 +87,7 @@ const MiniMap = ({ mainMap }) => {
 
       miniMap.current.jumpTo({
         center: mainMap.getCenter(),
-        zoom: mainMap.getZoom() - 5,
+        zoom: mainMap.getZoom() - zoomAdjustment,
       })
 
       trackingRectSource.current = miniMap.current.getSource('trackingRect')
@@ -109,6 +95,10 @@ const MiniMap = ({ mainMap }) => {
     })
 
     mainMap.on('move', () => {
+      miniMap.current.jumpTo({
+        center: mainMap.getCenter(),
+        zoom: mainMap.getZoom() - zoomAdjustment,
+      })
       updateTrackingRectangle(mainMap.getBounds())
     })
 

--- a/src/components/mermaidMap/MiniMap/MiniMap.js
+++ b/src/components/mermaidMap/MiniMap/MiniMap.js
@@ -1,0 +1,47 @@
+import React, { useEffect, useRef } from 'react'
+import maplibregl from 'maplibre-gl'
+import PropTypes from 'prop-types'
+import { satelliteBaseMap } from '../mapService'
+
+const MiniMap = ({ mainMap }) => {
+  const miniMapContainer = useRef(null)
+  const miniMap = useRef(null)
+
+  const _initializeMap = useEffect(() => {
+    console.log({ mainMap })
+    if (!miniMapContainer.current || !mainMap) {
+      return
+    }
+
+    miniMap.current = new maplibregl.Map({
+      container: miniMapContainer.current,
+      style: satelliteBaseMap,
+      center: mainMap.getCenter(), // Set mini-map center to main map center
+      zoom: mainMap.getZoom() - 10, // Adjust zoom level for mini-map
+      interactive: false, // Disable interaction with the mini-map
+    })
+
+    // Sync main map movements with mini-map
+    mainMap.on('move', () => {
+      miniMap.current.jumpTo({
+        center: mainMap.getCenter(),
+        zoom: mainMap.getZoom() - 2,
+      })
+    })
+
+    // eslint-disable-next-line consistent-return
+    return () => {
+      miniMap.current.remove()
+    }
+  }, [mainMap])
+
+  return (
+    <div ref={miniMapContainer} style={{ position: 'absolute', width: '150px', height: '100px' }} />
+  )
+}
+
+MiniMap.propTypes = {
+  mainMap: PropTypes.object.isRequired,
+}
+
+export default MiniMap

--- a/src/components/mermaidMap/MiniMap/MiniMap.js
+++ b/src/components/mermaidMap/MiniMap/MiniMap.js
@@ -18,9 +18,8 @@ const MiniMap = ({ mainMap }) => {
   const trackingRectSource = useRef(null)
   const defaultZoom = 2
   const zoomAdjustment = 5
-  const minZoomLevelForTrackingRectToDisplay = 2
 
-  const getIsMiniMapVisible = () => mainMap.getZoom() > minZoomLevelForTrackingRectToDisplay
+  const getIsMiniMapVisible = () => mainMap.getZoom() > defaultZoom
 
   const [isVisible, setIsVisible] = useState(getIsMiniMapVisible())
 
@@ -123,7 +122,6 @@ const MiniMap = ({ mainMap }) => {
     // eslint-disable-next-line consistent-return
     return () => miniMap.current.remove()
 
-    // avoid unncessary re-renders for initializeMap and handleMapMove
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mainMap])
 
@@ -131,7 +129,7 @@ const MiniMap = ({ mainMap }) => {
 }
 
 MiniMap.propTypes = {
-  // complex mapbox object - cannot be more specific
+  // complex mapbox object
   // eslint-disable-next-line react/forbid-prop-types
   mainMap: PropTypes.object.isRequired,
 }

--- a/src/components/mermaidMap/MiniMap/MiniMap.js
+++ b/src/components/mermaidMap/MiniMap/MiniMap.js
@@ -53,9 +53,16 @@ const MiniMap = ({ mainMap }) => {
     })
 
     mainMap.on('move', () => {
+      const mainMapZoom = mainMap.getZoom()
+
+      let zoomDiff = Math.max(0, mainMapZoom - 5)
+
+      // Clamp zoom difference to prevent going below 0
+      zoomDiff = Math.min(zoomDiff, mainMapZoom)
+
       miniMap.current.jumpTo({
         center: mainMap.getCenter(),
-        zoom: mainMap.getZoom() - 5,
+        zoom: zoomDiff,
       })
     })
 
@@ -90,6 +97,11 @@ const MiniMap = ({ mainMap }) => {
           'fill-color': '#FF0000',
           'fill-opacity': 0.3,
         },
+      })
+
+      miniMap.current.jumpTo({
+        center: mainMap.getCenter(),
+        zoom: mainMap.getZoom() - 5,
       })
 
       trackingRectSource.current = miniMap.current.getSource('trackingRect')

--- a/src/components/mermaidMap/MiniMap/MiniMap.js
+++ b/src/components/mermaidMap/MiniMap/MiniMap.js
@@ -1,14 +1,22 @@
 import React, { useEffect, useRef } from 'react'
 import maplibregl from 'maplibre-gl'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
 import { satelliteBaseMap } from '../mapService'
+
+const MiniMapWrapper = styled.div`
+  position: absolute;
+  width: 150px;
+  height: 100px;
+`
+
+const defaultZoom = 1
 
 const MiniMap = ({ mainMap }) => {
   const miniMapContainer = useRef(null)
   const miniMap = useRef(null)
 
   const _initializeMap = useEffect(() => {
-    console.log({ mainMap })
     if (!miniMapContainer.current || !mainMap) {
       return
     }
@@ -16,31 +24,28 @@ const MiniMap = ({ mainMap }) => {
     miniMap.current = new maplibregl.Map({
       container: miniMapContainer.current,
       style: satelliteBaseMap,
-      center: mainMap.getCenter(), // Set mini-map center to main map center
-      zoom: mainMap.getZoom() - 10, // Adjust zoom level for mini-map
-      interactive: false, // Disable interaction with the mini-map
+      center: mainMap.getCenter(),
+      zoom: defaultZoom,
+      interactive: false,
     })
-
     // Sync main map movements with mini-map
     mainMap.on('move', () => {
       miniMap.current.jumpTo({
         center: mainMap.getCenter(),
-        zoom: mainMap.getZoom() - 2,
+        zoom: mainMap.getZoom() - 9,
       })
     })
 
     // eslint-disable-next-line consistent-return
-    return () => {
-      miniMap.current.remove()
-    }
+    return () => miniMap.current.remove()
   }, [mainMap])
 
-  return (
-    <div ref={miniMapContainer} style={{ position: 'absolute', width: '150px', height: '100px' }} />
-  )
+  return <MiniMapWrapper ref={miniMapContainer} />
 }
 
 MiniMap.propTypes = {
+  // complex mapbox object - cannot be more specific
+  // eslint-disable-next-line react/forbid-prop-types
   mainMap: PropTypes.object.isRequired,
 }
 

--- a/src/components/mermaidMap/MiniMap/index.js
+++ b/src/components/mermaidMap/MiniMap/index.js
@@ -1,0 +1,3 @@
+import MiniMap from './MiniMap'
+
+export default MiniMap

--- a/src/components/mermaidMap/ProjectSitesMap/ProjectSitesMap.js
+++ b/src/components/mermaidMap/ProjectSitesMap/ProjectSitesMap.js
@@ -15,7 +15,8 @@ import {
   loadMapMarkersLayer,
   handleMapOnWheel,
 } from '../mapService'
-import { MapContainer, MapWrapper, MapZoomHelpMessage } from '../Map.styles'
+import { MapContainer, MiniMapContainer, MapWrapper, MapZoomHelpMessage } from '../Map.styles'
+import MiniMap from '../MiniMap'
 import Popup from '../Popup'
 import usePrevious from '../../../library/usePrevious'
 
@@ -134,6 +135,11 @@ const ProjectSitesMap = ({ sitesForMapMarkers, choices }) => {
         updateGeomorphicLayers={updateGeomorphicLayers}
         updateBenthicLayers={updateBenthicLayers}
       />
+      {map.current ? (
+        <MiniMapContainer>
+          <MiniMap mainMap={map.current} />
+        </MiniMapContainer>
+      ) : null}
     </MapContainer>
   )
 }

--- a/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
+++ b/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
@@ -17,6 +17,7 @@ import { IconMapMarker } from '../../icons'
 import { MapInputRow, MapContainer, MapWrapper, MapZoomHelpMessage } from '../Map.styles'
 import theme from '../../../theme'
 import { roundToSixDecimalPlaces } from '../../../library/numbers/roundToSixDecimalPlaces'
+import MiniMap from '../MiniMap'
 
 const StyledPlaceMarkerButton = styled(ButtonSecondary)`
   padding: 0 5px;
@@ -30,6 +31,14 @@ const StyledPlaceMarkerButton = styled(ButtonSecondary)`
   & > svg {
     margin-right: 1px;
   }
+`
+
+const MiniMapContainer = styled.div`
+  position: absolute;
+  bottom: 5px;
+  left: 15px;
+  width: 200px;
+  height: 150px;
 `
 
 const defaultCenter = [0, 0]
@@ -226,6 +235,10 @@ const SingleSiteMap = ({
           updateGeomorphicLayers={updateGeomorphicLayers}
           updateBenthicLayers={updateBenthicLayers}
         />
+        {/* Integration of MiniMap component */}
+        <MiniMapContainer>
+          <MiniMap mainMap={map.current} />
+        </MiniMapContainer>
       </MapContainer>
     </MapInputRow>
   )

--- a/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
+++ b/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
@@ -14,7 +14,13 @@ import {
 } from '../mapService'
 import { ButtonSecondary } from '../../generic/buttons'
 import { IconMapMarker } from '../../icons'
-import { MapInputRow, MapContainer, MapWrapper, MapZoomHelpMessage } from '../Map.styles'
+import {
+  MapInputRow,
+  MapContainer,
+  MiniMapContainer,
+  MapWrapper,
+  MapZoomHelpMessage,
+} from '../Map.styles'
 import theme from '../../../theme'
 import { roundToSixDecimalPlaces } from '../../../library/numbers/roundToSixDecimalPlaces'
 import MiniMap from '../MiniMap'
@@ -31,14 +37,6 @@ const StyledPlaceMarkerButton = styled(ButtonSecondary)`
   & > svg {
     margin-right: 1px;
   }
-`
-
-const MiniMapContainer = styled.div`
-  position: absolute;
-  bottom: 5px;
-  left: 15px;
-  width: 200px;
-  height: 150px;
 `
 
 const defaultCenter = [0, 0]

--- a/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
+++ b/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
@@ -235,10 +235,11 @@ const SingleSiteMap = ({
           updateGeomorphicLayers={updateGeomorphicLayers}
           updateBenthicLayers={updateBenthicLayers}
         />
-        {/* Integration of MiniMap component */}
-        <MiniMapContainer>
-          <MiniMap mainMap={map.current} />
-        </MiniMapContainer>
+        {map.current ? (
+          <MiniMapContainer>
+            <MiniMap mainMap={map.current} />
+          </MiniMapContainer>
+        ) : null}
       </MapContainer>
     </MapInputRow>
   )

--- a/src/components/mermaidMap/mapService.js
+++ b/src/components/mermaidMap/mapService.js
@@ -119,6 +119,25 @@ const benthicOpacityExpression = [
   0, // Default / other
 ]
 
+export const lightBaseMap = {
+  version: 8,
+  name: 'light',
+  sources: {
+    worldmap: {
+      type: 'raster',
+      tiles: [
+        'https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}',
+      ],
+    },
+  },
+  layers: [
+    {
+      id: 'base-map',
+      type: 'raster',
+      source: 'worldmap',
+    },
+  ],
+}
 export const satelliteBaseMap = {
   version: 8,
   name: 'World Map',


### PR DESCRIPTION
[trello card](https://trello.com/c/xLAb5jYy/653-add-inset-map-to-site-map)

- added inset map to single site map, project sites map, and copy sites map
- inset map is automatically hidden when main map zoom level is 2 or less

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a Mini Map feature for an enhanced mapping experience. This Mini Map provides a smaller, synchronized overview alongside the main map, complete with a tracking rectangle to outline the visible area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->