### PR TITLE
[776] ACA layer bug

### DIFF
--- a/src/components/mermaidMap/ProjectSitesMap/ProjectSitesMap.js
+++ b/src/components/mermaidMap/ProjectSitesMap/ProjectSitesMap.js
@@ -13,6 +13,7 @@ import {
   handleMapOnWheel,
   addClusterSourceAndLayers,
   addClusterEventListeners,
+  loadACALayers,
 } from '../mapService'
 import { MapContainer, MiniMapContainer, MapWrapper, MapZoomHelpMessage } from '../Map.styles'
 import MiniMap from '../MiniMap'
@@ -46,6 +47,7 @@ const ProjectSitesMap = ({ sitesForMapMarkers, choices }) => {
       addClusterSourceAndLayers(map.current)
       addClusterEventListeners(map.current, popUpRef, choices)
       handleMapOnWheel(map.current, handleZoomDisplayHelpText)
+      loadACALayers(map.current)
       setIsMapInitialized(true)
     })
 

--- a/src/components/mermaidMap/mapService.js
+++ b/src/components/mermaidMap/mapService.js
@@ -246,37 +246,46 @@ export const loadACALayers = (map) => {
     maxZoom: 22,
   })
 
-  map.addLayer({
-    id: 'atlas-planet',
-    type: 'raster',
-    source: 'atlas-planet',
-    'source-layer': 'planet',
-    paint: {
-      'raster-opacity': rasterOpacityExpression,
+  map.addLayer(
+    {
+      id: 'atlas-planet',
+      type: 'raster',
+      source: 'atlas-planet',
+      'source-layer': 'planet',
+      paint: {
+        'raster-opacity': rasterOpacityExpression,
+      },
     },
-  })
+    'clusters',
+  ) // Add this layer before the clusters layer to prevent overlapping
 
-  map.addLayer({
-    id: 'atlas-geomorphic',
-    type: 'fill',
-    source: 'atlas-geomorphic',
-    'source-layer': 'geomorphic',
-    paint: {
-      'fill-color': geomorphicColorExpression,
-      'fill-opacity': fillGeomorphicOpacityExpression,
+  map.addLayer(
+    {
+      id: 'atlas-geomorphic',
+      type: 'fill',
+      source: 'atlas-geomorphic',
+      'source-layer': 'geomorphic',
+      paint: {
+        'fill-color': geomorphicColorExpression,
+        'fill-opacity': fillGeomorphicOpacityExpression,
+      },
     },
-  })
+    'clusters',
+  )
 
-  map.addLayer({
-    id: 'atlas-benthic',
-    type: 'fill',
-    source: 'atlas-benthic',
-    'source-layer': 'benthic',
-    paint: {
-      'fill-color': benthicColorExpression,
-      'fill-opacity': fillBenthicOpacityExpression,
+  map.addLayer(
+    {
+      id: 'atlas-benthic',
+      type: 'fill',
+      source: 'atlas-benthic',
+      'source-layer': 'benthic',
+      paint: {
+        'fill-color': benthicColorExpression,
+        'fill-opacity': fillBenthicOpacityExpression,
+      },
     },
-  })
+    'clusters',
+  )
 }
 
 export const getMapMarkersFeature = (records) => {


### PR DESCRIPTION
bug fix for ACA layers not showing 

- `loadACALayers` is added on map load
-  clusters layers are added after atlas-planet, atlas-geomorphic, atlas-benthic to prevent layer overlap and ensure visibliity

[trello card](https://trello.com/c/GaCk2wVc/776-not-all-pins-are-shown-on-the-sites-page-map)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Enhanced the map functionality by adding support for loading ACA layers in the Project Sites Map component.
- **Improvements**
    - Improved map layer setup by modifying `map.addLayer` calls to include clustering support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->