### PR TITLE
[494] add helper text to table filter fields

### DIFF
--- a/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
+++ b/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components/macro'
+import domPurify from 'dompurify'
 import theme from '../../theme'
 
 export const TooltipPopup = styled('span')`
@@ -38,6 +39,10 @@ export const TooltipPopup = styled('span')`
 `
 
 const ColumnHeaderToolTip = ({ helperText, bottom, left, top, maxWidth, html }) => {
+  const sanitizeHtml = domPurify.sanitize
+  const dirtyHTML = html
+  const cleanHTML = sanitizeHtml(dirtyHTML)
+
   return (
     <TooltipPopup
       role="tooltip"
@@ -48,7 +53,7 @@ const ColumnHeaderToolTip = ({ helperText, bottom, left, top, maxWidth, html }) 
       top={top}
     >
       {/* eslint-disable-next-line react/no-danger */}
-      {html ? <div dangerouslySetInnerHTML={{ __html: html }} /> : <span>{helperText}</span>}
+      {html ? <div dangerouslySetInnerHTML={{ __html: cleanHTML }} /> : <span>{helperText}</span>}
     </TooltipPopup>
   )
 }

--- a/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
+++ b/src/components/ColumnHeaderToolTip/ColumnHeaderToolTip.js
@@ -5,7 +5,7 @@ import theme from '../../theme'
 
 export const TooltipPopup = styled('span')`
   display: block;
-  max-width: 25rem;
+  max-width:  ${(props) => props.maxWidth || '25rem'};
   width: max-content;
   background: ${theme.color.primaryColor};
   color: ${theme.color.white};
@@ -37,10 +37,18 @@ export const TooltipPopup = styled('span')`
   text-align: left;
 `
 
-const ColumnHeaderToolTip = ({ helperText, bottom, left }) => {
+const ColumnHeaderToolTip = ({ helperText, bottom, left, top, maxWidth, html }) => {
   return (
-    <TooltipPopup role="tooltip" aria-labelledby="tooltip" bottom={bottom} left={left}>
-      {helperText}
+    <TooltipPopup
+      role="tooltip"
+      aria-labelledby="tooltip"
+      bottom={bottom}
+      left={left}
+      maxWidth={maxWidth}
+      top={top}
+    >
+      {/* eslint-disable-next-line react/no-danger */}
+      {html ? <div dangerouslySetInnerHTML={{ __html: html }} /> : <span>{helperText}</span>}
     </TooltipPopup>
   )
 }
@@ -50,10 +58,17 @@ export default ColumnHeaderToolTip
 ColumnHeaderToolTip.defaultProps = {
   bottom: '4em',
   left: '0em',
+  maxWidth: '25rem',
+  top: '0',
+  html: '',
+  helperText: '',
 }
 
 ColumnHeaderToolTip.propTypes = {
-  helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   bottom: PropTypes.string,
   left: PropTypes.string,
+  top: PropTypes.string,
+  maxWidth: PropTypes.string,
+  html: PropTypes.string,
 }

--- a/src/components/FilterSearchToolbar/FilterSearchToolbar.js
+++ b/src/components/FilterSearchToolbar/FilterSearchToolbar.js
@@ -1,7 +1,11 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components/macro'
-import { Input, inputStyles } from '../generic/form'
+import { Input, LabelContainer, inputStyles } from '../generic/form'
+import { IconInfo } from '../icons'
+import { IconButton } from '../generic/buttons'
+import language from '../../language'
+import ColumnHeaderToolTip from '../ColumnHeaderToolTip/ColumnHeaderToolTip'
 
 const FilterLabelWrapper = styled.label`
   display: flex;
@@ -22,6 +26,7 @@ const FilterSearchToolbar = ({
   handleGlobalFilterChange,
 }) => {
   const [searchText, setSearchText] = useState(globalSearchText)
+  const [isHelperTextShowing, setIsHelperTextShowing] = useState(false)
 
   const handleFilterChange = (event) => {
     const eventValue = event.target.value
@@ -30,9 +35,33 @@ const FilterSearchToolbar = ({
     handleGlobalFilterChange(eventValue)
   }
 
+  const handleInfoIconClick = (event) => {
+    isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
+
+    event.stopPropagation()
+  }
+
   return (
     <FilterLabelWrapper htmlFor={id}>
-      {name}
+      <LabelContainer>
+        {name}
+        <IconButton
+          type="button"
+          onClick={(event) => handleInfoIconClick(event, 'benthicAttribute')}
+        >
+          <IconInfo aria-label="info" />
+        </IconButton>
+        {isHelperTextShowing ? (
+          <ColumnHeaderToolTip
+            id={`aria-descp${id}`}
+            left="22em"
+            top="7em"
+            bottom="58em"
+            maxWidth="50em"
+            html={language.pages.submittedTable.filterSearchHelperText.__html}
+          />
+        ) : null}
+      </LabelContainer>
       <FilterInput
         type="text"
         id={id}

--- a/src/language.js
+++ b/src/language.js
@@ -358,6 +358,12 @@ const pages = {
     title: 'Submitted',
     filterToolbarText: 'Filter this table by site, management, or observer',
     noDataMainText: `This project has no submitted sample units.`,
+    filterSearchHelperText: {
+      __html: `
+        <span style="font-weight: bold;">Use double quotes to search exact phases.</span><br>
+        For example, search North Shore to find records with the words North or Shore (records with South Shore would match). Or search “North Shore” to find records that have exactly the words North Shore (records with South Shore would not match).
+      `,
+    },
   },
   userTable: {
     title: 'Users',


### PR DESCRIPTION
[trello card](https://trello.com/c/njVA0Wxy/494-add-helper-text-to-table-filter-fields)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `ColumnHeaderToolTip` component to support HTML content sanitization and added customization options such as `top` positioning and `maxWidth`.
	- Added an information icon to the `FilterSearchToolbar` that toggles the visibility of helper text, providing additional context for filter search usage.
- **Documentation**
	- Updated language support to include `filterSearchHelperText` with HTML content for search tips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->