### PR TITLE
[624] handle ref for fish grouping

### DIFF
--- a/src/App/mermaidData/fishNameHelpers.js
+++ b/src/App/mermaidData/fishNameHelpers.js
@@ -58,12 +58,13 @@ export const getFishNameOptions = ({ species, genera, families, groupings = [] }
 
 export const getFishNameTable = ({
   fishFamilies,
+  fishGroupings,
   choices,
   fishGenera,
   fishSpecies,
   fishNameId,
 }) => {
-  const fishNameInfo = [...fishSpecies, ...fishGenera, ...fishFamilies].find(
+  const fishNameInfo = [...fishSpecies, ...fishGenera, ...fishFamilies, ...fishGroupings].find(
     (item) => item.id === fishNameId,
   )
 

--- a/src/App/mermaidData/fishNameHelpers.js
+++ b/src/App/mermaidData/fishNameHelpers.js
@@ -99,29 +99,29 @@ export const getFishNameTable = ({
     }
   `
   const trophicGroupName = choices.fishgrouptrophics.data?.find(
-    (item) => item.id === fishNameInfo.trophic_group,
+    (item) => item.id === fishNameInfo?.trophic_group,
   )?.name
 
   const functionalGroupName = choices.fishgroupfunctions.data?.find(
-    (item) => item.id === fishNameInfo.functional_group,
+    (item) => item.id === fishNameInfo?.functional_group,
   )?.name
 
   const fishGroupSizeName = choices.fishgroupsizes.data?.find(
-    (item) => item.id === fishNameInfo.group_size,
+    (item) => item.id === fishNameInfo?.group_size,
   )?.name
 
-  const maxLength = fishNameInfo.max_length_type
-    ? `${fishNameInfo.max_length} (${fishNameInfo.max_length_type})`
-    : fishNameInfo.max_length
+  const maxLength = fishNameInfo?.max_length_type
+    ? `${fishNameInfo?.max_length} (${fishNameInfo?.max_length_type})`
+    : fishNameInfo?.max_length
 
   const fishFamilyId =
-    fishNameInfo.family ??
-    fishGenera.find((genusInfo) => genusInfo.id === fishNameInfo.genus)?.family
+    fishNameInfo?.family ??
+    fishGenera.find((genusInfo) => genusInfo.id === fishNameInfo?.genus)?.family
   const fishFamilyName = fishFamilies.find((item) => item.id === fishFamilyId)?.name
 
   return (
     <TableContainer>
-      <label htmlFor="popoverTable">{fishNameInfo.display_name ?? fishNameInfo.name}</label>
+      <label htmlFor="popoverTable">{fishNameInfo?.display_name ?? fishNameInfo?.name}</label>
       <Table id="popoverTable">
         <tbody>
           {fishFamilyName ? (
@@ -134,14 +134,14 @@ export const getFishNameTable = ({
             <Td as="th">{tableLanguage.biomasConstants}</Td>
             <Td>
               <ul>
-                <li>A - {fishNameInfo.biomass_constant_a}</li>
-                <li>B - {fishNameInfo.biomass_constant_b}</li>
-                <li>C - {fishNameInfo.biomass_constant_c}</li>
+                <li>A - {fishNameInfo?.biomass_constant_a}</li>
+                <li>B - {fishNameInfo?.biomass_constant_b}</li>
+                <li>C - {fishNameInfo?.biomass_constant_c}</li>
               </ul>
             </Td>
           </Tr>
 
-          {fishNameInfo.max_length ? (
+          {fishNameInfo?.max_length ? (
             <Tr>
               <Td as="th">Max Length (cm)</Td>
               <Td>{maxLength}</Td>
@@ -153,10 +153,10 @@ export const getFishNameTable = ({
               <Td>{fishGroupSizeName}</Td>
             </Tr>
           ) : null}
-          {fishNameInfo.max_type ? (
+          {fishNameInfo?.max_type ? (
             <Tr>
               <Td as="th">{tableLanguage.maxType}</Td>
-              <Td>{fishNameInfo.max_length_type}</Td>
+              <Td>{fishNameInfo?.max_length_type}</Td>
             </Tr>
           ) : null}
           {functionalGroupName ? (

--- a/src/App/mermaidData/fishNameHelpers.js
+++ b/src/App/mermaidData/fishNameHelpers.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import language from '../../language'
 import { Table, Td, Tr } from '../../components/generic/Table/table'
 import theme from '../../theme'
+import { TextLink, LinkContainer } from '../../components/generic/links'
 
 const FAMILY_RANK = 'family'
 const GENUS_RANK = 'genus'
@@ -120,60 +121,79 @@ export const getFishNameTable = ({
     fishGenera.find((genusInfo) => genusInfo.id === fishNameInfo?.genus)?.family
   const fishFamilyName = fishFamilies.find((item) => item.id === fishFamilyId)?.name
 
+  const FishRefLinkContent = () => (
+    <LinkContainer>
+      <TextLink
+        href={process.env.REACT_APP_MERMAID_REFERENCE_LINK}
+        target="_blank"
+        rel="noreferrer"
+        download
+      >
+        See References (xlsx download)
+      </TextLink>
+    </LinkContainer>
+  )
+
   return (
     <TableContainer>
-      <label htmlFor="popoverTable">{fishNameInfo?.display_name ?? fishNameInfo?.name}</label>
-      <Table id="popoverTable">
-        <tbody>
-          {fishFamilyName ? (
-            <Tr>
-              <Td as="th">{tableLanguage.family}</Td>
-              <Td>{fishFamilyName}</Td>
-            </Tr>
-          ) : null}
-          <Tr>
-            <Td as="th">{tableLanguage.biomasConstants}</Td>
-            <Td>
-              <ul>
-                <li>A - {fishNameInfo?.biomass_constant_a}</li>
-                <li>B - {fishNameInfo?.biomass_constant_b}</li>
-                <li>C - {fishNameInfo?.biomass_constant_c}</li>
-              </ul>
-            </Td>
-          </Tr>
+      {fishNameInfo.name === 'Others CRCP' ? (
+        <FishRefLinkContent />
+      ) : (
+        <>
+          <label htmlFor="popoverTable">{fishNameInfo?.display_name ?? fishNameInfo?.name}</label>
+          <Table id="popoverTable">
+            <tbody>
+              {fishFamilyName ? (
+                <Tr>
+                  <Td as="th">{tableLanguage.family}</Td>
+                  <Td>{fishFamilyName}</Td>
+                </Tr>
+              ) : null}
+              <Tr>
+                <Td as="th">{tableLanguage.biomasConstants}</Td>
+                <Td>
+                  <ul>
+                    <li>A - {fishNameInfo?.biomass_constant_a}</li>
+                    <li>B - {fishNameInfo?.biomass_constant_b}</li>
+                    <li>C - {fishNameInfo?.biomass_constant_c}</li>
+                  </ul>
+                </Td>
+              </Tr>
 
-          {fishNameInfo?.max_length ? (
-            <Tr>
-              <Td as="th">Max Length (cm)</Td>
-              <Td>{maxLength}</Td>
-            </Tr>
-          ) : null}
-          {fishGroupSizeName ? (
-            <Tr>
-              <Td as="th">{tableLanguage.groupSize}</Td>
-              <Td>{fishGroupSizeName}</Td>
-            </Tr>
-          ) : null}
-          {fishNameInfo?.max_type ? (
-            <Tr>
-              <Td as="th">{tableLanguage.maxType}</Td>
-              <Td>{fishNameInfo?.max_length_type}</Td>
-            </Tr>
-          ) : null}
-          {functionalGroupName ? (
-            <Tr>
-              <Td as="th">{tableLanguage.functionalGroup}</Td>
-              <Td>{functionalGroupName}</Td>
-            </Tr>
-          ) : null}
-          {trophicGroupName ? (
-            <Tr>
-              <Td as="th">{tableLanguage.trophicGroup}</Td>
-              <Td>{trophicGroupName}</Td>
-            </Tr>
-          ) : null}
-        </tbody>
-      </Table>
+              {fishNameInfo?.max_length ? (
+                <Tr>
+                  <Td as="th">Max Length (cm)</Td>
+                  <Td>{maxLength}</Td>
+                </Tr>
+              ) : null}
+              {fishGroupSizeName ? (
+                <Tr>
+                  <Td as="th">{tableLanguage.groupSize}</Td>
+                  <Td>{fishGroupSizeName}</Td>
+                </Tr>
+              ) : null}
+              {fishNameInfo?.max_type ? (
+                <Tr>
+                  <Td as="th">{tableLanguage.maxType}</Td>
+                  <Td>{fishNameInfo?.max_length_type}</Td>
+                </Tr>
+              ) : null}
+              {functionalGroupName ? (
+                <Tr>
+                  <Td as="th">{tableLanguage.functionalGroup}</Td>
+                  <Td>{functionalGroupName}</Td>
+                </Tr>
+              ) : null}
+              {trophicGroupName ? (
+                <Tr>
+                  <Td as="th">{tableLanguage.trophicGroup}</Td>
+                  <Td>{trophicGroupName}</Td>
+                </Tr>
+              ) : null}
+            </tbody>
+          </Table>
+        </>
+      )}
     </TableContainer>
   )
 }

--- a/src/App/mermaidData/mermaidDataProptypes.js
+++ b/src/App/mermaidData/mermaidDataProptypes.js
@@ -533,5 +533,6 @@ export const fishSpeciesSingluarPropType = PropTypes.shape({
 })
 
 export const fishFamiliesPropType = PropTypes.arrayOf(fishFamiliyPropType)
+export const fishGroupingsPropType = PropTypes.arrayOf(fishFamiliyPropType)
 export const fishSpeciesPropType = PropTypes.arrayOf(fishSpeciesSingluarPropType)
 export const fishGeneraPropType = PropTypes.arrayOf(fishGeneraSingluarPropType)

--- a/src/components/generic/links.js
+++ b/src/components/generic/links.js
@@ -26,10 +26,10 @@ export const LinkThatLooksLikeButton = styled.a`
 export const NavLinkThatLooksLikeButtonIcon = styled(NavLinkThatLooksLikeButton)``
 
 export const TextLink = styled('a')`
-  padding: 0.4em;
+  padding: ${theme.spacing.small};
 `
 export const LinkContainer = styled('div')`
-  padding: 0.4em;
+  padding: ${theme.spacing.small};
 `
 
 export const HelperTextLink = styled('a')`

--- a/src/components/generic/links.js
+++ b/src/components/generic/links.js
@@ -25,6 +25,13 @@ export const LinkThatLooksLikeButton = styled.a`
 
 export const NavLinkThatLooksLikeButtonIcon = styled(NavLinkThatLooksLikeButton)``
 
+export const TextLink = styled('a')`
+  padding: 0.4em;
+`
+export const LinkContainer = styled('div')`
+  padding: 0.4em;
+`
+
 export const HelperTextLink = styled('a')`
   font-size: 1.2rem;
   color: ${(props) => props.color || '#000000'};

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltForm.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltForm.js
@@ -55,6 +55,7 @@ const FishBeltForm = ({ isNewRecord }) => {
   const [fishSpecies, setFishSpecies] = useState([])
   const [fishGenera, setFishGenera] = useState([])
   const [fishFamilies, setFishFamilies] = useState([])
+  const [fishGroupings, setFishGroupings] = useState([])
 
   const _getSupportingData = useEffect(() => {
     if (databaseSwitchboardInstance && projectId && !isSyncInProgress) {
@@ -127,6 +128,7 @@ const FishBeltForm = ({ isNewRecord }) => {
               setFishSpecies(fishSpeciesResponse)
               setFishGenera(fishGeneraResponse)
               setFishFamilies(fishFamiliesResponse)
+              setFishGroupings(fishGroupingsResponse)
               setIsLoading(false)
             }
           },
@@ -255,6 +257,7 @@ const FishBeltForm = ({ isNewRecord }) => {
             fishNameConstants={fishNameConstants}
             fishNameOptions={fishNameOptions}
             fishFamilies={fishFamilies}
+            fishGroupings={fishGroupings}
             fishGenera={fishGenera}
             fishSpecies={fishSpecies}
             {...props}
@@ -265,7 +268,7 @@ const FishBeltForm = ({ isNewRecord }) => {
       return null
     },
 
-    [fishFamilies, fishGenera, fishNameConstants, fishNameOptions, fishSpecies],
+    [fishFamilies, fishGenera, fishNameConstants, fishNameOptions, fishSpecies, fishGroupings],
   )
 
   const PartiallyAppliedFishBeltTransectInputs = useCallback(

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltObservationTable.js
@@ -8,6 +8,7 @@ import {
   fishNameConstantsPropType,
   fishBeltPropType,
   fishFamiliesPropType,
+  fishGroupingsPropType,
   fishGeneraPropType,
   fishSpeciesPropType,
 } from '../../../../App/mermaidData/mermaidDataProptypes'
@@ -97,6 +98,7 @@ const FishBeltObservationTable = ({
   fishNameOptions,
   testId,
   fishFamilies,
+  fishGroupings,
   fishGenera,
   fishSpecies,
 }) => {
@@ -166,6 +168,7 @@ const FishBeltObservationTable = ({
     ({ observationId, fishNameId }) => {
       const popoverTable = getFishNameTable({
         fishFamilies,
+        fishGroupings,
         choices,
         fishGenera,
         fishSpecies,
@@ -175,7 +178,7 @@ const FishBeltObservationTable = ({
       setFishNamePopoverContent(popoverTable)
       setObservationIdWithFishNamePopoverShowing(observationId)
     },
-    [choices, fishFamilies, fishGenera, fishSpecies],
+    [choices, fishFamilies, fishGenera, fishSpecies, fishGroupings],
   )
 
   const resetObservationIdWithFishNamePopoverShowing = () => {
@@ -583,6 +586,7 @@ FishBeltObservationTable.propTypes = {
   setIsNewBenthicAttributeModalOpen: PropTypes.func.isRequired,
   testId: PropTypes.string.isRequired,
   fishFamilies: fishFamiliesPropType.isRequired,
+  fishGroupings: fishGroupingsPropType.isRequired,
   fishGenera: fishGeneraPropType.isRequired,
   fishSpecies: fishSpeciesPropType.isRequired,
 }


### PR DESCRIPTION
- fixed type error when you previously selected 'Others CRCP' in fishbelt observations
- add fish grouping to `fishNameHelpers.js`
- added reference link to pop up for Others CRCP

[trello card](https://trello.com/c/VqSwYIMz/624-handle-reference-popover-for-fish-grouping)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new component `FishRefLinkContent` for displaying reference links, enhancing the user interface.
	- Added functionality to manage and display fish groupings in the `FishBeltForm` and `FishBeltObservationTable`, improving data organization and user experience.

- **Enhancements**
	- Updated the `getFishNameTable` function to include `fishGroupings`, allowing for more detailed fish name information.
	- Added `fishGroupingsPropType` for better type validation, ensuring data integrity.

- **Style**
	- Introduced new styled components `TextLink` and `LinkContainer` for improved aesthetics and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->