### PR TITLE
Bug fix: inset map centering

### DIFF
--- a/src/components/mermaidMap/MiniMap/MiniMap.js
+++ b/src/components/mermaidMap/MiniMap/MiniMap.js
@@ -73,9 +73,9 @@ const MiniMap = ({ mainMap }) => {
     const getMainMapCenter = () => {
       // prevents tests from failing due to maplibre-gl not being available
       try {
-        mainMap.getCenter()
+        return mainMap.getCenter()
       } catch (e) {
-        console.error('Error getting map center: ', e)
+        return console.error('Error getting map center: ', e)
       }
     }
 


### PR DESCRIPTION
add return to try/catch in `getMainMapCenter`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the mini-map's centering functionality to accurately reflect the main map's center and enhanced error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->