### PR TITLE
[1006] add polling for images

### DIFF
--- a/src/App/mermaidData/databaseSwitchboard/ImageClassificationMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/ImageClassificationMixin.js
@@ -56,6 +56,29 @@ const ImageClassificationMixin = (Base) =>
             .then((apiResults) => apiResults.data)
         : Promise.reject(this._notAuthenticatedAndReadyError)
     }
+
+    getAllImagesInProject = async (projectId, collectRecordId, excludeParams = '') => {
+      if (!projectId || !collectRecordId) {
+        return Promise.reject(new Error('projectId and collectRecordId are required parameters.'))
+      }
+
+      // Add `exclude` query param
+      const queryParams = [`collect_record_id=${collectRecordId}`]
+      if (excludeParams) {
+        queryParams.push(`exclude=${encodeURIComponent(excludeParams)}`)
+      }
+
+      const queryString = queryParams.length > 0 ? `?${queryParams.join('&')}` : ''
+
+      return this._isOnlineAuthenticatedAndReady
+        ? axios
+            .get(
+              `${this._apiBaseUrl}/projects/${projectId}/classification/images/${queryString}`,
+              await getAuthorizationHeaders(this._getAccessToken),
+            )
+            .then((apiResults) => apiResults.data)
+        : Promise.reject(this._notAuthenticatedAndReadyError)
+    }
   }
 
 export default ImageClassificationMixin

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -93,6 +93,8 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
         )
         setImages(response.results)
 
+        console.log({ response })
+
         // Check if all images are processed
         const allProcessed = response.results.every((file) =>
           isImageProcessed(file.classification_status.status),

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
+import { useParams } from 'react-router-dom'
 import { H2 } from '../../../generic/text'
 import { InputWrapper } from '../../../generic/form'
 import {
@@ -12,6 +13,7 @@ import { ButtonPrimary, ButtonCaution } from '../../../generic/buttons'
 import { IconClose } from '../../../icons'
 import ImageAnnotationModal from '../ImageAnnotationModal/ImageAnnotationModal'
 import Thumbnail from './Thumbnail'
+import { useDatabaseSwitchboardInstance } from '../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 
 const tableHeaders = [
   { align: 'right', id: 'number-label', text: '#' },
@@ -64,6 +66,13 @@ const statusLabels = {
 
 const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }) => {
   const [imageId, setImageId] = useState()
+  const [images, setImages] = useState(uploadedFiles)
+  const [polling, setPolling] = useState(false)
+  const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
+  const { projectId, recordId } = useParams()
+  const excludeParams =
+    'data,points,created_by,updated_by,created_on,updated_on,original_image_width,original_image_height,location,comments,image,photo_timestamp'
+
   const isImageProcessed = (status) => status === 3
 
   const handleImageClick = (file) => {
@@ -71,6 +80,51 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
       setImageId(file.id)
     }
   }
+
+  // Poll every 5 seconds after the first image is uploaded
+  const _pollImageStatuses = useEffect(() => {
+    let intervalId
+    const startPolling = async () => {
+      try {
+        const response = await databaseSwitchboardInstance.getAllImagesInProject(
+          projectId,
+          recordId,
+          excludeParams,
+        )
+        setImages(response.results)
+
+        // Check if all images are processed
+        const allProcessed = response.results.every((file) =>
+          isImageProcessed(file.classification_status.status),
+        )
+
+        if (allProcessed) {
+          clearInterval(intervalId) // Stop polling when all images are processed
+          setPolling(false)
+        }
+      } catch (error) {
+        console.error('Error polling images:', error)
+      }
+    }
+
+    if (polling) {
+      intervalId = setInterval(startPolling, 5000)
+    }
+
+    return () => {
+      if (intervalId) {
+        clearInterval(intervalId)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [polling, projectId])
+
+  // Start polling after the first image is uploaded
+  useEffect(() => {
+    if (uploadedFiles.length > 0 && !polling) {
+      setPolling(true)
+    }
+  }, [uploadedFiles, polling])
 
   return (
     <>
@@ -83,7 +137,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
               <SubHeaderRow />
             </thead>
             <tbody>
-              {uploadedFiles.map((file, index) => (
+              {images.map((file, index) => (
                 <Tr key={index}>
                   <StyledTd>{index + 1}</StyledTd>
                   <TdWithHoverText
@@ -131,6 +185,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
 ImageClassificationObservationTable.propTypes = {
   uploadedFiles: PropTypes.arrayOf(PropTypes.object),
   handleRemoveFile: PropTypes.func,
+  projectId: PropTypes.string.isRequired,
 }
 
 export default ImageClassificationObservationTable

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -14,6 +14,7 @@ import { IconClose } from '../../../icons'
 import ImageAnnotationModal from '../ImageAnnotationModal/ImageAnnotationModal'
 import Thumbnail from './Thumbnail'
 import { useDatabaseSwitchboardInstance } from '../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
+import { EXCLUDE_PARAMS } from '../../../../library/constants/constants'
 
 const tableHeaders = [
   { align: 'right', id: 'number-label', text: '#' },
@@ -70,8 +71,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   const [polling, setPolling] = useState(false)
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
   const { projectId, recordId } = useParams()
-  const excludeParams =
-    'data,points,created_by,updated_by,created_on,updated_on,original_image_width,original_image_height,location,comments,image,photo_timestamp'
 
   const isImageProcessed = (status) => status === 3
 
@@ -89,7 +88,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
         const response = await databaseSwitchboardInstance.getAllImagesInProject(
           projectId,
           recordId,
-          excludeParams,
+          EXCLUDE_PARAMS,
         )
         setImages(response.results)
 

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -93,8 +93,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
         )
         setImages(response.results)
 
-        console.log({ response })
-
         // Check if all images are processed
         const allProcessed = response.results.every((file) =>
           isImageProcessed(file.classification_status.status),

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -119,8 +119,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [polling, projectId])
 
-  // Start polling after the first image is uploaded
-  useEffect(() => {
+  const _beginPollingAfterFirstImageIsUploaded = useEffect(() => {
     if (uploadedFiles.length > 0 && !polling) {
       setPolling(true)
     }

--- a/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
@@ -63,11 +63,8 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
     try {
       const imageData = await databaseSwitchboardInstance.uploadImage(projectId, recordId, file)
 
-      // Placeholder: Polling logic will go here.
-      // TODO: Implement polling to check the status of image processing before proceeding to the next image.
-      // something like: `await pollForCompletion(imageData.id);`
-
       setProcessedFiles((prev) => prev + 1)
+
       return imageData
     } catch (error) {
       toast.error(`Failed to upload ${file.name}: ${error.message}`)

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
@@ -53,7 +53,7 @@ const BenthicPhotoQuadratForm = ({ isNewRecord = true }) => {
   const [isImageClassification, setIsImageClassification] = useState(null)
 
   const [observationsState, observationsDispatch] = observationsReducer // eslint-disable-line no-unused-vars
-  const enableImageClassification = collectRecordBeingEdited?.data?.imageClassification
+  const enableImageClassification = collectRecordBeingEdited?.data?.image_classification
 
   useEffect(
     function loadSupportingData() {

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
@@ -376,7 +376,7 @@ const CollectRecordFormPage = ({
       formikValues: formik.values,
       observationsTable1State,
       observationsTable2State,
-      imageClassification: isImageClassification,
+      image_classification: isImageClassification,
     })
 
     setSaveButtonState(buttonGroupStates.saving)
@@ -389,7 +389,7 @@ const CollectRecordFormPage = ({
         profileId: currentUser.id,
         projectId,
         protocol: sampleUnitName,
-        imageClassification: isImageClassification,
+        image_classification: isImageClassification,
       })
       .then((collectRecordResponse) => {
         setIsFormDirty(false)

--- a/src/components/pages/collectRecordFormPages/reformatFormValuesIntoRecord.js
+++ b/src/components/pages/collectRecordFormPages/reformatFormValuesIntoRecord.js
@@ -56,7 +56,7 @@ export const reformatFormValuesIntoBenthicPQTRecord = ({
   collectRecordBeingEdited,
   formikValues,
   observationsTable1State,
-  imageClassification,
+  image_classification,
 }) => {
   const {
     depth,
@@ -105,7 +105,7 @@ export const reformatFormValuesIntoBenthicPQTRecord = ({
       },
       obs_benthic_photo_quadrats: observationsTable1State,
       observers,
-      imageClassification,
+      image_classification,
     },
   }
 }

--- a/src/library/constants/constants.js
+++ b/src/library/constants/constants.js
@@ -24,6 +24,10 @@ export const IMAGE_CLASSIFICATION_COLORS = {
   unclassified: '#BF6B69',
   highlighted: 'blue', // TODO: This colour is not yet defined
 }
+
+export const EXCLUDE_PARAMS =
+  'data,points,created_by,updated_by,created_on,updated_on,original_image_width,original_image_height,location,comments,image,photo_timestamp'
+
 Object.freeze(PROJECT_CODES)
 Object.freeze(apiDataTypes)
 Object.freeze(IMAGE_CLASSIFICATION_COLORS)


### PR DESCRIPTION
- add `getAllImagesInProject` to mixin
- add  `pollImageStatuses` to observation table (occurs every 5 seconds until all images are done processing)
-  update property to `image_classification` (instead of camel case) for api 

next: fill in the number of points columns with confirmed/unconfirmed/etc

to test:
1. create a new BPQ record
2. upload images
3. observe status showing pending in table
4. wait for status to change to completed
5. image thumbnail click and review button get activated


note 
- waiting for an api update to pass in collect record as query. right now, all project images get added into a record when polling