### PR TITLE
Feat: Update document titles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -64,7 +64,6 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>MERMAID - Marine Ecological Research Management Aid</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/pages/ManagementRegimesOverview/ManagementRegimesOverview.js
+++ b/src/components/pages/ManagementRegimesOverview/ManagementRegimesOverview.js
@@ -39,6 +39,7 @@ import { reactTableNaturalSort } from '../../generic/Table/reactTableNaturalSort
 import { PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
 import MethodsFilterDropDown from '../../MethodsFilterDropDown/MethodsFilterDropDown'
 import FilterIndicatorPill from '../../generic/FilterIndicatorPill/FilterIndicatorPill'
+import useDocumentTitle from '../../../library/useDocumentTitle'
 
 const groupManagementRegimes = (records) => {
   return records.reduce((accumulator, record) => {
@@ -72,6 +73,8 @@ const ManagementRegimesOverview = () => {
   const [methodsFilter, setMethodsFilter] = useState([])
   const isMethodFilterInitializedWithPersistedTablePreferences = useRef(false)
   const [searchFilteredRowsLength, setSearchFilteredRowsLength] = useState(null)
+
+  useDocumentTitle(`${language.pages.managementRegimesOverview.title} - ${language.title.mermaid}`)
 
   const _getSupportingData = useEffect(() => {
     if (!isAppOnline) {

--- a/src/components/pages/UsersAndTransects/UsersAndTransects.js
+++ b/src/components/pages/UsersAndTransects/UsersAndTransects.js
@@ -45,6 +45,7 @@ import CollectSampleUnitPopup from '../../SampleUnitPopups/CollectSampleUnitPopu
 import { PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
 import MethodsFilterDropDown from '../../MethodsFilterDropDown/MethodsFilterDropDown'
 import FilterIndicatorPill from '../../generic/FilterIndicatorPill/FilterIndicatorPill'
+import useDocumentTitle from '../../../library/useDocumentTitle'
 
 const EMPTY_VALUE = '-'
 
@@ -115,6 +116,8 @@ const UsersAndTransects = () => {
   const [methodsFilter, setMethodsFilter] = useState([])
   const isMethodFilterInitializedWithPersistedTablePreferences = useRef(false)
   const [searchFilteredRows, setSearchFilteredRows] = useState([])
+
+  useDocumentTitle(`${language.pages.usersAndTransectsTable.title} - ${language.title.mermaid}`)
 
   const _getSupportingData = useEffect(() => {
     if (!isAppOnline) {

--- a/src/components/pages/gfcrPages/Gfcr/Gfcr.js
+++ b/src/components/pages/gfcrPages/Gfcr/Gfcr.js
@@ -58,7 +58,7 @@ const Gfcr = () => {
   // const closeCopySitesModal = () => setIsCopySitesModalOpen(false)
   const [searchFilteredRowsLength, setSearchFilteredRowsLength] = useState(null)
 
-  useDocumentTitle(`${language.pages.siteTable.title} - ${language.title.mermaid}`)
+  useDocumentTitle(`${language.pages.gfcrTable.title} - ${language.title.mermaid}`)
 
   const _getIndicatorSets = useEffect(() => {
     if (!isAppOnline) {

--- a/src/components/pages/gfcrPages/GfcrIndicatorSet/IndicatorSetTitle.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSet/IndicatorSetTitle.js
@@ -36,7 +36,7 @@ const IndicatorSetTitle = ({ indicatorSetTitle, type, reportingDate, isNew = fal
   useDocumentTitle(
     isNew
       ? language.pages.gfcrIndicatorSet.title
-      : `${indicatorSetTitle} - ${type} - ${reportingYear}`,
+      : `${indicatorSetTitle} ${type} ${reportingYear} - ${language.title.mermaid}`,
   )
 
   if (isNew) {


### PR DESCRIPTION
Applied to Gfcr, Management Regime and Users and Transects tables.

Ref: [M894](https://trello.com/c/5pw6xI1j/894-page-title-is-still-sites-when-on-the-indicator-set-table)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dynamic document titles are now set for Management Regimes Overview, Users and Transects, and GFCR pages, enhancing navigation and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->