### PR TITLE
[909] small fix: adjust on click handler for dropzone in image drop modal

### DIFF
--- a/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
@@ -182,9 +182,7 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
               <br />
               or
               <br />
-              <ButtonPrimary type="button" onClick={handleButtonClick}>
-                Select files from your computer...
-              </ButtonPrimary>
+              <ButtonPrimary type="button">Select files from your computer...</ButtonPrimary>
               <HiddenInput
                 type="file"
                 multiple


### PR DESCRIPTION
prevents a weird bug where first batch of uploads wouldn't work, and just reopened the file drop