### PR TITLE
update logic used for unclassified points

### DIFF
--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
@@ -1,5 +1,7 @@
 import styled from 'styled-components'
 import theme from '../../../../theme'
+import { Tr } from '../../../generic/Table/table'
+import { IMAGE_CLASSIFICATION_COLORS as COLORS } from '../../../../library/constants/constants'
 
 export const Footer = styled.div`
   display: flex;
@@ -33,4 +35,13 @@ export const ImageAnnotationMapContainer = styled.div`
   width: ${({ $width }) => `${$width}px`};
   height: ${({ $height }) => `${$height}px`};
   margin-top: '2rem';
+`
+
+export const TrWithBorderStyling = styled(Tr)`
+  border: ${({ $isSelected }) => $isSelected && `2px solid ${COLORS.current}`};
+  background-color: ${({ $isConfirmed }) => $isConfirmed && `${COLORS.confirmed} !important`};
+
+  &:hover {
+    border: ${({ $isSelected }) => !$isSelected && `2px solid ${COLORS.highlighted}`};
+  }
 `

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
@@ -83,7 +83,7 @@ const ImageAnnotationModalMap = ({
             id: point.id,
             benthicAttributeId: point.annotations[0]?.benthic_attribute,
             growthFormId: point.annotations[0]?.growth_form,
-            isUnclassified: point.annotations.length === 0,
+            isUnclassified: !!point.is_unclassified || !point.annotations.length,
             isConfirmed: point.annotations[0]?.is_confirmed,
           },
           geometry: {

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalTable.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalTable.js
@@ -1,20 +1,10 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
 import { Table, Tr, Th, Td } from '../../../generic/Table/table'
-import { IMAGE_CLASSIFICATION_COLORS as COLORS } from '../../../../library/constants/constants'
 import { ButtonPrimary, ButtonCaution } from '../../../generic/buttons'
 import { IconClose } from '../../../icons'
 import { imageClassificationPointsPropType } from '../../../../App/mermaidData/mermaidDataProptypes'
-
-const TrWithBorderStyling = styled(Tr)`
-  border: ${({ $isSelected }) => $isSelected && `2px solid ${COLORS.current}`};
-  background-color: ${({ $isConfirmed }) => $isConfirmed && `${COLORS.confirmed} !important`};
-
-  &:hover {
-    border: ${({ $isSelected }) => !$isSelected && `2px solid ${COLORS.highlighted}`};
-  }
-`
+import { TrWithBorderStyling } from './ImageAnnotationModal.styles'
 
 const ImageAnnotationModalTable = ({
   points,
@@ -25,9 +15,11 @@ const ImageAnnotationModalTable = ({
   setSelectedPoints,
 }) => {
   const [selectedRowIndex, setSelectedRowIndex] = useState()
-  const pointsWithAnnotations = points.filter(({ annotations }) => annotations.length)
+  const classifiedPoints = points.filter(
+    ({ is_unclassified, annotations }) => !is_unclassified && annotations.length > 0,
+  )
   const tableData = Object.groupBy(
-    pointsWithAnnotations,
+    classifiedPoints,
     ({ annotations }) => annotations[0].benthic_attribute + '_' + annotations[0].growth_form,
   )
 
@@ -64,7 +56,11 @@ const ImageAnnotationModalTable = ({
 
     const updatedPoints = points.map((point) => {
       const isPointInRow = rowData.some((pointInRow) => pointInRow.id === point.id)
-      return isPointInRow ? { ...point, annotations: [] } : point
+      if (isPointInRow) {
+        point.is_unclassified = true
+      }
+
+      return point
     })
 
     setDataToReview((prevState) => ({ ...prevState, points: updatedPoints }))


### PR DESCRIPTION
Relates to [Ticket 993](https://trello.com/c/8ZGFtBmg/993-update-logic-for-deleting-a-row)

**Changes**
- Updated logic when deleting a row to set `point.is_unclassified: true` instead of removing annotations
  - This allows the user to select one of these annotations after unclassifying the point if need be.
  - This also allows us to keep information that has already been classified.
- Moved a styled component in `ImageAnnotationModalTable` to style file.
- Updated logic for map and table to check both `is_unclassified` and length of annotations array for a point.
  - Need to check for both because it is possible that a point is unclassified from the API (meaning no annotations)