### PR TITLE
Bug: Fix cancel button in new indicator set form

### DIFF
--- a/src/components/pages/gfcrPages/Gfcr/NewIndicatorSetModal.js
+++ b/src/components/pages/gfcrPages/Gfcr/NewIndicatorSetModal.js
@@ -105,7 +105,7 @@ const NewIndicatorSetModal = ({ indicatorSetType, isOpen, onDismiss }) => {
   const footer = (
     <StyledModalFooterWrapper>
       <StyledModalLeftFooter>
-        <ButtonSecondary onClick={onDismiss} disabled={isLoading}>
+        <ButtonSecondary onClick={() => onDismiss(formik.resetForm)} disabled={isLoading}>
           {modalLanguage.cancel}
         </ButtonSecondary>
       </StyledModalLeftFooter>


### PR DESCRIPTION
Pass formik.resetForm into onDismiss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `NewIndicatorSetModal` by resetting the form when the dismiss button is clicked, improving user experience by clearing form data upon modal closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->