### PR TITLE
M916 cpu spike

### DIFF
--- a/src/components/mermaidMap/ProjectSitesMap/ProjectSitesMap.js
+++ b/src/components/mermaidMap/ProjectSitesMap/ProjectSitesMap.js
@@ -43,17 +43,17 @@ const ProjectSitesMap = ({ sitesForMapMarkers, choices }) => {
     addZoomController(map.current)
 
     map.current.on('load', () => {
-      addClusterSourceAndLayers(map.current, sitesForMapMarkers)
+      addClusterSourceAndLayers(map.current)
       addClusterEventListeners(map.current, popUpRef, choices)
       handleMapOnWheel(map.current, handleZoomDisplayHelpText)
       setIsMapInitialized(true)
     })
 
-    // clean up on unmount
     return () => {
+      // clean up on unmount
       map.current.remove()
     }
-  }, [sitesForMapMarkers, choices])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const _updateMapMarkers = useEffect(() => {
     if (!map.current || !isMapInitialized) {
@@ -62,9 +62,7 @@ const ProjectSitesMap = ({ sitesForMapMarkers, choices }) => {
 
     const { markersData, bounds } = getMapMarkersFeature(sitesForMapMarkers)
 
-    if (map.current.getSource('mapMarkers') !== undefined) {
-      map.current.getSource('mapMarkers').setData(markersData)
-    }
+    map.current.getSource('mapMarkers')?.setData(markersData)
 
     if (sitesForMapMarkers.length > 0) {
       map.current.fitBounds(bounds, { padding: 25, animate: false })

--- a/src/components/mermaidMap/mapService.js
+++ b/src/components/mermaidMap/mapService.js
@@ -358,12 +358,13 @@ export const handleMapOnWheel = (mapCurrent, handleZoomDisplayHelpText) => {
   })
 }
 
-export const addClusterSourceAndLayers = (map, data) => {
-  const { markersData } = getMapMarkersFeature(data)
-
+export const addClusterSourceAndLayers = (map) => {
   map.addSource('mapMarkers', {
     type: 'geojson',
-    data: markersData,
+    data: {
+      type: 'FeatureCollection',
+      features: [],
+    },
     cluster: true,
     clusterMaxZoom: 14,
     clusterRadius: 50,


### PR DESCRIPTION
[Relates to Ticket 916](https://trello.com/c/55knHtKP/916-cpu-spike-on-sites-page)

Changes:
- Updated `addClusterSourceAndLayers` to initialize with an empty array of features instead of `sitesForMapMarkers`.
  - This is because we have a `useEffect` that updates the source data based on the value of `sitesForMapMarkers`.
- Updated the dependencies for the `_initializeMap` `useEffect`. 
  - Previously it was using `sitesForMapMarkers` as a dependency, this was causing the entire map to re-render whenever the user would submit a query. 
  - Now, the `useEffect` only runs when our page loads, and the `_updateMapMarkers` `useEffect` handles the query.
- Removed the `sourcedata` event.
  - This was causing the infinite re-render as explained in the ticket linked above. Instead we handle updating the markers through a `useEffect` that is dependent on `sitesForMapMarkers`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined map initialization process and marker updates for improved performance.
  - Removed unused `usePrevious` hook.
  - Simplified internal logic of functions to reduce code complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->