### PR TITLE
Feat: Non-admin user

### DIFF
--- a/src/components/generic/ButtonSecondaryDropdown/ButtonSecondaryDropdown.js
+++ b/src/components/generic/ButtonSecondaryDropdown/ButtonSecondaryDropdown.js
@@ -5,11 +5,11 @@ import { ButtonSecondary } from '../buttons'
 import { IconDown } from '../../icons'
 import { StyledDropdownContainer } from './ButtonSecondaryDropdown.styles'
 
-const ButtonSecondaryDropdown = ({ children, label, className }) => {
+const ButtonSecondaryDropdown = ({ children, label, className = undefined, disabled = false }) => {
   return (
     <HideShow
       button={
-        <ButtonSecondary className={className}>
+        <ButtonSecondary className={className} disabled={disabled}>
           {label} <IconDown />
         </ButtonSecondary>
       }
@@ -22,9 +22,7 @@ ButtonSecondaryDropdown.propTypes = {
   children: PropTypes.node.isRequired,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   className: PropTypes.string,
-}
-ButtonSecondaryDropdown.defaultProps = {
-  className: undefined,
+  disabled: PropTypes.bool,
 }
 
 export default ButtonSecondaryDropdown

--- a/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.js
@@ -11,7 +11,6 @@ import { ensureTrailingSlash } from '../../../../library/strings/ensureTrailingS
 import { getIsUserAdminForProject } from '../../../../App/currentUserProfileHelpers'
 import { getIndicatorSetFormInitialValues } from './indicatorSetFormInitialValues'
 import { getToastArguments } from '../../../../library/getToastArguments'
-import { ItalicizedInfo } from '../../../generic/text'
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
 import { useDatabaseSwitchboardInstance } from '../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 import { useHttpResponseErrorHandler } from '../../../../App/HttpResponseErrorHandlerContext'
@@ -22,11 +21,13 @@ import LoadingModal from '../../../LoadingModal/LoadingModal'
 import SaveButton from '../../../generic/SaveButton'
 import useCurrentProjectPath from '../../../../library/useCurrentProjectPath'
 import useIsMounted from '../../../../library/useIsMounted'
-import { DeleteRecordButtonCautionWrapper } from '../../collectRecordFormPages/CollectingFormPage.Styles'
 import { useCurrentProject } from '../../../../App/CurrentProjectContext'
 import GfcrIndicatorSetNav from '../GfcrIndicatorSetNav'
 import GfcrIndicatorSetForm from '../GfcrIndicatorSetForm/GfcrIndicatorSetForm'
 import IndicatorSetTitle from './IndicatorSetTitle'
+import { GfcrPageUnavailablePadding } from '../Gfcr/Gfcr.styles'
+import PageUnavailable from '../../PageUnavailable'
+import IdsNotFound from '../../IdsNotFound/IdsNotFound'
 
 // const ReadOnlySiteContent = ({
 //   site,
@@ -108,7 +109,6 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
   //   setIsDeleteRecordModalOpen(false)
   // }
 
-  // const isReadOnlyUser = getIsUserReadOnlyForProject(currentUser, projectId)
   const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
 
   // const {
@@ -123,8 +123,9 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
         .then(([indicatorSetsResponse]) => {
           if (isMounted.current) {
             setGfcrIndicatorSets(indicatorSetsResponse.results)
-            setIsLoading(false)
           }
+
+          setIsLoading(false)
         })
         .catch((error) => {
           handleHttpResponseError({
@@ -133,6 +134,8 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
               toast.error(...getToastArguments(language.error.gfcrIndicatorSetsUnavailable))
             },
           })
+
+          setIsLoading(false)
         })
     }
 
@@ -154,7 +157,7 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
       const indicatorSet = gfcrIndicatorSets.find(
         (indicatorSet) => indicatorSet.id === indicatorSetId,
       )
-const indicatorSet = gfcrIndicatorSets?.find(
+
       setIndicatorSetBeingEdited(indicatorSet)
     }
   }, [gfcrIndicatorSets, indicatorSetId])
@@ -355,8 +358,6 @@ const indicatorSet = gfcrIndicatorSets?.find(
   //     })
   // }
 
-  // const displayIdNotFoundErrorPage = idsNotAssociatedWithData.length && !isNewIndicatorSet
-
   // const contentViewByReadOnlyRole = isNewIndicatorSet ? (
   //   <PageUnavailable mainText={language.error.pageReadOnly} />
   // ) : (
@@ -371,7 +372,7 @@ const indicatorSet = gfcrIndicatorSets?.find(
   //   />
   // )
 
-  const contentViewByRole = (
+  const contentViewByRole = isAdminUser ? (
     <div
       style={{
         display: 'flex',
@@ -401,24 +402,28 @@ const indicatorSet = gfcrIndicatorSets?.find(
           openModal={openDeleteRecordModal}
         />
       )} */}
-      {!isAdminUser && isAppOnline ? (
-        <DeleteRecordButtonCautionWrapper>
-          <ItalicizedInfo>{language.pages.siteForm.nonAdminDelete}</ItalicizedInfo>
-        </DeleteRecordButtonCautionWrapper>
-      ) : null}
+      {/* {!isAdminUser && isAppOnline ? (
+        // <DeleteRecordButtonCautionWrapper>
+        //   <ItalicizedInfo>{language.pages.siteForm.nonAdminDelete}</ItalicizedInfo>
+        // </DeleteRecordButtonCautionWrapper>
+      ) : null} */}
       {saveButtonState === buttonGroupStates.saving && <LoadingModal />}
       <EnhancedPrompt shouldPromptTrigger={shouldPromptTrigger} />
     </div>
+  ) : (
+    <GfcrPageUnavailablePadding>
+      <PageUnavailable mainText={language.error.pageAdminOnly} />
+    </GfcrPageUnavailablePadding>
   )
 
-  // return displayIdNotFoundErrorPage ? (
-  //   <ContentPageLayout
-  //     isPageContentLoading={isLoading}
-  //     content={<IdsNotFound ids={idsNotAssociatedWithData} />}
-  //   />
-  // ) : (
+  const displayIdNotFoundErrorPage = !indicatorSetBeingEdited && !newIndicatorSetType
 
-  return (
+  return displayIdNotFoundErrorPage ? (
+    <ContentPageLayout
+      isPageContentLoading={isLoading}
+      content={<IdsNotFound ids={indicatorSetId} />}
+    />
+  ) : (
     <ContentPageLayout
       isPageContentLoading={isLoading}
       isToolbarSticky={true}


### PR DESCRIPTION
**Summary**:
- Display the indicator title as text (not link) in table.
- Disable create new button when user not admin.
- Update loading status logic for GFCR components.
- Add  property to ButtonSecondaryDropdown and switch from defaultProps to JS default parameters. Fix incorrect syntagix in _setIndicatorSet().

Ref: https://trello.com/c/szs0ddO0/748-non-admin-view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `disabled` prop to `ButtonSecondaryDropdown` component with a default value of `false`.

- **Improvements**
  - Simplified toolbar buttons in `Gfcr` based on user permissions.
  - Enhanced content rendering in `GfcrIndicatorSet` based on user roles and app status.

- **Code Cleanup**
  - Removed unused imports and commented-out code in `GfcrIndicatorSet`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->