### PR TITLE
Feat: Use required dropdown instead of checkbox

### DIFF
--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.js
@@ -142,7 +142,7 @@ const FinanceSolutionModal = ({
         errors.local_enterprise = [{ code: language.error.formValidation.required, id: 'Required' }]
       }
 
-      if (!values.gender_smart === '') {
+      if (values.gender_smart === '') {
         errors.gender_smart = [{ code: language.error.formValidation.required, id: 'Required' }]
       }
 

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.js
@@ -4,14 +4,7 @@ import { OutlinedInput } from '@mui/material'
 
 import language from '../../../../../language'
 import theme from '../../../../../theme'
-import {
-  CheckRadioLabel,
-  CheckRadioWrapper,
-  Input,
-  RequiredIndicator,
-  Select,
-  Textarea,
-} from '../../../../generic/form'
+import { Input, RequiredIndicator, Select, Textarea } from '../../../../generic/form'
 import {
   CustomMenuItem,
   CustomMuiSelect,
@@ -66,6 +59,8 @@ const FinanceSolutionModal = ({
         id: financeSolution?.id,
         used_an_incubator:
           formikValues.used_an_incubator === 'none' ? null : formikValues.used_an_incubator,
+        local_enterprise: formikValues.local_enterprise === 'true',
+        gender_smart: formikValues.gender_smart === 'true',
       }
 
       const existingFinanceSolutions = indicatorSet.finance_solutions
@@ -137,10 +132,18 @@ const FinanceSolutionModal = ({
         errors.sector = [{ code: language.error.formValidation.required, id: 'Required' }]
       }
 
-      if (!values.used_an_incubator) {
+      if (values.used_an_incubator === '') {
         errors.used_an_incubator = [
           { code: language.error.formValidation.required, id: 'Required' },
         ]
+      }
+
+      if (values.local_enterprise === '') {
+        errors.local_enterprise = [{ code: language.error.formValidation.required, id: 'Required' }]
+      }
+
+      if (!values.gender_smart === '') {
+        errors.gender_smart = [{ code: language.error.formValidation.required, id: 'Required' }]
       }
 
       return errors
@@ -265,37 +268,32 @@ const FinanceSolutionModal = ({
           </Select>
         </StyledModalInputRow>
         <StyledModalInputRow>
-          <CheckRadioWrapper>
-            <input
-              id="local-enterprise-input"
-              aria-labelledby="local-enterprise-label"
-              type="checkbox"
-              checked={formik.getFieldProps('local_enterprise').value}
-              onChange={({ target }) => {
-                formik.setFieldValue('local_enterprise', target.checked)
-              }}
-            />
-            <CheckRadioLabel id="local-enterprise-label" htmlFor="local-enterprise-input">
-              {modalLanguage.localEnterprise}
-            </CheckRadioLabel>
-          </CheckRadioWrapper>
+          <label id="local-enterprise-label" htmlFor="local-enterprise-select">
+            {modalLanguage.localEnterprise} <RequiredIndicator />
+          </label>
+          <Select
+            id="local-enterprise-select"
+            aria-labelledby="local-enterprise-label"
+            {...formik.getFieldProps('local_enterprise')}
+          >
+            <option value="">{language.placeholders.select}</option>
+            <option value="true">{modalLanguage.yes}</option>
+            <option value="false">{modalLanguage.no}</option>
+          </Select>
         </StyledModalInputRow>
         <StyledModalInputRow>
-          <CheckRadioWrapper>
-            <input
-              id="gender-smart-input"
-              aria-labelledby="gender-smart-label"
-              type="checkbox"
-              checked={formik.getFieldProps('gender_smart').value}
-              onChange={({ target }) => {
-                formik.setFieldValue('gender_smart', target.checked)
-              }}
-            />
-
-            <CheckRadioLabel id="gender-smart-label" htmlFor="gender-smart-input">
-              {modalLanguage.genderSmart}
-            </CheckRadioLabel>
-          </CheckRadioWrapper>
+          <label id="gender-smart-label" htmlFor="gender-smart-select">
+            {modalLanguage.genderSmart} <RequiredIndicator />
+          </label>
+          <Select
+            id="gender-smart-select"
+            aria-labelledby="gender-smart-label"
+            {...formik.getFieldProps('gender_smart')}
+          >
+            <option value="">{language.placeholders.select}</option>
+            <option value="true">{modalLanguage.yes}</option>
+            <option value="false">{modalLanguage.no}</option>
+          </Select>
         </StyledModalInputRow>
         <StyledModalInputRow>
           <label

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/RevenueModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/RevenueModal.js
@@ -2,13 +2,7 @@ import PropTypes from 'prop-types'
 import React, { useState, useEffect, useCallback, useMemo } from 'react'
 
 import language from '../../../../../language'
-import {
-  CheckRadioLabel,
-  CheckRadioWrapper,
-  RequiredIndicator,
-  Select,
-  Textarea,
-} from '../../../../generic/form'
+import { RequiredIndicator, Select, Textarea } from '../../../../generic/form'
 import Modal, { RightFooter } from '../../../../generic/Modal/Modal'
 import {
   StyledModalInputRow,
@@ -59,6 +53,7 @@ const RevenueModal = ({
       const formattedValues = {
         ...formikValues,
         id: revenue?.id,
+        sustainable_revenue_stream: formikValues.sustainable_revenue_stream === 'true',
       }
 
       // Find the finance solution with the id which matches revenue.finance_solution
@@ -141,6 +136,12 @@ const RevenueModal = ({
 
       if (!values.revenue_type) {
         errors.revenue_type = [{ code: language.error.formValidation.required, id: 'Required' }]
+      }
+
+      if (values.sustainable_revenue_stream === '') {
+        errors.sustainable_revenue_stream = [
+          { code: language.error.formValidation.required, id: 'Required' },
+        ]
       }
 
       if (values.annual_revenue === '') {
@@ -266,23 +267,18 @@ const RevenueModal = ({
           </Select>
         </StyledModalInputRow>
         <StyledModalInputRow>
-          <CheckRadioWrapper>
-            <input
-              id="sustainable-revenue-stream-input"
-              aria-labelledby="sustainable-revenue-stream-label"
-              type="checkbox"
-              checked={formik.getFieldProps('sustainable_revenue_stream').value}
-              onChange={({ target }) => {
-                formik.setFieldValue('sustainable_revenue_stream', target.checked)
-              }}
-            />
-            <CheckRadioLabel
-              id="sustainable-revenue-stream-label"
-              htmlFor="sustainable-revenue-stream-input"
-            >
-              {modalLanguage.sustainableRevenueStream}
-            </CheckRadioLabel>
-          </CheckRadioWrapper>
+          <label id="sustainable-revenue-stream-label" htmlFor="sustainable-revenue-stream-select">
+            {modalLanguage.sustainableRevenueStream} <RequiredIndicator />
+          </label>
+          <Select
+            id="sustainable-revenue-stream-select"
+            aria-labelledby="sustainable-revenue-stream-label"
+            {...formik.getFieldProps('sustainable_revenue_stream')}
+          >
+            <option value="">{language.placeholders.select}</option>
+            <option value="true">{modalLanguage.yes}</option>
+            <option value="false">{modalLanguage.no}</option>
+          </Select>
         </StyledModalInputRow>
         <StyledModalInputRow>
           <label id="annual-revenue-label" htmlFor="annual-revenue-input">

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/financeSolutionInitialValues.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/financeSolutionInitialValues.js
@@ -2,8 +2,8 @@ const getFinanceSolutionInitialValues = (financeSolution) => {
   const {
     name = '',
     sector = '',
-    gender_smart = false,
-    local_enterprise = false,
+    gender_smart = '',
+    local_enterprise = '',
     sustainable_finance_mechanisms = [],
     notes = '',
   } = financeSolution || {}

--- a/src/language.js
+++ b/src/language.js
@@ -276,6 +276,8 @@ const gfcrFinanceSolutionModal = {
   cancel: 'Cancel',
   remove: 'Remove Row',
   none: 'None',
+  yes: 'Yes',
+  no: 'No',
 }
 
 const gfcrInvestmentModal = {
@@ -306,6 +308,8 @@ const gfcrRevenueModal = {
   cancel: 'Cancel',
   remove: 'Remove Row',
   none: 'None',
+  yes: 'Yes',
+  no: 'No',
 }
 
 const clearSizeValuesModal = {


### PR DESCRIPTION
Applied to Finance Solution and Revenue Stream modals.

Ref: https://trello.com/c/j4ywl8rK/853-use-a-required-dropdown-for-checkboxes-with-yes-no-options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added new form fields for `local_enterprise` and `gender_smart` in the Finance Solution Modal.

- **Enhancements**
    - Updated the `sustainable_revenue_stream` field in Revenue Modal to use a `Select` component with 'Yes' and 'No' options for improved user experience.

- **Bug Fixes**
    - Initial values for `gender_smart` and `local_enterprise` are now set to empty strings instead of `false` to ensure proper form handling.

- **Localization**
    - Added 'yes' and 'no' translations to support new form fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->