### PR TITLE
[705] bug fix: only set initial zoom to 13 if there are lng/lat coordinates

### DIFF
--- a/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
+++ b/src/components/mermaidMap/SingleSiteMap/SingleSiteMap.js
@@ -82,11 +82,18 @@ const SingleSiteMap = ({
       container: mapContainer.current,
       style: satelliteBaseMap,
       center: defaultCenter,
-      zoom: nullishLatitudeOrLongitude ? defaultZoom : 13,
+      zoom: defaultZoom,
       maxZoom: 16,
       attributionControl: true,
       customAttribution: language.map.attribution,
     })
+
+    if (formLatitudeValue && formLongitudeValue) {
+      const initialZoom = 13
+
+      map.current.setCenter([formLongitudeValue, formLatitudeValue])
+      map.current.setZoom(initialZoom)
+    }
 
     recordMarker.current = new maplibregl.Marker({ draggable: !isReadOnlyUser })
     const recordMarkerElement = recordMarker.current.getElement()
@@ -111,6 +118,9 @@ const SingleSiteMap = ({
       map.current.remove()
       recordMarker.current.remove()
     }
+    // Removed formLongitudeValue and formLatitudeValue from the dependency array
+    // Only want to auto-zoom 13 when the map is first initialized (and if there are lng/lat values)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isReadOnlyUser,
     handleLatitudeChange,


### PR DESCRIPTION
[trello card](https://trello.com/c/CMdCiAB2/705-map-pin-placement-bug-auto-zooms-into-incorrect-location)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced map interaction by automatically adjusting zoom and center based on user input of latitude and longitude.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->