### PR TITLE
[803] fix drop down update bug for fish bin size

### DIFF
--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltTransectInputs.js
@@ -64,10 +64,12 @@ const FishBeltTransectInputs = ({
   const hasFishBeltObservations =
     !!observationsState?.length > 0 && observationsState[0]?.fish_attribute
   const [isClearSizeValueModalOpen, setIsClearSizeValueModalOpen] = useState(false)
-  const [sizeBinEvent, setSizeBinEvent] = useState({})
+  const [sizeBinValue, setSizeBinValue] = useState('')
 
   const onSizeBinChange = (event) => {
-    const sizeBinId = event.target.value
+    let sizeBinId
+
+    sizeBinValue ? (sizeBinId = sizeBinValue) : (sizeBinId = event?.target?.value)
 
     formik.setFieldValue('size_bin', sizeBinId)
 
@@ -179,8 +181,8 @@ const FishBeltTransectInputs = ({
 
   const handleSizeBinChange = (event) => {
     if (hasFishBeltObservations) {
+      setSizeBinValue(event.target.value)
       openClearSizeValuesModal()
-      setSizeBinEvent(event)
     } else {
       onSizeBinChange(event)
       resetNonObservationFieldValidations({
@@ -249,7 +251,7 @@ const FishBeltTransectInputs = ({
   }
 
   const handleResetSizeValues = () => {
-    onSizeBinChange(sizeBinEvent)
+    onSizeBinChange()
     resetNonObservationFieldValidations({
       inputName: 'size_bin',
       validationPath: SIZE_BIN_VALIDATION_PATH,


### PR DESCRIPTION
[trello card](https://trello.com/c/rvKXGJ3m/803-fishbelt-size-bin-can-only-be-changed-after-the-data-are-removed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved state management and logic handling for size bin changes in the FishBeltTransectInputs component, resulting in smoother user interactions and more reliable input resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->