### PR TITLE
Feat: Rename Annual Report to Report

### DIFF
--- a/src/App/routes.js
+++ b/src/App/routes.js
@@ -174,8 +174,8 @@ export const routes = [
     Component: () => <Gfcr />,
   },
   {
-    path: '/projects/:projectId/gfcr/new/annual-report',
-    Component: () => <GfcrIndicatorSet newIndicatorSetType={'annual_report'} />,
+    path: '/projects/:projectId/gfcr/new/report',
+    Component: () => <GfcrIndicatorSet newIndicatorSetType={'report'} />,
   },
   {
     path: '/projects/:projectId/gfcr/new/target',

--- a/src/components/pages/gfcrPages/Gfcr/Gfcr.js
+++ b/src/components/pages/gfcrPages/Gfcr/Gfcr.js
@@ -121,7 +121,7 @@ const Gfcr = () => {
 
       return {
         title: isAdminUser ? <Link to={`${currentProjectPath}/gfcr/${id}`}>{title}</Link> : title,
-        indicator_set_type: indicator_set_type === 'annual_report' ? 'Annual Report' : 'Target',
+        indicator_set_type: indicator_set_type === 'report' ? 'Report' : 'Target',
         report_date: localizedDate,
       }
     })
@@ -230,8 +230,8 @@ const Gfcr = () => {
       <StyledToolbarButtonWrapper>
         <ButtonSecondaryDropdown label={createDropdownLabel} disabled={!isAdminUser}>
           <Column as="nav" data-testid="export-to-csv">
-            <DropdownItemStyle as="button" onClick={() => handleNewIndicatorSet('annual-report')}>
-              Annual Report
+            <DropdownItemStyle as="button" onClick={() => handleNewIndicatorSet('report')}>
+              Report
             </DropdownItemStyle>
             <DropdownItemStyle as="button" onClick={() => handleNewIndicatorSet('target')}>
               Target

--- a/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.js
@@ -49,7 +49,7 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
   const [selectedNavItem, setSelectedNavItem] = useState('report-title-and-year')
   const shouldPromptTrigger = isFormDirty && saveButtonState !== buttonGroupStates.saving // we need to prevent the user from seeing the dirty form prompt when a new indicator set is saved (and that triggers a navigation to its new page)
   const indicatorSetType = indicatorSetBeingEdited?.indicator_set_type || newIndicatorSetType
-  const indicatorSetTypeName = indicatorSetType === 'annual_report' ? 'Annual Report' : 'Target'
+  const indicatorSetTypeName = indicatorSetType === 'report' ? 'Report' : 'Target'
 
   const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
 

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F4Form.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F4Form.js
@@ -41,7 +41,7 @@ const F4Form = ({
   handleFormSubmit,
 }) => {
   const [isUpdateFromCalc, setIsUpdateFromCalc] = useState(false)
-  const isAnnualReport = indicatorSetType === 'annual_report'
+  const isReport = indicatorSetType === 'report'
 
   const _indicatorSetChanged = useEffect(() => {
     if (isUpdateFromCalc) {
@@ -123,7 +123,7 @@ const F4Form = ({
 
   return (
     <StyledGfcrInputWrapper>
-      {isAnnualReport && (
+      {isReport && (
         <StyledInputRowDates>
           <label>
             <b>{gfcrIndicatorSetLanguage.f4_reportingDateRange}</b>
@@ -165,8 +165,8 @@ const F4Form = ({
           unit="%"
           {...formik.getFieldProps('f4_1')}
           onBlur={(event) => handleInputBlur(formik, event, 'f4_1', true)}
-          helperText={isAnnualReport ? f41HelperText : gfcrIndicatorSetLanguage.f4_1_helper}
-          showHelperText={isAnnualReport && true}
+          helperText={isReport ? f41HelperText : gfcrIndicatorSetLanguage.f4_1_helper}
+          showHelperText={isReport && true}
           onKeyDown={(event) => enforceNumberInput(event)}
         />
       </StyledInputRowQuestions>
@@ -182,8 +182,8 @@ const F4Form = ({
           unit="%"
           {...formik.getFieldProps('f4_2')}
           onBlur={(event) => handleInputBlur(formik, event, 'f4_2', true)}
-          helperText={isAnnualReport ? f42HelperText : gfcrIndicatorSetLanguage.f4_2_helper}
-          showHelperText={isAnnualReport && true}
+          helperText={isReport ? f42HelperText : gfcrIndicatorSetLanguage.f4_2_helper}
+          showHelperText={isReport && true}
           onKeyDown={(event) => enforceNumberInput(event)}
         />
       </StyledInputRowQuestions>
@@ -199,8 +199,8 @@ const F4Form = ({
           unit="kg/ha"
           {...formik.getFieldProps('f4_3')}
           onBlur={(event) => handleInputBlur(formik, event, 'f4_3', true)}
-          helperText={isAnnualReport ? f43HelperText : gfcrIndicatorSetLanguage.f4_3_helper}
-          showHelperText={isAnnualReport && true}
+          helperText={isReport ? f43HelperText : gfcrIndicatorSetLanguage.f4_3_helper}
+          showHelperText={isReport && true}
           onKeyDown={(event) => enforceNumberInput(event)}
         />
       </StyledInputRowQuestions>


### PR DESCRIPTION
- Update the button in the “Create new” dropdown to just say “Report”, not “Annual Report”.
- Update code to reflect updated terminology.

Ref: https://trello.com/c/M7sV5MXj/852-change-annual-report-label-to-report

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated path for creating a new indicator set in Gfcr section to `/projects/:projectId/gfcr/new/report`.
- **Improvements**
	- Changed display text and dropdown items from 'Annual Report' to 'Report' for better clarity.
	- Simplified variable logic and condition checks from 'annual_report' to 'report' in Gfcr-related forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->