### PR TITLE
[704] fix keyboard shortcut bug in colonies bleaching

### DIFF
--- a/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/ColoniesBleachedObservationsTable.js
@@ -77,8 +77,9 @@ const ColoniesBleachedObservationTable = ({
     const handleKeyDown = ({ event, index, observation, isLastCell }) => {
       const isTabKey = event.code === 'Tab' && !event.shiftKey
       const isEnterKey = event.code === 'Enter'
+      const isLastRow = index === observationsState.length - 1
 
-      if (isTabKey && isLastCell) {
+      if (isTabKey && isLastCell && isLastRow) {
         event.preventDefault()
         setAutoFocusAllowed(true)
         observationsDispatch({


### PR DESCRIPTION
[trello card](https://trello.com/c/9cg5NJ7k/704-incorrect-keyboard-shortcuts-for-observation-table)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved tab navigation in the `Colonies Bleached Observations Table` by ensuring it only moves to the next cell if it's not in the last row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->