### PR TITLE
Image classification: modal image drop file validations

### DIFF
--- a/src/components/pages/ImageClassification/ImageClassificationContainer.js
+++ b/src/components/pages/ImageClassification/ImageClassificationContainer.js
@@ -12,7 +12,6 @@ const ImageClassificationContainer = () => {
 
   const handleFilesUpload = (files) => {
     setUploadedFiles([...uploadedFiles, ...files])
-    toast.success('Files uploaded successfully')
     setIsModalOpen(false)
   }
 
@@ -41,6 +40,7 @@ const ImageClassificationContainer = () => {
           onClose={() => setIsModalOpen(false)}
           onFilesUpload={handleFilesUpload}
           isOpen={isModalOpen}
+          existingFiles={uploadedFiles}
         />
       )}
     </>

--- a/src/components/pages/ImageClassification/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal.js
@@ -65,9 +65,9 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
     const dimensionResults = await Promise.all(dimensionPromises)
 
     dimensionResults.forEach((result) => {
-      if (result && result.valid && !result.corrupt) {
+      if (result?.valid && !result?.corrupt) {
         validFiles.push(result.file)
-      } else if (result && result.corrupt) {
+      } else if (result?.corrupt) {
         corruptFiles.push(result.file)
       } else if (result && !result.valid) {
         dimensionExceededFiles.push(result.file)

--- a/src/components/pages/ImageClassification/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal.js
@@ -46,10 +46,12 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
       toast.error('Some files were not added because they exceed the 30 MB size limit.')
     }
 
-    if (invalidFiles.length === 0 && duplicateFiles.length === 0 && validFiles.length > 0) {
+    if (validFiles.length > 0) {
       setSelectedFiles((prevFiles) => [...prevFiles, ...validFiles])
       onFilesUpload([...selectedFiles, ...validFiles])
-      toast.success('Files uploaded successfully')
+      if (invalidFiles.length === 0 && duplicateFiles.length === 0 && oversizedFiles.length === 0) {
+        toast.success('Files uploaded successfully')
+      }
     }
   }
 
@@ -106,7 +108,7 @@ ImageUploadModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onFilesUpload: PropTypes.func.isRequired,
-  existingFiles: PropTypes.array.isRequired,
+  existingFiles: PropTypes.array.isRequired, // New prop type for existing files
 }
 
 export default ImageUploadModal

--- a/src/components/pages/ImageClassification/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal.js
@@ -32,17 +32,13 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
       toast.error('Some files are duplicates and were not added.')
     }
 
-    if (invalidFiles.length > 0 && validFiles.length === 0) {
-      toast.error(
-        'Invalid file. Only JPEG, PJPEG, PNG, and MPO files are allowed. Please try again.',
-      )
-    } else if (invalidFiles.length > 0 && validFiles.length > 0) {
-      setSelectedFiles((prevFiles) => [...prevFiles, ...validFiles])
-      onFilesUpload([...selectedFiles, ...validFiles])
+    if (invalidFiles.length > 0) {
       toast.error(
         'Some files were not added due to invalid file types. Only JPEG, PJPEG, PNG, and MPO files are allowed.',
       )
-    } else if (validFiles.length > 0) {
+    }
+
+    if (invalidFiles.length === 0 && duplicateFiles.length === 0 && validFiles.length > 0) {
       setSelectedFiles((prevFiles) => [...prevFiles, ...validFiles])
       onFilesUpload([...selectedFiles, ...validFiles])
       toast.success('Files uploaded successfully')

--- a/src/components/pages/ImageClassification/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal.js
@@ -131,7 +131,13 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
           <ButtonPrimary type="button" onClick={handleButtonClick}>
             Select files from your computer...
           </ButtonPrimary>
-          <HiddenInput type="file" multiple onChange={handleFileChange} ref={fileInputRef} />
+          <HiddenInput
+            type="file"
+            multiple
+            onChange={handleFileChange}
+            ref={fileInputRef}
+            accept={validFileTypes.join(',')}
+          />
         </DropZone>
       }
       footerContent={

--- a/src/components/pages/ImageClassification/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal.js
@@ -98,7 +98,7 @@ ImageUploadModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onFilesUpload: PropTypes.func.isRequired,
-  existingFiles: PropTypes.array.isRequired, // New prop type for existing files
+  existingFiles: PropTypes.array.isRequired,
 }
 
 export default ImageUploadModal

--- a/src/components/pages/ImageClassification/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
 import Modal from '../../generic/Modal'
 import { ButtonPrimary } from '../../generic/buttons'
@@ -6,11 +6,10 @@ import { DropZone, HiddenInput } from './ImageUploadModal.styles'
 import { toast } from 'react-toastify'
 
 const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => {
-  const [selectedFiles, setSelectedFiles] = useState([])
   const fileInputRef = useRef(null)
 
   const validFileTypes = ['image/jpeg', 'image/pjpeg', 'image/png', 'image/mpo']
-  const maxFileSize = 30 * 1024 * 1024 // 30 MB in bytes
+  const maxFileSize = 30 * 1024 * 1024 // 30 MB
 
   const validateAndUploadFiles = (files) => {
     const validFiles = []
@@ -18,7 +17,7 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
     const duplicateFiles = []
     const oversizedFiles = []
 
-    const allFiles = [...existingFiles, ...selectedFiles]
+    const allFiles = [...existingFiles]
 
     files.forEach((file) => {
       if (!validFileTypes.includes(file.type)) {
@@ -47,9 +46,7 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
     }
 
     if (validFiles.length > 0) {
-      const newSelectedFiles = [...selectedFiles, ...validFiles]
-      setSelectedFiles(newSelectedFiles)
-      onFilesUpload(newSelectedFiles)
+      onFilesUpload(validFiles)
       if (invalidFiles.length === 0 && duplicateFiles.length === 0 && oversizedFiles.length === 0) {
         toast.success('Files uploaded successfully')
       }
@@ -58,6 +55,7 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
 
   const handleFileChange = (event) => {
     const files = Array.from(event.target.files)
+
     validateAndUploadFiles(files)
   }
 

--- a/src/components/pages/ImageClassification/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal.js
@@ -47,8 +47,9 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
     }
 
     if (validFiles.length > 0) {
-      setSelectedFiles((prevFiles) => [...prevFiles, ...validFiles])
-      onFilesUpload([...selectedFiles, ...validFiles])
+      const newSelectedFiles = [...selectedFiles, ...validFiles]
+      setSelectedFiles(newSelectedFiles)
+      onFilesUpload(newSelectedFiles)
       if (invalidFiles.length === 0 && duplicateFiles.length === 0 && oversizedFiles.length === 0) {
         toast.success('Files uploaded successfully')
       }

--- a/src/components/pages/ImageClassification/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal.js
@@ -10,17 +10,21 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
   const fileInputRef = useRef(null)
 
   const validFileTypes = ['image/jpeg', 'image/pjpeg', 'image/png', 'image/mpo']
+  const maxFileSize = 30 * 1024 * 1024 // 30 MB in bytes
 
   const validateAndUploadFiles = (files) => {
     const validFiles = []
     const invalidFiles = []
     const duplicateFiles = []
+    const oversizedFiles = []
 
     const allFiles = [...existingFiles, ...selectedFiles]
 
     files.forEach((file) => {
       if (!validFileTypes.includes(file.type)) {
         invalidFiles.push(file)
+      } else if (file.size > maxFileSize) {
+        oversizedFiles.push(file)
       } else if (allFiles.some((existingFile) => existingFile.name === file.name)) {
         duplicateFiles.push(file)
       } else {
@@ -36,6 +40,10 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
       toast.error(
         'Some files were not added due to invalid file types. Only JPEG, PJPEG, PNG, and MPO files are allowed.',
       )
+    }
+
+    if (oversizedFiles.length > 0) {
+      toast.error('Some files were not added because they exceed the 30 MB size limit.')
     }
 
     if (invalidFiles.length === 0 && duplicateFiles.length === 0 && validFiles.length > 0) {


### PR DESCRIPTION
- add validations/error toasts for max image upload size, duplicates, and file types

to test:

1. go to collections
2. add new BPQ
3. scroll down to observations
4. click image classification
5. click upload photos
6. try testing different file types (single and batches)