### PR TITLE
Feat: Delete indicator set

### DIFF
--- a/src/App/mermaidData/databaseSwitchboard/GfcrMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/GfcrMixin.js
@@ -47,6 +47,21 @@ const GfcrMixin = (Base) =>
           : Promise.reject(this._notAuthenticatedAndReadyError)
       }
     }
+
+    deleteIndicatorSet = async function deleteIndicatorSet(projectId, indicatorSetId) {
+      if (!projectId || !indicatorSetId) {
+        throw new Error(this._operationMissingParameterError)
+      }
+
+      return this._isOnlineAuthenticatedAndReady
+        ? axios
+            .delete(
+              `${this._apiBaseUrl}/projects/${projectId}/indicatorsets/${indicatorSetId}/`,
+              await getAuthorizationHeaders(this._getAccessToken),
+            )
+            .then((apiResults) => apiResults.data)
+        : Promise.reject(this._notAuthenticatedAndReadyError)
+    }
   }
 
 export default GfcrMixin

--- a/src/components/generic/ButtonSecondaryDropdown/ButtonSecondaryDropdown.js
+++ b/src/components/generic/ButtonSecondaryDropdown/ButtonSecondaryDropdown.js
@@ -5,11 +5,11 @@ import { ButtonSecondary } from '../buttons'
 import { IconDown } from '../../icons'
 import { StyledDropdownContainer } from './ButtonSecondaryDropdown.styles'
 
-const ButtonSecondaryDropdown = ({ children, label, className }) => {
+const ButtonSecondaryDropdown = ({ children, label, className = undefined, disabled = false }) => {
   return (
     <HideShow
       button={
-        <ButtonSecondary className={className}>
+        <ButtonSecondary className={className} disabled={disabled}>
           {label} <IconDown />
         </ButtonSecondary>
       }
@@ -22,9 +22,7 @@ ButtonSecondaryDropdown.propTypes = {
   children: PropTypes.node.isRequired,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   className: PropTypes.string,
-}
-ButtonSecondaryDropdown.defaultProps = {
-  className: undefined,
+  disabled: PropTypes.bool,
 }
 
 export default ButtonSecondaryDropdown

--- a/src/components/pages/collectRecordFormPages/CollectingFormPage.Styles.js
+++ b/src/components/pages/collectRecordFormPages/CollectingFormPage.Styles.js
@@ -136,10 +136,7 @@ export const TableValidationList = styled.ul`
 
 export const DeleteRecordButtonCautionWrapper = styled('div')`
   padding: ${theme.spacing.medium};
-  text-align: end;
-  ${mediaQueryTabletLandscapeOnly(css`
-    text-align: start;
-  `)}
+  margin: ${theme.spacing.large} 0;
 `
 
 export const DeleteProjectButtonCautionWrapper = styled(DeleteRecordButtonCautionWrapper)`

--- a/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.js
@@ -11,7 +11,6 @@ import { ensureTrailingSlash } from '../../../../library/strings/ensureTrailingS
 import { getIsUserAdminForProject } from '../../../../App/currentUserProfileHelpers'
 import { getIndicatorSetFormInitialValues } from './indicatorSetFormInitialValues'
 import { getToastArguments } from '../../../../library/getToastArguments'
-import { ItalicizedInfo } from '../../../generic/text'
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
 import { useDatabaseSwitchboardInstance } from '../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 import { useHttpResponseErrorHandler } from '../../../../App/HttpResponseErrorHandlerContext'
@@ -22,11 +21,13 @@ import LoadingModal from '../../../LoadingModal/LoadingModal'
 import SaveButton from '../../../generic/SaveButton'
 import useCurrentProjectPath from '../../../../library/useCurrentProjectPath'
 import useIsMounted from '../../../../library/useIsMounted'
-import { DeleteRecordButtonCautionWrapper } from '../../collectRecordFormPages/CollectingFormPage.Styles'
 import { useCurrentProject } from '../../../../App/CurrentProjectContext'
 import GfcrIndicatorSetNav from '../GfcrIndicatorSetNav'
 import GfcrIndicatorSetForm from '../GfcrIndicatorSetForm/GfcrIndicatorSetForm'
 import IndicatorSetTitle from './IndicatorSetTitle'
+import { GfcrPageUnavailablePadding } from '../Gfcr/Gfcr.styles'
+import PageUnavailable from '../../PageUnavailable'
+import IdsNotFound from '../../IdsNotFound/IdsNotFound'
 
 // const ReadOnlySiteContent = ({
 //   site,
@@ -108,7 +109,6 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
   //   setIsDeleteRecordModalOpen(false)
   // }
 
-  // const isReadOnlyUser = getIsUserReadOnlyForProject(currentUser, projectId)
   const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
 
   // const {
@@ -123,8 +123,9 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
         .then(([indicatorSetsResponse]) => {
           if (isMounted.current) {
             setGfcrIndicatorSets(indicatorSetsResponse.results)
-            setIsLoading(false)
           }
+
+          setIsLoading(false)
         })
         .catch((error) => {
           handleHttpResponseError({
@@ -133,6 +134,8 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
               toast.error(...getToastArguments(language.error.gfcrIndicatorSetsUnavailable))
             },
           })
+
+          setIsLoading(false)
         })
     }
 
@@ -154,7 +157,7 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
       const indicatorSet = gfcrIndicatorSets.find(
         (indicatorSet) => indicatorSet.id === indicatorSetId,
       )
-const indicatorSet = gfcrIndicatorSets?.find(
+
       setIndicatorSetBeingEdited(indicatorSet)
     }
   }, [gfcrIndicatorSets, indicatorSetId])
@@ -355,8 +358,6 @@ const indicatorSet = gfcrIndicatorSets?.find(
   //     })
   // }
 
-  // const displayIdNotFoundErrorPage = idsNotAssociatedWithData.length && !isNewIndicatorSet
-
   // const contentViewByReadOnlyRole = isNewIndicatorSet ? (
   //   <PageUnavailable mainText={language.error.pageReadOnly} />
   // ) : (
@@ -371,7 +372,7 @@ const indicatorSet = gfcrIndicatorSets?.find(
   //   />
   // )
 
-  const contentViewByRole = (
+  const contentViewByRole = isAdminUser ? (
     <div
       style={{
         display: 'flex',
@@ -401,24 +402,28 @@ const indicatorSet = gfcrIndicatorSets?.find(
           openModal={openDeleteRecordModal}
         />
       )} */}
-      {!isAdminUser && isAppOnline ? (
-        <DeleteRecordButtonCautionWrapper>
-          <ItalicizedInfo>{language.pages.siteForm.nonAdminDelete}</ItalicizedInfo>
-        </DeleteRecordButtonCautionWrapper>
-      ) : null}
+      {/* {!isAdminUser && isAppOnline ? (
+        // <DeleteRecordButtonCautionWrapper>
+        //   <ItalicizedInfo>{language.pages.siteForm.nonAdminDelete}</ItalicizedInfo>
+        // </DeleteRecordButtonCautionWrapper>
+      ) : null} */}
       {saveButtonState === buttonGroupStates.saving && <LoadingModal />}
       <EnhancedPrompt shouldPromptTrigger={shouldPromptTrigger} />
     </div>
+  ) : (
+    <GfcrPageUnavailablePadding>
+      <PageUnavailable mainText={language.error.pageAdminOnly} />
+    </GfcrPageUnavailablePadding>
   )
 
-  // return displayIdNotFoundErrorPage ? (
-  //   <ContentPageLayout
-  //     isPageContentLoading={isLoading}
-  //     content={<IdsNotFound ids={idsNotAssociatedWithData} />}
-  //   />
-  // ) : (
+  const displayIdNotFoundErrorPage = !indicatorSetBeingEdited && !newIndicatorSetType
 
-  return (
+  return displayIdNotFoundErrorPage ? (
+    <ContentPageLayout
+      isPageContentLoading={isLoading}
+      content={<IdsNotFound ids={indicatorSetId} />}
+    />
+  ) : (
     <ContentPageLayout
       isPageContentLoading={isLoading}
       isToolbarSticky={true}

--- a/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.js
@@ -95,20 +95,6 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
   const indicatorSetType = indicatorSetBeingEdited?.indicator_set_type || newIndicatorSetType
   const indicatorSetTypeName = indicatorSetType === 'annual_report' ? 'Annual Report' : 'Target'
 
-  // const goToPageOneOfDeleteRecordModal = () => {
-  //   setCurrentDeleteRecordModalPage(1)
-  // }
-  // const goToPageTwoOfDeleteRecordModal = () => {
-  //   setCurrentDeleteRecordModalPage(2)
-  // }
-  // const openDeleteRecordModal = () => {
-  //   setIsDeleteRecordModalOpen(true)
-  // }
-  // const closeDeleteRecordModal = () => {
-  //   goToPageOneOfDeleteRecordModal()
-  //   setIsDeleteRecordModalOpen(false)
-  // }
-
   const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
 
   // const {
@@ -320,44 +306,6 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
     [formik.dirty],
   )
 
-  // const deleteRecord = () => {
-  //   // only available online
-  //   setIsDeletingSite(true)
-
-  //   databaseSwitchboardInstance
-  //     .deleteSite(siteBeingEdited, projectId)
-  //     .then(() => {
-  //       clearPersistedUnsavedFormikData()
-  //       closeDeleteRecordModal()
-  //       setIsDeletingSite(false)
-  //       toast.success(...getToastArguments(language.success.getMermaidDataDeleteSuccess('site')))
-  //       navigate(`${ensureTrailingSlash(currentProjectPath)}sites/`)
-  //     })
-  //     .catch((error) => {
-  //       const { isSyncError, isDeleteRejectedError } = error
-
-  //       if (isSyncError && !isDeleteRejectedError) {
-  //         const toastTitle = language.error.getDeleteOnlineSyncErrorTitle('site')
-
-  //         showSyncToastError({ toastTitle, error, testId: 'site-toast-error' })
-  //         setIsDeletingSite(false)
-  //         closeDeleteRecordModal()
-  //       }
-
-  //       if (isSyncError && isDeleteRejectedError) {
-  //         // show modal which lists the associated sumbitted sample units that are associated with the site
-  //         setSiteDeleteErrorData(error.associatedSampleUnits)
-  //         setIsDeletingSite(false)
-  //         goToPageTwoOfDeleteRecordModal()
-  //       }
-  //       if (!isSyncError) {
-  //         handleHttpResponseError({
-  //           error,
-  //         })
-  //       }
-  //     })
-  // }
-
   // const contentViewByReadOnlyRole = isNewIndicatorSet ? (
   //   <PageUnavailable mainText={language.error.pageReadOnly} />
   // ) : (
@@ -388,6 +336,7 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
         selectedNavItem={selectedNavItem}
         indicatorSetType={indicatorSetType}
         handleFormSubmit={handleFormSubmit}
+        isNewIndicatorSet={!!newIndicatorSetType}
       />
       {/* {isAdminUser && isAppOnline && (
         <DeleteRecordButton

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/GfcrIndicatorSetForm.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/GfcrIndicatorSetForm.js
@@ -34,6 +34,7 @@ const GfcrIndicatorSetForm = ({
   indicatorSetType,
   indicatorSet,
   handleFormSubmit,
+  isNewIndicatorSet,
 }) => {
   return (
     <form id="indicator-set-form" onSubmit={formik.handleSubmit}>
@@ -42,6 +43,7 @@ const GfcrIndicatorSetForm = ({
           formik={formik}
           handleInputBlur={handleInputBlur}
           setInputToDefaultValue={setInputToDefaultValue}
+          isNewIndicatorSet={isNewIndicatorSet}
         />
       )}
       {selectedNavItem === 'f1' && <F1Form formik={formik} handleInputBlur={handleInputBlur} />}
@@ -69,6 +71,7 @@ GfcrIndicatorSetForm.propTypes = {
   selectedNavItem: PropTypes.string.isRequired,
   indicatorSetType: PropTypes.string.isRequired,
   indicatorSet: PropTypes.object.isRequired,
+  isNewIndicatorSet: PropTypes.bool.isRequired,
   handleFormSubmit: PropTypes.func.isRequired,
 }
 

--- a/src/language.js
+++ b/src/language.js
@@ -74,6 +74,7 @@ const error = {
     `The ${mermaidDataTypeLabel} has failed to delete from your computer or online.`,
   gfcrIndicatorSetsUnavailable: 'GFCR indicator sets are currently unavailable.',
   gfcrIndicatorSetSave: 'Indicator set has not been saved.',
+  gfcrIndicatorSetDelete: 'Indicator set has not been deleted.',
   idNotFoundUserAction: "Please check the URL in your browser's address bar.",
   invalidEmailAdd: 'Invalid email address.',
   managementRegimeRecordsUnavailable: 'Management Regime records data are currently unavailable.',
@@ -151,6 +152,7 @@ const success = {
   getUserRoleChangeSuccessMessage: ({ userName, role }) =>
     `${userName}'s role is now set to ${role}.`,
   gfcrIndicatorSetSave: 'Indicator set saved.',
+  gfcrIndicatorSetDelete: 'Indicator set deleted.',
   newUserAdd: 'New user added.',
   newPendingUserAdd: 'Sign-up email sent. New user added as Pending User.',
   userRemoved: 'User removed',
@@ -166,7 +168,6 @@ const success = {
       : `The ${mermaidDataTypeLabel} has been saved on your computer.`,
   getMermaidDataDeleteSuccess: (mermaidDataTypeLabel) =>
     `The ${mermaidDataTypeLabel} has been deleted from your computer and online.`,
-
   submittedRecordMoveToCollect: 'The submitted record has been moved to collecting.',
   projectStatusSaved: `Test project selection saved.`,
   getDataSharingPolicyChangeSuccess: (method, policy_code) => {


### PR DESCRIPTION
**Summary**:
Add Delete Indicator Set button to Indicator Set local nav.
Add deleteIndicatorSet to GfcrMixin.
Add language.

Ref: https://trello.com/c/2zaFMfDM/744-delete-indicator-set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to delete indicator sets for projects.
  - Introduced a new `disabled` prop in the `ButtonSecondaryDropdown` component.

- **Improvements**
  - Enhanced user role logic and toolbar button adjustments based on permissions in the Gfcr page.
  - Updated `GfcrIndicatorSetForm` to include a required `isNewIndicatorSet` prop.
  - Improved state management and delete functionality in the `IndicatorSetForm`.

- **Bug Fixes**
  - Corrected import statements and dependencies in various components to ensure proper functionality.

- **Messages**
  - Added success and error messages for deleting indicator sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->