### PR TITLE
[923] benthic pit observation table rounding error

### DIFF
--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/benthicPitObservationReducer.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/benthicPitObservationReducer.js
@@ -8,21 +8,17 @@ const benthicPitObservationReducer = (state, action) => {
   }) => {
     const recalculatedObservations = []
     const isIntervalStart = intervalStart !== ''
-    const intervalStartToUse = isIntervalStart ? intervalStart : intervalSize
+    const intervalStartToUse = isIntervalStart ? Number(intervalStart) : 0
+    const intervalSizeToUse = Number(intervalSize)
 
-    if (!intervalSize) {
+    if (!intervalSizeToUse) {
       return observations.map((observation) => ({ ...observation, interval: '-' }))
     }
 
     observations.forEach((observation, index) => {
-      const previousObservation = recalculatedObservations[index - 1]
-      const interval = !previousObservation
-        ? Number(intervalStartToUse).toFixed(1)
-        : (Number(previousObservation.interval) + Number(intervalSize)).toFixed(1)
-
+      const interval = (intervalStartToUse + intervalSizeToUse * index).toFixed(2)
       recalculatedObservations.push({ ...observation, interval })
     })
-
     return recalculatedObservations
   }
 

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/benthicPitObservationReducer.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/benthicPitObservationReducer.js
@@ -10,13 +10,16 @@ const benthicPitObservationReducer = (state, action) => {
     const isIntervalStart = intervalStart !== ''
     const intervalStartToUse = isIntervalStart ? Number(intervalStart) : 0
     const intervalSizeToUse = Number(intervalSize)
+    const formatInterval = (interval) => {
+      return interval % 1 === 0 ? interval.toFixed(1) : interval.toFixed(2)
+    }
 
     if (!intervalSizeToUse) {
       return observations.map((observation) => ({ ...observation, interval: '-' }))
     }
 
     observations.forEach((observation, index) => {
-      const interval = (intervalStartToUse + intervalSizeToUse * index).toFixed(2)
+      const interval = formatInterval(intervalStartToUse + intervalSizeToUse * index)
       recalculatedObservations.push({ ...observation, interval })
     })
     return recalculatedObservations


### PR DESCRIPTION
[trello card](https://trello.com/c/XjHiORpB/923-benthic-pit-observation-interval-rounding-error)

this fix ensures that `intervalStart` and `intervalSize` are correctly passed as numbers to  `getObservationsWithRecalculatedIntervals`, in addition to interval formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced interval calculations for more accurate data handling.
	- Added a formatting feature for interval values, ensuring consistent display.

- **Improvements**
	- Improved type safety by converting interval values to numbers.
	- Streamlined the logic for interval calculations, simplifying the control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->