### PR TITLE
Feat: Add helper text to finance modals

### DIFF
--- a/src/components/mermaidInputs/InputNoRowSelectWithLabelAndValidation/InputNoRowSelectWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputNoRowSelectWithLabelAndValidation/InputNoRowSelectWithLabelAndValidation.js
@@ -1,0 +1,132 @@
+import React, { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import PropTypes from 'prop-types'
+import { getProjectIdFromLocation } from '../../../library/getProjectIdFromLocation'
+import {
+  IconContainer,
+  Select,
+  HelperText,
+  InputContainer,
+  LabelContainer,
+  RequiredIndicator,
+} from '../../generic/form'
+import { inputOptionsPropTypes } from '../../../library/miscPropTypes'
+import InputValidationInfo from '../InputValidationInfo/InputValidationInfo'
+import mermaidInputsPropTypes from '../mermaidInputsPropTypes'
+import { IconButton } from '../../generic/buttons'
+import { ViewLink } from '../../generic/links'
+import { IconInfo, IconSites, IconMgmt } from '../../icons'
+import language from '../../../language'
+
+const InputNoRowSelectWithLabelAndValidation = ({
+  label,
+  id,
+  required,
+  options,
+  helperText = undefined,
+  validationMessages = [],
+  ignoreNonObservationFieldValidations = () => {},
+  resetNonObservationFieldValidations = () => {},
+  validationType = undefined,
+  value = '',
+  updateValueAndResetValidationForDuplicateWarning = () => {},
+  displayViewLink = false,
+  showHelperText = false,
+  ...restOfProps
+}) => {
+  const [internalShowHelperText, setInternalShowHelperText] = useState()
+
+  useEffect(() => {
+    setInternalShowHelperText(showHelperText)
+  }, [showHelperText])
+
+  const location = useLocation()
+
+  const projectId = getProjectIdFromLocation(location)
+
+  const optionList = options.map((item) => (
+    <option key={item.value} value={item.value}>
+      {item.label}
+    </option>
+  ))
+
+  const handleInfoIconClick = (event) => {
+    setInternalShowHelperText(!internalShowHelperText)
+
+    event.stopPropagation()
+  }
+
+  const linkToSiteOrMR = `/projects/${projectId}/${
+    label === 'Site' ? 'sites' : 'management-regimes'
+  }/${value}`
+
+  return (
+    <>
+      <LabelContainer>
+        <label id={`aria-label${id}`} htmlFor={id}>
+          {label}
+        </label>
+        <span>{required ? <RequiredIndicator /> : null}</span>
+        {helperText ? (
+          <IconButton type="button" onClick={(event) => handleInfoIconClick(event, label)}>
+            <IconInfo aria-label="info" />
+          </IconButton>
+        ) : null}
+      </LabelContainer>
+
+      <div>
+        <InputContainer>
+          <Select
+            aria-labelledby={`aria-label${id}`}
+            aria-describedby={`aria-descp${id}`}
+            id={id}
+            value={value}
+            {...restOfProps}
+          >
+            <option value="">{language.placeholders.select}</option>
+            {optionList}
+          </Select>
+
+          {displayViewLink ? (
+            <ViewLink disabled={!value} href={linkToSiteOrMR}>
+              <IconContainer>{label === 'Site' ? <IconSites /> : <IconMgmt />}</IconContainer>
+              {language.pages.collectRecord.viewLink}
+            </ViewLink>
+          ) : null}
+        </InputContainer>
+        {showHelperText || internalShowHelperText ? (
+          <HelperText id={`aria-descp${id}`}>{helperText}</HelperText>
+        ) : null}
+      </div>
+      <InputValidationInfo
+        ignoreNonObservationFieldValidations={ignoreNonObservationFieldValidations}
+        resetNonObservationFieldValidations={resetNonObservationFieldValidations}
+        validationMessages={validationMessages}
+        validationType={validationType}
+        currentSelectValue={value}
+        updateValueAndResetValidationForDuplicateWarning={
+          updateValueAndResetValidationForDuplicateWarning
+        }
+      />
+    </>
+  )
+}
+
+InputNoRowSelectWithLabelAndValidation.propTypes = {
+  displayViewLink: PropTypes.bool,
+  helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  id: PropTypes.string.isRequired,
+  required: PropTypes.bool.isRequired,
+  ignoreNonObservationFieldValidations: PropTypes.func,
+  label: PropTypes.string.isRequired,
+  options: inputOptionsPropTypes.isRequired,
+  resetNonObservationFieldValidations: PropTypes.func,
+  testId: PropTypes.string,
+  value: PropTypes.string,
+  validationMessages: mermaidInputsPropTypes.validationMessagesPropType,
+  validationType: PropTypes.string,
+  updateValueAndResetValidationForDuplicateWarning: PropTypes.func,
+  showHelperText: PropTypes.bool,
+}
+
+export default InputNoRowSelectWithLabelAndValidation

--- a/src/components/mermaidInputs/InputNoRowSelectWithLabelAndValidation/index.js
+++ b/src/components/mermaidInputs/InputNoRowSelectWithLabelAndValidation/index.js
@@ -1,0 +1,3 @@
+import InputNoRowSelectWithLabelAndValidation from './InputNoRowSelectWithLabelAndValidation'
+
+export default InputNoRowSelectWithLabelAndValidation

--- a/src/components/mermaidInputs/InputNoRowWithLabelAndValidation/InputNoRowWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputNoRowWithLabelAndValidation/InputNoRowWithLabelAndValidation.js
@@ -1,0 +1,124 @@
+import React, { useEffect, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
+
+import {
+  Input,
+  InputContainer,
+  HelperText,
+  LabelContainer,
+  RequiredIndicator,
+} from '../../generic/form'
+import { useStopInputScrollingIncrementNumber } from '../../../library/useStopInputScrollingIncrementNumber'
+import InputNumberNoScrollWithUnit from '../../generic/InputNumberNoScrollWithUnit'
+
+import InputValidationInfo from '../InputValidationInfo/InputValidationInfo'
+import mermaidInputsPropTypes from '../mermaidInputsPropTypes'
+import { IconButton } from '../../generic/buttons'
+import { IconInfo } from '../../icons'
+
+const InputNoRowWithLabelAndValidation = ({
+  required = false,
+  helperText = undefined,
+  id,
+  ignoreNonObservationFieldValidations = () => {},
+  label,
+  resetNonObservationFieldValidations = () => {},
+  unit = undefined,
+  validationMessages = [],
+  validationType = undefined,
+  renderItemWithinInput = undefined,
+  renderItemAboveInput = undefined,
+  isInputDisabled = false,
+  showHelperText = false,
+
+  ...restOfProps
+}) => {
+  const textFieldRef = useRef()
+
+  useStopInputScrollingIncrementNumber(textFieldRef)
+
+  const [internalShowHelperText, setInternalShowHelperText] = useState()
+
+  useEffect(() => {
+    setInternalShowHelperText(showHelperText)
+  }, [showHelperText])
+
+  const handleInfoIconClick = (event) => {
+    setInternalShowHelperText(!internalShowHelperText)
+
+    event.stopPropagation()
+  }
+
+  const inputType = unit ? (
+    <InputNumberNoScrollWithUnit
+      aria-labelledby={`aria-label${id}`}
+      aria-describedby={`aria-descp${id}`}
+      id={id}
+      unit={unit}
+      disabled={isInputDisabled}
+      {...restOfProps}
+    />
+  ) : (
+    <Input
+      aria-labelledby={`aria-label${id}`}
+      aria-describedby={`aria-descp${id}`}
+      id={id}
+      {...restOfProps}
+      ref={textFieldRef}
+    />
+  )
+
+  return (
+    <>
+      <LabelContainer>
+        <label id={`aria-label${id}`} htmlFor={id}>
+          {label}
+        </label>
+        <span>{required ? <RequiredIndicator /> : null}</span>
+        {helperText ? (
+          <IconButton type="button" onClick={(event) => handleInfoIconClick(event, label)}>
+            <IconInfo aria-label="info" />
+          </IconButton>
+        ) : null}
+      </LabelContainer>
+
+      <div>
+        {renderItemAboveInput || null}
+        <InputContainer>
+          {inputType}
+
+          {renderItemWithinInput || null}
+        </InputContainer>
+        {showHelperText || internalShowHelperText ? (
+          <HelperText id={`aria-descp${id}`}>{helperText}</HelperText>
+        ) : null}
+      </div>
+
+      <InputValidationInfo
+        validationType={validationType}
+        validationMessages={validationMessages}
+        ignoreNonObservationFieldValidations={ignoreNonObservationFieldValidations}
+        resetNonObservationFieldValidations={resetNonObservationFieldValidations}
+      />
+    </>
+  )
+}
+
+InputNoRowWithLabelAndValidation.propTypes = {
+  required: PropTypes.bool,
+  helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  showHelperText: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  isInputDisabled: PropTypes.bool,
+  ignoreNonObservationFieldValidations: PropTypes.func,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  renderItemAboveInput: PropTypes.node,
+  renderItemWithinInput: PropTypes.node,
+  resetNonObservationFieldValidations: PropTypes.func,
+  testId: PropTypes.string,
+  unit: PropTypes.string,
+  validationMessages: mermaidInputsPropTypes.validationMessagesPropType,
+  validationType: PropTypes.string,
+}
+
+export default InputNoRowWithLabelAndValidation

--- a/src/components/mermaidInputs/InputNoRowWithLabelAndValidation/index.js
+++ b/src/components/mermaidInputs/InputNoRowWithLabelAndValidation/index.js
@@ -1,0 +1,3 @@
+import InputNoRowWithLabelAndValidation from './InputNoRowWithLabelAndValidation'
+
+export default InputNoRowWithLabelAndValidation

--- a/src/components/mermaidInputs/InputSelectWithLabelAndValidation/InputSelectWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputSelectWithLabelAndValidation/InputSelectWithLabelAndValidation.js
@@ -1,23 +1,9 @@
-import React, { useState } from 'react'
-import { useLocation } from 'react-router-dom'
+import React from 'react'
 import PropTypes from 'prop-types'
-import { getProjectIdFromLocation } from '../../../library/getProjectIdFromLocation'
-import {
-  IconContainer,
-  InputRow,
-  Select,
-  HelperText,
-  InputContainer,
-  LabelContainer,
-  RequiredIndicator,
-} from '../../generic/form'
+import { InputRow } from '../../generic/form'
 import { inputOptionsPropTypes } from '../../../library/miscPropTypes'
-import InputValidationInfo from '../InputValidationInfo/InputValidationInfo'
 import mermaidInputsPropTypes from '../mermaidInputsPropTypes'
-import { IconButton } from '../../generic/buttons'
-import { ViewLink } from '../../generic/links'
-import { IconInfo, IconSites, IconMgmt } from '../../icons'
-import language from '../../../language'
+import InputNoRowSelectWithLabelAndValidation from '../InputNoRowSelectWithLabelAndValidation'
 
 const InputSelectWithLabelAndValidation = ({
   label,
@@ -33,76 +19,29 @@ const InputSelectWithLabelAndValidation = ({
   value = '',
   updateValueAndResetValidationForDuplicateWarning = () => {},
   displayViewLink = false,
+  showHelperText = false,
   ...restOfProps
 }) => {
-  const [isHelperTextShowing, setIsHelperTextShowing] = useState(false)
-
-  // const navigate = useNavigate()
-  const location = useLocation()
-
-  const projectId = getProjectIdFromLocation(location)
-
-  const optionList = options.map((item) => (
-    <option key={item.value} value={item.value}>
-      {item.label}
-    </option>
-  ))
-
-  const handleInfoIconClick = (event) => {
-    isHelperTextShowing ? setIsHelperTextShowing(false) : setIsHelperTextShowing(true)
-
-    event.stopPropagation()
-  }
-
-  const linkToSiteOrMR = `/projects/${projectId}/${
-    label === 'Site' ? 'sites' : 'management-regimes'
-  }/${value}`
-
   return (
     <InputRow validationType={validationType} data-testid={testId}>
-      <LabelContainer>
-        <label id={`aria-label${id}`} htmlFor={id}>
-          {label}
-        </label>
-        <span>{required ? <RequiredIndicator /> : null}</span>
-        {helperText ? (
-          <IconButton type="button" onClick={(event) => handleInfoIconClick(event, label)}>
-            <IconInfo aria-label="info" />
-          </IconButton>
-        ) : null}
-      </LabelContainer>
-
-      <div>
-        <InputContainer>
-          <Select
-            aria-labelledby={`aria-label${id}`}
-            aria-describedby={`aria-descp${id}`}
-            id={id}
-            value={value}
-            {...restOfProps}
-          >
-            <option value="">{language.placeholders.select}</option>
-            {optionList}
-          </Select>
-
-          {displayViewLink ? (
-            <ViewLink disabled={!value} href={linkToSiteOrMR}>
-              <IconContainer>{label === 'Site' ? <IconSites /> : <IconMgmt />}</IconContainer>
-              {language.pages.collectRecord.viewLink}
-            </ViewLink>
-          ) : null}
-        </InputContainer>
-        {isHelperTextShowing ? <HelperText id={`aria-descp${id}`}>{helperText}</HelperText> : null}
-      </div>
-      <InputValidationInfo
+      <InputNoRowSelectWithLabelAndValidation
+        label={label}
+        id={id}
+        required={required}
+        options={options}
+        helperText={helperText}
+        validationMessages={validationMessages}
         ignoreNonObservationFieldValidations={ignoreNonObservationFieldValidations}
         resetNonObservationFieldValidations={resetNonObservationFieldValidations}
-        validationMessages={validationMessages}
         validationType={validationType}
-        currentSelectValue={value}
+        testId={testId}
+        value={value}
         updateValueAndResetValidationForDuplicateWarning={
           updateValueAndResetValidationForDuplicateWarning
         }
+        displayViewLink={displayViewLink}
+        showHelperText={showHelperText}
+        {...restOfProps}
       />
     </InputRow>
   )
@@ -122,6 +61,7 @@ InputSelectWithLabelAndValidation.propTypes = {
   validationMessages: mermaidInputsPropTypes.validationMessagesPropType,
   validationType: PropTypes.string,
   updateValueAndResetValidationForDuplicateWarning: PropTypes.func,
+  showHelperText: PropTypes.bool,
 }
 
 export default InputSelectWithLabelAndValidation

--- a/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
+++ b/src/components/mermaidInputs/InputWithLabelAndValidation/InputWithLabelAndValidation.js
@@ -1,21 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
 
-import {
-  Input,
-  InputContainer,
-  InputRow,
-  HelperText,
-  LabelContainer,
-  RequiredIndicator,
-} from '../../generic/form'
+import { InputRow } from '../../generic/form'
 import { useStopInputScrollingIncrementNumber } from '../../../library/useStopInputScrollingIncrementNumber'
-import InputNumberNoScrollWithUnit from '../../generic/InputNumberNoScrollWithUnit'
 
-import InputValidationInfo from '../InputValidationInfo/InputValidationInfo'
 import mermaidInputsPropTypes from '../mermaidInputsPropTypes'
-import { IconButton } from '../../generic/buttons'
-import { IconInfo } from '../../icons'
+import InputNoRowWithLabelAndValidation from '../InputNoRowWithLabelAndValidation'
 
 const InputWithLabelAndValidation = ({
   required = false,
@@ -39,68 +29,24 @@ const InputWithLabelAndValidation = ({
 
   useStopInputScrollingIncrementNumber(textFieldRef)
 
-  const [internalShowHelperText, setInternalShowHelperText] = useState()
-
-  useEffect(() => {
-    setInternalShowHelperText(showHelperText)
-  }, [showHelperText])
-
-  const handleInfoIconClick = (event) => {
-    setInternalShowHelperText(!internalShowHelperText)
-
-    event.stopPropagation()
-  }
-
-  const inputType = unit ? (
-    <InputNumberNoScrollWithUnit
-      aria-labelledby={`aria-label${id}`}
-      aria-describedby={`aria-descp${id}`}
-      id={id}
-      unit={unit}
-      disabled={isInputDisabled}
-      {...restOfProps}
-    />
-  ) : (
-    <Input
-      aria-labelledby={`aria-label${id}`}
-      aria-describedby={`aria-descp${id}`}
-      id={id}
-      {...restOfProps}
-      ref={textFieldRef}
-    />
-  )
-
   return (
     <InputRow required={required} validationType={validationType} data-testid={testId}>
-      <LabelContainer>
-        <label id={`aria-label${id}`} htmlFor={id}>
-          {label}
-        </label>
-        <span>{required ? <RequiredIndicator /> : null}</span>
-        {helperText ? (
-          <IconButton type="button" onClick={(event) => handleInfoIconClick(event, label)}>
-            <IconInfo aria-label="info" />
-          </IconButton>
-        ) : null}
-      </LabelContainer>
-
-      <div>
-        {renderItemAboveInput || null}
-        <InputContainer>
-          {inputType}
-
-          {renderItemWithinInput || null}
-        </InputContainer>
-        {showHelperText || internalShowHelperText ? (
-          <HelperText id={`aria-descp${id}`}>{helperText}</HelperText>
-        ) : null}
-      </div>
-
-      <InputValidationInfo
-        validationType={validationType}
-        validationMessages={validationMessages}
+      <InputNoRowWithLabelAndValidation
+        required={required}
+        helperText={helperText}
+        showHelperText={showHelperText}
+        id={id}
+        isInputDisabled={isInputDisabled}
         ignoreNonObservationFieldValidations={ignoreNonObservationFieldValidations}
+        label={label}
+        renderItemAboveInput={renderItemAboveInput}
+        renderItemWithinInput={renderItemWithinInput}
         resetNonObservationFieldValidations={resetNonObservationFieldValidations}
+        testId={testId}
+        unit={unit}
+        validationMessages={validationMessages}
+        validationType={validationType}
+        {...restOfProps}
       />
     </InputRow>
   )

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/GfcrIndicatorSetForm.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/GfcrIndicatorSetForm.js
@@ -145,6 +145,7 @@ const GfcrIndicatorSetForm = ({
           indicatorSet={indicatorSet}
           setIndicatorSet={setIndicatorSet}
           choices={choices}
+          displayHelp={displayHelp}
         />
       )}
       {selectedNavItem === 'investments' && (
@@ -153,6 +154,7 @@ const GfcrIndicatorSetForm = ({
           setIndicatorSet={setIndicatorSet}
           choices={choices}
           setSelectedNavItem={setSelectedNavItem}
+          displayHelp={displayHelp}
         />
       )}
       {selectedNavItem === 'revenues' && (
@@ -161,6 +163,7 @@ const GfcrIndicatorSetForm = ({
           setIndicatorSet={setIndicatorSet}
           choices={choices}
           setSelectedNavItem={setSelectedNavItem}
+          displayHelp={displayHelp}
         />
       )}
     </>

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.js
@@ -4,7 +4,7 @@ import { Checkbox, OutlinedInput } from '@mui/material'
 
 import language from '../../../../../language'
 import theme from '../../../../../theme'
-import { Input, RequiredIndicator, Select, Textarea } from '../../../../generic/form'
+import { HelperText, Textarea } from '../../../../generic/form'
 import {
   CustomMenuItem,
   CustomMuiSelect,
@@ -19,14 +19,18 @@ import { getFinanceSolutionInitialValues } from './financeSolutionInitialValues'
 import { useFormik } from 'formik'
 import { buttonGroupStates } from '../../../../../library/buttonGroupStates'
 import { choicesPropType } from '../../../../../App/mermaidData/mermaidDataProptypes'
-import { ButtonCaution, ButtonSecondary } from '../../../../generic/buttons'
+import { ButtonCaution, ButtonSecondary, IconButton } from '../../../../generic/buttons'
 import SaveButton from './SaveButton'
-import { getChips, getOptionList } from './modalHelpers'
+import { getChips } from './modalHelpers'
 import { useDatabaseSwitchboardInstance } from '../../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 import { useParams } from 'react-router-dom'
 import { toast } from 'react-toastify'
 import { getToastArguments } from '../../../../../library/getToastArguments'
 import { useHttpResponseErrorHandler } from '../../../../../App/HttpResponseErrorHandlerContext'
+import InputNoRowWithLabelAndValidation from '../../../../mermaidInputs/InputNoRowWithLabelAndValidation'
+import InputNoRowSelectWithLabelAndValidation from '../../../../mermaidInputs/InputNoRowSelectWithLabelAndValidation'
+import { getOptions } from '../../../../../library/getOptions'
+import { IconInfo } from '../../../../icons'
 
 const modalLanguage = language.gfcrFinanceSolutionModal
 
@@ -37,6 +41,7 @@ const FinanceSolutionModal = ({
   indicatorSet,
   setIndicatorSet,
   choices,
+  displayHelp,
 }) => {
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
   const { projectId } = useParams()
@@ -199,6 +204,18 @@ const FinanceSolutionModal = ({
 
   const _setIsFormDirty = useEffect(() => setIsFormDirty(!!formik.dirty), [formik.dirty])
 
+  const [SFMShowHelperText, setSFMShowHelperText] = useState()
+
+  useEffect(() => {
+    setSFMShowHelperText(displayHelp)
+  }, [displayHelp])
+
+  const handleSFMInfoIconClick = (event) => {
+    setSFMShowHelperText(!SFMShowHelperText)
+
+    event.stopPropagation()
+  }
+
   const cancelButton = (
     <ButtonSecondary type="button" onClick={() => onDismiss(formik.resetForm)}>
       {modalLanguage.cancel}
@@ -231,69 +248,70 @@ const FinanceSolutionModal = ({
     return (
       <form id="finance-solution-form" onSubmit={formik.handleSubmit}>
         <StyledModalInputRow>
-          <label id="finance-solution-label" htmlFor="finance-solution-input">
-            {modalLanguage.name} <RequiredIndicator />
-          </label>
-          <Input
+          <InputNoRowWithLabelAndValidation
+            label={modalLanguage.name}
             id="finance-solution-input"
-            aria-labelledby="finance-solution-label"
+            type="text"
             {...formik.getFieldProps('name')}
+            helperText={modalLanguage.getNameHelper()}
+            showHelperText={displayHelp}
+            required={true}
           />
         </StyledModalInputRow>
         <StyledModalInputRow>
-          <label id="sector-label" htmlFor="sector-select">
-            {modalLanguage.sector} <RequiredIndicator />
-          </label>
-          <Select
+          <InputNoRowSelectWithLabelAndValidation
+            label={modalLanguage.sector}
             id="sector-select"
-            aria-labelledby="sector-label"
             {...formik.getFieldProps('sector')}
-          >
-            <option value="">{language.placeholders.select}</option>
-            {getOptionList(choices.sectors.data)}
-          </Select>
+            options={getOptions(choices.sectors.data)}
+            helperText={modalLanguage.getSectorHelper()}
+            showHelperText={displayHelp}
+            required={true}
+          />
         </StyledModalInputRow>
         <StyledModalInputRow>
-          <label id="used-an-incubator-label" htmlFor="used-an-incubator-select">
-            {modalLanguage.usedAnIncubator} <RequiredIndicator />
-          </label>
-          <Select
+          <InputNoRowSelectWithLabelAndValidation
+            label={modalLanguage.usedAnIncubator}
             id="used-an-incubator-select"
-            aria-labelledby="used-an-incubator-label"
             {...formik.getFieldProps('used_an_incubator')}
-          >
-            <option value="">{language.placeholders.select}</option>
-            <option value="none">{modalLanguage.none}</option>
-            {getOptionList(choices.incubatortypes.data)}
-          </Select>
+            options={[
+              { value: 'none', label: modalLanguage.none },
+              ...getOptions(choices.incubatortypes.data),
+            ]}
+            helperText={modalLanguage.getUsedAnIncubatorHelper()}
+            showHelperText={displayHelp}
+            required={true}
+          />
         </StyledModalInputRow>
         <StyledModalInputRow>
-          <label id="local-enterprise-label" htmlFor="local-enterprise-select">
-            {modalLanguage.localEnterprise} <RequiredIndicator />
-          </label>
-          <Select
+          <InputNoRowSelectWithLabelAndValidation
+            label={modalLanguage.localEnterprise}
             id="local-enterprise-select"
-            aria-labelledby="local-enterprise-label"
             {...formik.getFieldProps('local_enterprise')}
-          >
-            <option value="">{language.placeholders.select}</option>
-            <option value="true">{modalLanguage.yes}</option>
-            <option value="false">{modalLanguage.no}</option>
-          </Select>
+            options={[
+              { value: 'none', label: modalLanguage.none },
+              { value: 'true', label: modalLanguage.yes },
+              { value: 'false', label: modalLanguage.no },
+            ]}
+            helperText={modalLanguage.getLocalEnterpriseHelper()}
+            showHelperText={displayHelp}
+            required={true}
+          />
         </StyledModalInputRow>
         <StyledModalInputRow>
-          <label id="gender-smart-label" htmlFor="gender-smart-select">
-            {modalLanguage.genderSmart} <RequiredIndicator />
-          </label>
-          <Select
+          <InputNoRowSelectWithLabelAndValidation
+            label={modalLanguage.genderSmart}
             id="gender-smart-select"
-            aria-labelledby="gender-smart-label"
             {...formik.getFieldProps('gender_smart')}
-          >
-            <option value="">{language.placeholders.select}</option>
-            <option value="true">{modalLanguage.yes}</option>
-            <option value="false">{modalLanguage.no}</option>
-          </Select>
+            options={[
+              { value: 'none', label: modalLanguage.none },
+              { value: 'true', label: modalLanguage.yes },
+              { value: 'false', label: modalLanguage.no },
+            ]}
+            helperText={modalLanguage.getGenderSmartHelper()}
+            showHelperText={displayHelp}
+            required={true}
+          />
         </StyledModalInputRow>
         <StyledModalInputRow>
           <label
@@ -301,6 +319,9 @@ const FinanceSolutionModal = ({
             htmlFor="sustainable-finance-mechanisms-select"
           >
             {modalLanguage.sustainableFinanceMechanisms}
+            <IconButton type="button" onClick={(event) => handleSFMInfoIconClick(event)}>
+              <IconInfo aria-label="info" />
+            </IconButton>
           </label>
           <CustomMuiSelect
             id="sustainable-finance-mechanisms-select"
@@ -330,6 +351,11 @@ const FinanceSolutionModal = ({
               </CustomMenuItem>
             ))}
           </CustomMuiSelect>
+          {displayHelp || SFMShowHelperText ? (
+            <HelperText id="sfm-helper">
+              {modalLanguage.getSustainableFinanceMechanismsHelper()}
+            </HelperText>
+          ) : null}
         </StyledModalInputRow>
         <hr />
         <StyledModalInputRow>
@@ -367,6 +393,7 @@ FinanceSolutionModal.propTypes = {
   financeSolution: PropTypes.object,
   isOpen: PropTypes.bool.isRequired,
   onDismiss: PropTypes.func.isRequired,
+  displayHelp: PropTypes.bool,
 }
 
 export default FinanceSolutionModal

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/InvestmentModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/InvestmentModal.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React, { useState, useEffect, useCallback, useMemo } from 'react'
 
 import language from '../../../../../language'
-import { RequiredIndicator, Select, Textarea } from '../../../../generic/form'
+import { Textarea } from '../../../../generic/form'
 import Modal, { RightFooter } from '../../../../generic/Modal/Modal'
 import {
   StyledModalInputRow,
@@ -14,14 +14,15 @@ import { buttonGroupStates } from '../../../../../library/buttonGroupStates'
 import { choicesPropType } from '../../../../../App/mermaidData/mermaidDataProptypes'
 import { ButtonCaution, ButtonSecondary } from '../../../../generic/buttons'
 import SaveButton from './SaveButton'
-import { getOptionList } from './modalHelpers'
 import { getInvestmentInitialValues } from './investmentInitialValues'
-import InputNumberNoScrollWithUnit from '../../../../generic/InputNumberNoScrollWithUnit'
 import { useDatabaseSwitchboardInstance } from '../../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 import { useParams } from 'react-router-dom'
 import { useHttpResponseErrorHandler } from '../../../../../App/HttpResponseErrorHandlerContext'
 import { toast } from 'react-toastify'
 import { getToastArguments } from '../../../../../library/getToastArguments'
+import InputNoRowSelectWithLabelAndValidation from '../../../../mermaidInputs/InputNoRowSelectWithLabelAndValidation'
+import { getOptions } from '../../../../../library/getOptions'
+import InputNoRowWithLabelAndValidation from '../../../../mermaidInputs/InputNoRowWithLabelAndValidation'
 
 const modalLanguage = language.gfcrInvestmentModal
 
@@ -33,6 +34,7 @@ const InvestmentModal = ({
   investment = undefined,
   choices,
   financeSolutions,
+  displayHelp,
 }) => {
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
   const { projectId } = useParams()
@@ -242,54 +244,49 @@ const InvestmentModal = ({
     return (
       <form id="investment-form" onSubmit={formik.handleSubmit}>
         <StyledModalInputRow>
-          <label id="finance-solution-label" htmlFor="finance-solution-select">
-            {modalLanguage.financeSolution} <RequiredIndicator />
-          </label>
-          <Select
+          <InputNoRowSelectWithLabelAndValidation
+            label={modalLanguage.financeSolution}
             id="finance-solution-select"
-            aria-labelledby="finance-solution-label"
             {...formik.getFieldProps('finance_solution')}
-          >
-            <option value="">{language.placeholders.select}</option>
-            {getOptionList(financeSolutions.map((fs) => ({ id: fs.id, name: fs.name })))}
-          </Select>
+            options={financeSolutions.map((fs) => ({ value: fs.id, label: fs.name }))}
+            helperText={modalLanguage.getFinanceSolutionHelper()}
+            showHelperText={displayHelp}
+            required={true}
+          />
         </StyledModalInputRow>
         <StyledModalInputRow>
-          <label id="investment-source-label" htmlFor="investment-source-select">
-            {modalLanguage.investmentSource} <RequiredIndicator />
-          </label>
-          <Select
+          <InputNoRowSelectWithLabelAndValidation
+            label={modalLanguage.investmentSource}
             id="investment-source-select"
-            aria-labelledby="investment-source-label"
             {...formik.getFieldProps('investment_source')}
-          >
-            <option value="">{language.placeholders.select}</option>
-            {getOptionList(choices.investmentsources.data)}
-          </Select>
+            options={getOptions(choices.investmentsources.data)}
+            helperText={modalLanguage.getInvestmentSourceHelper()}
+            showHelperText={displayHelp}
+            required={true}
+          />
         </StyledModalInputRow>
         <StyledModalInputRow>
-          <label id="investment-type-label" htmlFor="investment-type-select">
-            {modalLanguage.investmentType} <RequiredIndicator />
-          </label>
-          <Select
+          <InputNoRowSelectWithLabelAndValidation
+            label={modalLanguage.investmentType}
             id="investment-type-select"
-            aria-labelledby="investments-type-label"
             {...formik.getFieldProps('investment_type')}
-          >
-            <option value="">{language.placeholders.select}</option>
-            {getOptionList(choices.investmenttypes.data)}
-          </Select>
+            options={getOptions(choices.investmenttypes.data)}
+            helperText={modalLanguage.getInvestmentTypeHelper()}
+            showHelperText={displayHelp}
+            required={true}
+          />
         </StyledModalInputRow>
         <StyledModalInputRow>
-          <label id="investment-amount-label" htmlFor="investment-amount-input">
-            {modalLanguage.investmentAmount} <RequiredIndicator />
-          </label>
-          <InputNumberNoScrollWithUnit
-            aria-labelledby={'investment-amount-label'}
+          <InputNoRowWithLabelAndValidation
+            label={modalLanguage.investmentAmount}
             id="investment-amount-input"
+            type="number"
             unit="USD $"
             alignUnitsLeft={true}
             {...formik.getFieldProps('investment_amount')}
+            helperText={modalLanguage.getInvestmentAmountHelper()}
+            showHelperText={displayHelp}
+            required={true}
           />
         </StyledModalInputRow>
         <hr />
@@ -323,12 +320,13 @@ const InvestmentModal = ({
 
 InvestmentModal.propTypes = {
   indicatorSet: PropTypes.object.isRequired,
-  setIndicatorSet: PropTypes.object.isRequired,
+  setIndicatorSet: PropTypes.func.isRequired,
   choices: choicesPropType.isRequired,
   investment: PropTypes.object,
   financeSolutions: PropTypes.array.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onDismiss: PropTypes.func.isRequired,
+  displayHelp: PropTypes.bool,
 }
 
 export default InvestmentModal

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/ModalInputWithHelperText.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/ModalInputWithHelperText.js
@@ -1,0 +1,126 @@
+import React, { useEffect, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
+
+import {
+  Input,
+  InputContainer,
+  InputRow,
+  HelperText,
+  LabelContainer,
+  RequiredIndicator,
+} from '../../generic/form'
+import { useStopInputScrollingIncrementNumber } from '../../../library/useStopInputScrollingIncrementNumber'
+import InputNumberNoScrollWithUnit from '../../generic/InputNumberNoScrollWithUnit'
+
+import InputValidationInfo from '../InputValidationInfo/InputValidationInfo'
+import mermaidInputsPropTypes from '../mermaidInputsPropTypes'
+import { IconButton } from '../../generic/buttons'
+import { IconInfo } from '../../icons'
+
+const InputWithLabelAndValidation = ({
+  required = false,
+  helperText = undefined,
+  id,
+  ignoreNonObservationFieldValidations = () => {},
+  label,
+  resetNonObservationFieldValidations = () => {},
+  testId = undefined,
+  unit = undefined,
+  validationMessages = [],
+  validationType = undefined,
+  renderItemWithinInput = undefined,
+  renderItemAboveInput = undefined,
+  isInputDisabled = false,
+  showHelperText = false,
+
+  ...restOfProps
+}) => {
+  const textFieldRef = useRef()
+
+  useStopInputScrollingIncrementNumber(textFieldRef)
+
+  const [internalShowHelperText, setInternalShowHelperText] = useState()
+
+  useEffect(() => {
+    setInternalShowHelperText(showHelperText)
+  }, [showHelperText])
+
+  const handleInfoIconClick = (event) => {
+    setInternalShowHelperText(!internalShowHelperText)
+
+    event.stopPropagation()
+  }
+
+  const inputType = unit ? (
+    <InputNumberNoScrollWithUnit
+      aria-labelledby={`aria-label${id}`}
+      aria-describedby={`aria-descp${id}`}
+      id={id}
+      unit={unit}
+      disabled={isInputDisabled}
+      {...restOfProps}
+    />
+  ) : (
+    <Input
+      aria-labelledby={`aria-label${id}`}
+      aria-describedby={`aria-descp${id}`}
+      id={id}
+      {...restOfProps}
+      ref={textFieldRef}
+    />
+  )
+
+  return (
+    <InputRow required={required} validationType={validationType} data-testid={testId}>
+      <LabelContainer>
+        <label id={`aria-label${id}`} htmlFor={id}>
+          {label}
+        </label>
+        <span>{required ? <RequiredIndicator /> : null}</span>
+        {helperText ? (
+          <IconButton type="button" onClick={(event) => handleInfoIconClick(event, label)}>
+            <IconInfo aria-label="info" />
+          </IconButton>
+        ) : null}
+      </LabelContainer>
+
+      <div>
+        {renderItemAboveInput || null}
+        <InputContainer>
+          {inputType}
+
+          {renderItemWithinInput || null}
+        </InputContainer>
+        {showHelperText || internalShowHelperText ? (
+          <HelperText id={`aria-descp${id}`}>{helperText}</HelperText>
+        ) : null}
+      </div>
+
+      <InputValidationInfo
+        validationType={validationType}
+        validationMessages={validationMessages}
+        ignoreNonObservationFieldValidations={ignoreNonObservationFieldValidations}
+        resetNonObservationFieldValidations={resetNonObservationFieldValidations}
+      />
+    </InputRow>
+  )
+}
+
+InputWithLabelAndValidation.propTypes = {
+  required: PropTypes.bool,
+  helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  showHelperText: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  isInputDisabled: PropTypes.bool,
+  ignoreNonObservationFieldValidations: PropTypes.func,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  renderItemAboveInput: PropTypes.node,
+  renderItemWithinInput: PropTypes.node,
+  resetNonObservationFieldValidations: PropTypes.func,
+  testId: PropTypes.string,
+  unit: PropTypes.string,
+  validationMessages: mermaidInputsPropTypes.validationMessagesPropType,
+  validationType: PropTypes.string,
+}
+
+export default InputWithLabelAndValidation

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/RevenueModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/RevenueModal.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React, { useState, useEffect, useCallback, useMemo } from 'react'
 
 import language from '../../../../../language'
-import { RequiredIndicator, Select, Textarea } from '../../../../generic/form'
+import { Textarea } from '../../../../generic/form'
 import Modal, { RightFooter } from '../../../../generic/Modal/Modal'
 import {
   StyledModalInputRow,
@@ -14,14 +14,15 @@ import { buttonGroupStates } from '../../../../../library/buttonGroupStates'
 import { choicesPropType } from '../../../../../App/mermaidData/mermaidDataProptypes'
 import { ButtonCaution, ButtonSecondary } from '../../../../generic/buttons'
 import SaveButton from './SaveButton'
-import { getOptionList } from './modalHelpers'
 import { getRevenueInitialValues } from './revenueInitialValues'
-import InputNumberNoScrollWithUnit from '../../../../generic/InputNumberNoScrollWithUnit'
 import { getToastArguments } from '../../../../../library/getToastArguments'
 import { toast } from 'react-toastify'
 import { useDatabaseSwitchboardInstance } from '../../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 import { useParams } from 'react-router-dom'
 import { useHttpResponseErrorHandler } from '../../../../../App/HttpResponseErrorHandlerContext'
+import InputNoRowSelectWithLabelAndValidation from '../../../../mermaidInputs/InputNoRowSelectWithLabelAndValidation'
+import { getOptions } from '../../../../../library/getOptions'
+import InputNoRowWithLabelAndValidation from '../../../../mermaidInputs/InputNoRowWithLabelAndValidation'
 
 const modalLanguage = language.gfcrRevenueModal
 
@@ -33,6 +34,7 @@ const RevenueModal = ({
   revenue = undefined,
   choices,
   financeSolutions,
+  displayHelp,
 }) => {
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
   const { projectId } = useParams()
@@ -241,55 +243,52 @@ const RevenueModal = ({
     return (
       <form id="revenue-form" onSubmit={formik.handleSubmit}>
         <StyledModalInputRow>
-          <label id="finance-solution-label" htmlFor="finance-solution-select">
-            {modalLanguage.financeSolution} <RequiredIndicator />
-          </label>
-          <Select
+          <InputNoRowSelectWithLabelAndValidation
+            label={modalLanguage.financeSolution}
             id="finance-solution-select"
-            aria-labelledby="finance-solution-label"
             {...formik.getFieldProps('finance_solution')}
-          >
-            <option value="">{language.placeholders.select}</option>
-            {getOptionList(financeSolutions.map((fs) => ({ id: fs.id, name: fs.name })))}
-          </Select>
+            options={financeSolutions.map((fs) => ({ value: fs.id, label: fs.name }))}
+            helperText={modalLanguage.getFinanceSolutionHelper()}
+            showHelperText={displayHelp}
+            required={true}
+          />
         </StyledModalInputRow>
         <StyledModalInputRow>
-          <label id="revenue-type-label" htmlFor="revenue-type-select">
-            {modalLanguage.revenueType} <RequiredIndicator />
-          </label>
-          <Select
+          <InputNoRowSelectWithLabelAndValidation
+            label={modalLanguage.revenueType}
             id="revenue-type-select"
-            aria-labelledby="revenue-type-label"
             {...formik.getFieldProps('revenue_type')}
-          >
-            <option value="">{language.placeholders.select}</option>
-            {getOptionList(choices.revenuetypes.data)}
-          </Select>
+            options={getOptions(choices.revenuetypes.data)}
+            helperText={modalLanguage.getRevenueTypeHelper()}
+            showHelperText={displayHelp}
+            required={true}
+          />
         </StyledModalInputRow>
         <StyledModalInputRow>
-          <label id="sustainable-revenue-stream-label" htmlFor="sustainable-revenue-stream-select">
-            {modalLanguage.sustainableRevenueStream} <RequiredIndicator />
-          </label>
-          <Select
+          <InputNoRowSelectWithLabelAndValidation
+            label={modalLanguage.sustainableRevenueStream}
             id="sustainable-revenue-stream-select"
-            aria-labelledby="sustainable-revenue-stream-label"
             {...formik.getFieldProps('sustainable_revenue_stream')}
-          >
-            <option value="">{language.placeholders.select}</option>
-            <option value="true">{modalLanguage.yes}</option>
-            <option value="false">{modalLanguage.no}</option>
-          </Select>
+            options={[
+              { value: 'true', label: modalLanguage.yes },
+              { value: 'false', label: modalLanguage.no },
+            ]}
+            helperText={modalLanguage.getSustainableRevenueStreamHelper()}
+            showHelperText={displayHelp}
+            required={true}
+          />
         </StyledModalInputRow>
         <StyledModalInputRow>
-          <label id="annual-revenue-label" htmlFor="annual-revenue-input">
-            {modalLanguage.annualRevenue} <RequiredIndicator />
-          </label>
-          <InputNumberNoScrollWithUnit
-            aria-labelledby={'annual-revenue-label'}
+          <InputNoRowWithLabelAndValidation
+            label={modalLanguage.annualRevenue}
             id="annual-revenue-input"
+            type="number"
             unit="USD $"
             alignUnitsLeft={true}
             {...formik.getFieldProps('annual_revenue')}
+            helperText={modalLanguage.getAnnualRevenueHelper()}
+            showHelperText={displayHelp}
+            required={true}
           />
         </StyledModalInputRow>
         <hr />
@@ -329,6 +328,7 @@ RevenueModal.propTypes = {
   financeSolutions: PropTypes.array.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onDismiss: PropTypes.func.isRequired,
+  displayHelp: PropTypes.bool,
 }
 
 export default RevenueModal

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/modalHelpers.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/modalHelpers.js
@@ -2,14 +2,6 @@ import { Box } from '@mui/material'
 import React from 'react'
 import { CustomMuiChip } from '../../../../mermaidInputs/InputMuiChipSelectWithLabelAndValidation/InputMuiChipSelectWithLabelAndValidation.styles'
 
-export const getOptionList = (selectChoices) => {
-  return selectChoices.map((item) => (
-    <option key={item.id} value={item.id}>
-      {item.name}
-    </option>
-  ))
-}
-
 export const getChips = (value, options) => (
   <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
     {options

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/revenueInitialValues.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/revenueInitialValues.js
@@ -2,7 +2,7 @@ const getRevenueInitialValues = (revenue) => {
   const {
     finance_solution,
     revenue_type = '',
-    sustainable_revenue_stream = false,
+    sustainable_revenue_stream = '',
     annual_revenue = '',
     notes = '',
   } = revenue || {}

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/FinanceSolutions.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/FinanceSolutions.js
@@ -26,7 +26,7 @@ import IconCheckLabel from './IconCheckLabel'
 
 const tableLanguage = language.pages.gfcrFinanceSolutionsTable
 
-const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices }) => {
+const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp }) => {
   const { currentUser } = useCurrentUser()
   const [searchFilteredRowsLength, setSearchFilteredRowsLength] = useState(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -290,6 +290,7 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices }) => {
         setIndicatorSet={setIndicatorSet}
         choices={choices}
         onDismiss={handleFinanceSolutionModalDismiss}
+        displayHelp={displayHelp}
       />
     </>
   )
@@ -299,6 +300,7 @@ FinanceSolutions.propTypes = {
   indicatorSet: PropTypes.object.isRequired,
   setIndicatorSet: PropTypes.func.isRequired,
   choices: choicesPropType.isRequired,
+  displayHelp: PropTypes.bool,
 }
 
 export default FinanceSolutions

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/Investments.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/Investments.js
@@ -30,8 +30,8 @@ const Investments = ({
   setIndicatorSet,
   choices,
   onSubmit,
-  onDelete,
   setSelectedNavItem,
+  displayHelp,
 }) => {
   const { currentUser } = useCurrentUser()
   const [searchFilteredRowsLength, setSearchFilteredRowsLength] = useState(null)
@@ -282,7 +282,7 @@ const Investments = ({
         choices={choices}
         onDismiss={handleInvestmentModalDismiss}
         onSubmit={onSubmit}
-        onDelete={onDelete}
+        displayHelp={displayHelp}
       />
     </>
   )
@@ -293,8 +293,8 @@ Investments.propTypes = {
   setIndicatorSet: PropTypes.func.isRequired,
   choices: choicesPropType.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  onDelete: PropTypes.func.isRequired,
   setSelectedNavItem: PropTypes.func.isRequired,
+  displayHelp: PropTypes.bool,
 }
 
 export default Investments

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/Revenues.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/Revenues.js
@@ -26,7 +26,7 @@ import RevenueModal from '../modals/RevenueModal'
 
 const tableLanguage = language.pages.gfcrRevenuesTable
 
-const Revenues = ({ indicatorSet, setIndicatorSet, choices, setSelectedNavItem }) => {
+const Revenues = ({ indicatorSet, setIndicatorSet, choices, setSelectedNavItem, displayHelp }) => {
   const { currentUser } = useCurrentUser()
   const [searchFilteredRowsLength, setSearchFilteredRowsLength] = useState(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -273,6 +273,7 @@ const Revenues = ({ indicatorSet, setIndicatorSet, choices, setSelectedNavItem }
         onDismiss={handleRevenueModalDismiss}
         indicatorSet={indicatorSet}
         setIndicatorSet={setIndicatorSet}
+        displayHelp={displayHelp}
       />
     </>
   )
@@ -283,6 +284,7 @@ Revenues.propTypes = {
   setIndicatorSet: PropTypes.func.isRequired,
   choices: choicesPropType.isRequired,
   setSelectedNavItem: PropTypes.func.isRequired,
+  displayHelp: PropTypes.bool,
 }
 
 export default Revenues

--- a/src/language.js
+++ b/src/language.js
@@ -13,9 +13,14 @@ import {
 } from './library/validationMessageHelpers'
 import { HelperTextLink } from './components/generic/links'
 import styled from 'styled-components'
+import theme from './theme'
 
 const StyledLink = styled.a`
   cursor: pointer;
+`
+
+const StyledHelperLink = styled.a`
+  font-size: ${theme.typography.smallFontSize};
 `
 
 const placeholders = { select: 'Choose...' }
@@ -265,11 +270,59 @@ const gfcrFinanceSolutionModal = {
   titleAdd: 'Add Finance Solution',
   titleUpdate: 'Update Finance Solution',
   name: 'Finance solution / business name',
+  getNameHelper: () => (
+    <>
+      Name helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   sector: 'Sector',
+  getSectorHelper: () => (
+    <>
+      Sector helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   usedAnIncubator: 'Used an incubator?',
+  getUsedAnIncubatorHelper: () => (
+    <>
+      Used an incubator helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   localEnterprise: 'Local enterprise',
+  getLocalEnterpriseHelper: () => (
+    <>
+      Local enterprise helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   genderSmart: 'Gender 2X Criteria',
+  getGenderSmartHelper: () => (
+    <>
+      Gender smart helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   sustainableFinanceMechanisms: 'Sustainable finance mechanisms',
+  getSustainableFinanceMechanismsHelper: () => (
+    <>
+      Sustainable finance mechanisms helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   notes: 'Notes',
   add: 'Add Finance Solution Row',
   save: 'Save Finance Solution Row',
@@ -284,9 +337,41 @@ const gfcrInvestmentModal = {
   titleAdd: 'Add Investment',
   titleUpdate: 'Update Investment',
   financeSolution: 'Finance solution (select from previous input)',
+  getFinanceSolutionHelper: () => (
+    <>
+      Finance solution helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   investmentSource: 'Investment source',
+  getInvestmentSourceHelper: () => (
+    <>
+      Investment source helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   investmentType: 'Investment type',
+  getInvestmentTypeHelper: () => (
+    <>
+      Investment type helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   investmentAmount: 'Investment amount',
+  getInvestmentAmountHelper: () => (
+    <>
+      Investment amount helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   notes: 'Notes',
   add: 'Add Investment Row',
   save: 'Save Investment Row',
@@ -299,9 +384,41 @@ const gfcrRevenueModal = {
   titleAdd: 'Add Revenue Stream',
   titleUpdate: 'Update Revenue Stream',
   financeSolution: 'Finance solution (select from previous input)',
+  getFinanceSolutionHelper: () => (
+    <>
+      Finance solution helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   revenueType: 'Revenue type',
+  getRevenueTypeHelper: () => (
+    <>
+      Revenue type helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   sustainableRevenueStream: 'Sustainable revenue stream',
+  getSustainableRevenueStreamHelper: () => (
+    <>
+      Sustainable revenue stream helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   annualRevenue: 'Annual revenue',
+  getAnnualRevenueHelper: () => (
+    <>
+      Annual revenue helper{' '}
+      <StyledHelperLink href="" target="_blank">
+        and link
+      </StyledHelperLink>
+    </>
+  ),
   notes: 'Notes',
   add: 'Add Revenue Row',
   save: 'Save Revenue Row',


### PR DESCRIPTION
Add functions to language file.
Create "No Row" input components to allow input components to be reused in modals without using app-wide row styling. Replace input elements in finance modals with mermaid input components to allow helper text. Pass displayHelp props to finance modals.
Fix sustainable revenue stream (previously defaulted to "No" instead of "Choose...".

Ref: https://trello.com/c/dsLTNM1J/854-add-helper-text-in-the-finance-modals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced new input components with enhanced validation and helper text features.
	- Added `displayHelp` prop to several components, allowing conditional rendering of help information.
	- Integrated helper text functionality in various modal components to improve user guidance.

- **Refactor**
	- Streamlined existing components by replacing older input methods with new components for better modularity and maintainability.

- **Bug Fixes**
	- Adjusted prop types and internal logic in components to ensure correct data handling and user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->