### PR TITLE
Fix PR Previews

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,10 @@ import { ClearPersistedFormDataHackProvider } from './App/ClearDirtyFormDataHack
 
 // Upgrading to react router v6 because of dependabot issues and data routers (createBrowserRouter) which is necessary for many functions we use(eg: useNavigate).
 // We keep the jsx routes as defined in app.js instead of having ALL routes defined here because we were not able to have conditional rendering of the loader otherwise
-const router = createBrowserRouter([
-  { path: '*', element: <App dexieCurrentUserInstance={dexieCurrentUserInstance} /> },
-])
+const router = createBrowserRouter(
+  [{ path: '*', element: <App dexieCurrentUserInstance={dexieCurrentUserInstance} /> }],
+  { basename: process.env.PUBLIC_URL },
+)
 
 const container = document.getElementById('root')
 const root = createRoot(container)


### PR DESCRIPTION
- Added `basename` property to `createBrowserRouter` as it was omitted when we upgraded from react router v5 to v6.
  - This property tells the application the starting point and routes accordingly. Its value should match the `homepage` value in `package.json`.
  - This is needed for PR previews where the `homepage` value is set to the PR Number. (ex. `https://preview.app2.datamermaid.org/<PR_NUMBER>/index.html`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved routing configuration to better handle base URLs, ensuring more consistent navigation within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->