### PR TITLE
Feat: Update GFCR Indicator Set Callout in Project Info.

### DIFF
--- a/src/components/GfcrCallout/GfcrCallout.js
+++ b/src/components/GfcrCallout/GfcrCallout.js
@@ -1,16 +1,27 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { ButtonPrimary, ButtonSecondary } from '../generic/buttons'
+import { ButtonCaution, ButtonPrimary, ButtonSecondary } from '../generic/buttons'
 import { IconCloseCircle, IconGfcr } from '../icons'
 import language from '../../language'
 import theme from '../../theme'
+import { useNavigate } from 'react-router-dom'
+import useCurrentProjectPath from '../../library/useCurrentProjectPath'
+import Modal, { RightFooter } from '../generic/Modal/Modal'
+
+const mermaidDashboardLink = process.env.REACT_APP_MERMAID_DASHBOARD_LINK
+const { gfcrCallout: gfcrCalloutLanguage } = language.pages.projectInfo
 
 const StyledGfcrCallout = styled('div')`
   padding: 10px;
   margin-bottom: 1em;
   background-color: ${theme.color.grey5};
+`
+
+const StyledGfcrEnableButtonsContainer = styled('div')`
+  display: flex;
+  gap: 2rem;
 `
 
 const buttonStyle = `
@@ -37,7 +48,7 @@ const StyledIconCloseCircle = styled(IconCloseCircle)`
   ${iconStyle}
 `
 
-const StyledIconIconGfcr = styled(IconGfcr)`
+const StyledIconGfcr = styled(IconGfcr)`
   ${iconStyle}
 `
 
@@ -45,31 +56,103 @@ const StyledParagraph = styled('p')`
   max-width: ${theme.spacing.maxTextWidth};
 `
 
-const GfcrCallout = ({ isGfcr = false, handleUpdateIncludesGfcr }) => {
-  return (
-    <StyledGfcrCallout>
-      <h3>{language.pages.projectInfo.gfcrCalloutHeading}</h3>
-      {isGfcr ? (
-        <>
-          <StyledParagraph>{language.pages.projectInfo.gfcrRemoveParagraph}</StyledParagraph>
-          <StyledButtonSecondary type="button" onClick={() => handleUpdateIncludesGfcr(false)}>
-            <StyledIconCloseCircle inline={true} /> {language.pages.projectInfo.gfcrRemoveButton}
-          </StyledButtonSecondary>
-        </>
-      ) : (
-        <>
-          <StyledParagraph>{language.pages.projectInfo.gfcrAddParagraph}</StyledParagraph>
-          <StyledButtonPrimary type="button" onClick={() => handleUpdateIncludesGfcr(true)}>
-            <StyledIconIconGfcr /> {language.pages.projectInfo.gfcrAddButton}
-          </StyledButtonPrimary>
-        </>
-      )}
-    </StyledGfcrCallout>
+const DisableIndicatorsModal = ({ isOpen = false, disableGfcr, onDismiss }) => {
+  const footerContent = (
+    <RightFooter>
+      <ButtonSecondary onClick={onDismiss}>{'Cancel'}</ButtonSecondary>
+      <ButtonCaution
+        onClick={() => {
+          disableGfcr()
+          onDismiss()
+        }}
+      >
+        {gfcrCalloutLanguage.disableButton}
+      </ButtonCaution>
+    </RightFooter>
   )
+
+  const content = (
+    <>
+      Disabling GFCR Indicators for this project will not delete them, but just hide them from the{' '}
+      <a href={mermaidDashboardLink} target="_blank" rel="noreferrer">
+        Global Dashboard
+      </a>
+      . No data will be lost. You can re-enable them at any time.
+    </>
+  )
+
+  return (
+    <Modal
+      title={gfcrCalloutLanguage.disableButton}
+      isOpen={isOpen}
+      onDismiss={onDismiss}
+      mainContent={content}
+      footerContent={footerContent}
+    />
+  )
+}
+
+const GfcrCallout = ({ isGfcr = false, isLoading = false, handleUpdateIncludesGfcr }) => {
+  const navigate = useNavigate()
+  const currentProjectPath = useCurrentProjectPath()
+
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  return (
+    <>
+      <StyledGfcrCallout>
+        <h3>{gfcrCalloutLanguage.calloutHeading}</h3>
+        {isGfcr ? (
+          <>
+            <StyledParagraph>{gfcrCalloutLanguage.removeParagraph}</StyledParagraph>
+            <StyledGfcrEnableButtonsContainer>
+              <StyledButtonPrimary
+                type="button"
+                disabled={isLoading}
+                onClick={() => navigate(`${currentProjectPath}/gfcr/`)}
+              >
+                <StyledIconGfcr inline={true} /> {gfcrCalloutLanguage.goToButton}
+              </StyledButtonPrimary>
+              <StyledButtonSecondary
+                type="button"
+                disabled={isLoading}
+                onClick={() => setIsModalOpen(true)}
+              >
+                <StyledIconCloseCircle inline={true} /> {gfcrCalloutLanguage.disableButton}
+              </StyledButtonSecondary>
+            </StyledGfcrEnableButtonsContainer>
+          </>
+        ) : (
+          <>
+            <StyledParagraph>{gfcrCalloutLanguage.addParagraph}</StyledParagraph>
+            <StyledButtonPrimary
+              type="button"
+              disabled={isLoading}
+              onClick={() => handleUpdateIncludesGfcr(true)}
+            >
+              <StyledIconGfcr /> {gfcrCalloutLanguage.enableButton}
+            </StyledButtonPrimary>
+          </>
+        )}
+      </StyledGfcrCallout>
+      <DisableIndicatorsModal
+        isOpen={isModalOpen}
+        disableGfcr={() => handleUpdateIncludesGfcr(false)}
+        onDismiss={() => setIsModalOpen(false)}
+      />
+    </>
+  )
+}
+
+DisableIndicatorsModal.propTypes = {
+  isOpen: PropTypes.bool,
+  disableGfcr: PropTypes.func.isRequired,
+  onDismiss: PropTypes.func.isRequired,
 }
 
 GfcrCallout.propTypes = {
   isGfcr: PropTypes.bool,
+  isLoading: PropTypes.bool,
   handleUpdateIncludesGfcr: PropTypes.func.isRequired,
 }
 

--- a/src/components/pages/ProjectInfo/ProjectInfo.js
+++ b/src/components/pages/ProjectInfo/ProjectInfo.js
@@ -166,6 +166,7 @@ const ProjectInfo = () => {
   const handleHttpResponseError = useHttpResponseErrorHandler()
   const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
   const isGfcrUserTester = getIsUserGfcrTester(currentUser)
+  const [isUpdatingGfcr, setIsUpdatingGfcr] = useState(false)
   const [projectNameError, setProjectNameError] = useState(false)
   const [isDeletingProject, setIsDeletingProject] = useState(false)
   const [isDeleteProjectModalOpen, setIsDeleteProjectModalOpen] = useState(false)
@@ -329,9 +330,13 @@ const ProjectInfo = () => {
   const updateIncludesGfcr = (includesGfcrValue) => {
     const editedValues = { includes_gfcr: includesGfcrValue }
 
+    setIsUpdatingGfcr(true)
+
     databaseSwitchboardInstance
       .saveProject({ projectId, editedValues })
       .then((updatedProject) => {
+        setIsUpdatingGfcr(false)
+
         setProjectBeingEdited(updatedProject)
 
         if (includesGfcrValue) {
@@ -342,6 +347,8 @@ const ProjectInfo = () => {
         }
       })
       .catch((error) => {
+        setIsUpdatingGfcr(false)
+
         handleHttpResponseError({
           error,
           callback: () => {
@@ -411,6 +418,7 @@ const ProjectInfo = () => {
           <GfcrCallout
             isGfcr={projectBeingEdited?.includes_gfcr}
             handleUpdateIncludesGfcr={updateIncludesGfcr}
+            isLoading={isUpdatingGfcr}
           />
         )}
         <DeleteProjectButton

--- a/src/language.js
+++ b/src/language.js
@@ -423,13 +423,16 @@ const pages = {
     organizations: 'Organizations',
     notes: 'Notes',
     noOrganization: 'This Project has no organizations.',
-    gfcrCalloutHeading: 'Global Fund for Coral Reefs (GFCR)',
-    gfcrRemoveParagraph:
-      'Removing GFCR indicators from this project will not delete them, but just hide them.',
-    gfcrAddParagraph:
-      'GFCR is a global partnership that aims to mobilize resources to support coral reef conservation and restoration projects around the world. ',
-    gfcrRemoveButton: 'Remove GFCR indicators from this project',
-    gfcrAddButton: 'Add GFCR indicators to this project',
+    gfcrCallout: {
+      calloutHeading: 'Global Fund for Coral Reefs (GFCR)',
+      removeParagraph:
+        'Removing GFCR indicators from this project will not delete them, but just hide them.',
+      addParagraph:
+        'GFCR is a global partnership that aims to mobilize resources to support coral reef conservation and restoration projects around the world. ',
+      disableButton: 'Disable GFCR Indicators',
+      enableButton: 'Enable GFCR Indicators for this project',
+      goToButton: 'Go to GFCR Indicators',
+    },
   },
   dataSharing: {
     introductionParagraph: `Given the urgent need for global coral reef conservation, MERMAID is committed to working collectively as a community and using the power of data to help make faster, better decisions. Coral reef monitoring data are collected with the intent of advancing coral reef science and improving management. We recognize the large effort to collect data and your sense of ownership. While not required, we hope you choose to make your data available to fuel new discoveries and inform conservation solutions.`,


### PR DESCRIPTION
Update enable text.
Add button to navigate to GFCR table.
Make disable button secondary.
Confirm disabling GFCR with modal.

Ref: https://trello.com/c/N6m7dSh6/849-make-the-remove-gfcr-indicators-button-smaller-secondary-and-add-a-direct-link-to-the-gfcr-indicators-table-page-from-the-projec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `DisableIndicatorsModal` component to manage GFCR indicator settings.
  - Added loading state management for GFCR updates in the Project Info page, enhancing user feedback.

- **Refactor**
  - Updated the organization of GFCR-related language content for better structure and clarity.

- **Enhancements**
  - Improved GFCR callout functionalities with new buttons and modal support.
  
- **UI/UX Improvements**
  - Added visual and interactive elements to the GFCR callout, enhancing user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->