### PR TITLE
Image classification: fix polling bug

### DIFF
--- a/src/App/mermaidData/databaseSwitchboard/ImageClassificationMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/ImageClassificationMixin.js
@@ -57,7 +57,7 @@ const ImageClassificationMixin = (Base) =>
         : Promise.reject(this._notAuthenticatedAndReadyError)
     }
 
-    getAllImagesInProject = async (projectId, collectRecordId, excludeParams = '') => {
+    getAllImagesInCollectRecord = async (projectId, collectRecordId, excludeParams = '') => {
       if (!projectId || !collectRecordId) {
         throw new Error('projectId and collectRecordId are required parameters.')
       }

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -71,6 +71,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   const [polling, setPolling] = useState(false)
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
   const { projectId, recordId } = useParams()
+  const [imagesDoneProcessing, setImagesDoneProcessing] = useState(false)
 
   const isImageProcessed = (status) => status === 3
 
@@ -85,7 +86,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
     let intervalId
     const startPolling = async () => {
       try {
-        const response = await databaseSwitchboardInstance.getAllImagesInProject(
+        const response = await databaseSwitchboardInstance.getAllImagesInCollectRecord(
           projectId,
           recordId,
           EXCLUDE_PARAMS,
@@ -100,6 +101,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
         if (allProcessed) {
           clearInterval(intervalId) // Stop polling when all images are processed
           setPolling(false)
+          setImagesDoneProcessing(true)
         }
       } catch (error) {
         console.error('Error polling images:', error)
@@ -119,10 +121,10 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   }, [polling, projectId])
 
   const _beginPollingAfterFirstImageIsUploaded = useEffect(() => {
-    if (uploadedFiles.length > 0 && !polling) {
+    if (uploadedFiles.length > 0 && !polling && !imagesDoneProcessing) {
       setPolling(true)
     }
-  }, [uploadedFiles, polling])
+  }, [uploadedFiles, polling, images, imagesDoneProcessing])
 
   return (
     <>
@@ -151,9 +153,9 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                   <StyledTd></StyledTd>
                   <StyledTd></StyledTd>
                   <StyledTd></StyledTd>
-                  <StyledTd></StyledTd>
-                  <StyledTd></StyledTd>
-                  <StyledTd></StyledTd>
+                  <StyledTd>{file.num_confirmed}</StyledTd>
+                  <StyledTd>{file.num_unconfirmed}</StyledTd>
+                  <StyledTd>{file.num_unclassified}</StyledTd>
                   <StyledTd></StyledTd>
                   <StyledTd>
                     <ButtonPrimary

--- a/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
@@ -95,7 +95,8 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
         toast.error(`File size exceeds the limit: ${file.name}`)
         continue
       }
-      if (existingFiles.some((existingFile) => existingFile.name === file.name)) {
+
+      if (existingFiles.some((existingFile) => existingFile.original_image_name === file.name)) {
         toast.error(`Duplicate file: ${file.name}`)
         continue
       }

--- a/src/library/constants/constants.js
+++ b/src/library/constants/constants.js
@@ -26,7 +26,7 @@ export const IMAGE_CLASSIFICATION_COLORS = {
 }
 
 export const EXCLUDE_PARAMS =
-  'data,points,created_by,updated_by,created_on,updated_on,original_image_width,original_image_height,location,comments,image,photo_timestamp'
+  'data,created_by,updated_by,created_on,updated_on,original_image_width,original_image_height,location,comments,image,photo_timestamp'
 
 Object.freeze(PROJECT_CODES)
 Object.freeze(apiDataTypes)


### PR DESCRIPTION
few minor changes here..

bugs
- ensure polling stops after all images are processed
- ensure no duplicate images are added (adjust data path)
- rename image classification mixin to `getAllImagesInCollectRecord` instead of `getAllImagesInProject`
