### PR TITLE
[776] add overflow y to atlas container

### DIFF
--- a/src/components/mermaidMap/AtlasLegendDrawer/AtlasLegendDrawer.styles.js
+++ b/src/components/mermaidMap/AtlasLegendDrawer/AtlasLegendDrawer.styles.js
@@ -5,6 +5,8 @@ import theme from '../../../theme'
 export const SliderContainer = styled.div`
   position: absolute;
   width: 270px;
+  overflow-y: auto;
+  height: 66vh;
   right: ${(props) => (props.isOpen ? '0px' : '-270px')};
   background: ${(props) => props.isOpen && 'rgba(255, 255, 255, 1)'};
   top: 1px;


### PR DESCRIPTION
small fix to add vertical scroll on atlas container - mentioned on [this trello card](https://trello.com/c/GaCk2wVc/776-not-all-pins-are-shown-on-the-sites-page-map)

to test:

1. go to sites. 
2. scroll down to sites map
3. adjust browser height so it's shorter, and cuts of atlas container div
4. scroll vertically to see all items in checked lest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the slider container with vertical scrolling for improved usability.
	- Set the slider container height to 66% of the viewport height for better responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->