### PR TITLE
Bug: Enable scroll down in finance solution modal

### DIFF
--- a/src/components/pages/gfcrPages/Gfcr/NewIndicatorSetModal.js
+++ b/src/components/pages/gfcrPages/Gfcr/NewIndicatorSetModal.js
@@ -155,7 +155,7 @@ const NewIndicatorSetModal = ({ indicatorSetType, isOpen, onDismiss }) => {
         </form>
       }
       footerContent={footer}
-      contentOverflowIsVisible={true}
+      contentOverflowIsVisible={false}
       maxWidth="65rem"
     />
   )

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.js
@@ -380,7 +380,7 @@ const FinanceSolutionModal = ({
       title={financeSolution ? modalLanguage.titleUpdate : modalLanguage.titleAdd}
       mainContent={financeSolutionForm()}
       footerContent={footer}
-      contentOverflowIsVisible={true}
+      contentOverflowIsVisible={false}
       maxWidth="65rem"
     />
   )

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/InvestmentModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/InvestmentModal.js
@@ -312,7 +312,7 @@ const InvestmentModal = ({
       title={investment ? modalLanguage.titleUpdate : modalLanguage.titleAdd}
       mainContent={investmentForm()}
       footerContent={footer}
-      contentOverflowIsVisible={true}
+      contentOverflowIsVisible={false}
       maxWidth="65rem"
     />
   )

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/RevenueModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/RevenueModal.js
@@ -314,7 +314,7 @@ const RevenueModal = ({
       title={revenue ? modalLanguage.titleUpdate : modalLanguage.titleAdd}
       mainContent={revenueForm()}
       footerContent={footer}
-      contentOverflowIsVisible={true}
+      contentOverflowIsVisible={false}
       maxWidth="65rem"
     />
   )


### PR DESCRIPTION
Set Modal's contentOverflowIsVisible property value to false.
Also apply to investment, revenue and new indicator set modals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Interface Changes**
	- Updated the `NewIndicatorSetModal`, `FinanceSolutionModal`, `InvestmentModal`, and `RevenueModal` to hide overflow content, improving layout consistency.
	- Users may need to scroll to view additional content within these modals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->