### PR TITLE
[1013] ensure clusters are loaded before adding layers

### DIFF
--- a/src/components/mermaidMap/mapService.js
+++ b/src/components/mermaidMap/mapService.js
@@ -225,6 +225,9 @@ export const loadACALayers = (map) => {
     ? benthicOpacityExpression
     : fillBenthicOpacityValue
 
+  // Check if 'clusters' layer exists before adding layers before it
+  const beforeLayerId = map.getLayer('clusters') ? 'clusters' : undefined
+
   map.addSource('atlas-planet', {
     type: 'raster',
     tiles: [
@@ -246,6 +249,7 @@ export const loadACALayers = (map) => {
     maxZoom: 22,
   })
 
+  // Add layers with a conditional check for 'beforeLayerId'
   map.addLayer(
     {
       id: 'atlas-planet',
@@ -256,8 +260,8 @@ export const loadACALayers = (map) => {
         'raster-opacity': rasterOpacityExpression,
       },
     },
-    'clusters',
-  ) // Add this layer before the clusters layer to prevent overlapping
+    beforeLayerId,
+  )
 
   map.addLayer(
     {
@@ -270,7 +274,7 @@ export const loadACALayers = (map) => {
         'fill-opacity': fillGeomorphicOpacityExpression,
       },
     },
-    'clusters',
+    beforeLayerId,
   )
 
   map.addLayer(
@@ -284,7 +288,7 @@ export const loadACALayers = (map) => {
         'fill-opacity': fillBenthicOpacityExpression,
       },
     },
-    'clusters',
+    beforeLayerId,
   )
 }
 
@@ -322,7 +326,8 @@ export const getMapMarkersFeature = (records) => {
 export const loadMapMarkersLayer = (map) => {
   map.loadImage(mapPin, (error, image) => {
     if (error) {
-      throw error
+      console.error('Error loading image: ', error)
+      return
     }
 
     map.addImage('custom-marker', image)

--- a/src/components/mermaidMap/mapService.js
+++ b/src/components/mermaidMap/mapService.js
@@ -249,7 +249,6 @@ export const loadACALayers = (map) => {
     maxZoom: 22,
   })
 
-  // Add layers with a conditional check for 'beforeLayerId'
   map.addLayer(
     {
       id: 'atlas-planet',

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -1,0 +1,191 @@
+import React, { useState, useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+import { H2 } from '../../../generic/text'
+import { InputWrapper } from '../../../generic/form'
+import {
+  StyledOverflowWrapper,
+  StickyObservationTable,
+} from '../../collectRecordFormPages/CollectingFormPage.Styles'
+import { Tr, Th } from '../../../generic/Table/table'
+import PropTypes from 'prop-types'
+import { StyledTd, TdWithHoverText } from './ImageClassificationObservationTable.styles'
+import { ButtonPrimary, ButtonCaution } from '../../../generic/buttons'
+import { IconClose } from '../../../icons'
+import ImageAnnotationModal from '../ImageAnnotationModal/ImageAnnotationModal'
+import Thumbnail from './Thumbnail'
+import { useDatabaseSwitchboardInstance } from '../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
+import { EXCLUDE_PARAMS } from '../../../../library/constants/constants'
+
+const tableHeaders = [
+  { align: 'right', id: 'number-label', text: '#' },
+  { align: 'center', id: 'thumbnail-label', text: 'Thumbnail' },
+  { align: 'right', id: 'status-label', text: 'Status' },
+  { align: 'right', id: 'quadrat-number-label', text: 'Quadrat' },
+  { align: 'left', id: 'benthic-attribute-label', text: 'Benthic Attribute' },
+  { align: 'right', id: 'growth-form-label', text: 'Growth Form' },
+  { colSpan: 3, align: 'center', id: 'number-of-points-label', text: 'Number of Points' },
+  { align: 'right', id: 'validations', text: 'Validations' },
+  { align: 'right', id: 'review', text: '' },
+  { align: 'right', id: 'remove', text: '' },
+]
+
+const TableHeaderRow = () => (
+  <Tr>
+    {tableHeaders.map((header) => (
+      <Th key={header.id} align={header.align} id={header.id} colSpan={header.colSpan || 1}>
+        <span>{header.text}</span>
+      </Th>
+    ))}
+  </Tr>
+)
+
+const subHeaderColumns = [
+  { align: 'center', text: 'Confirmed' },
+  { align: 'center', text: 'Unconfirmed' },
+  { align: 'center', text: 'Unknown' },
+]
+
+const SubHeaderRow = () => (
+  <Tr>
+    <Th colSpan={6} />
+    {subHeaderColumns.map((col, index) => (
+      <Th key={index} align={col.align}>
+        <span>{col.text}</span>
+      </Th>
+    ))}
+    <Th colSpan={4} />
+  </Tr>
+)
+
+const statusLabels = {
+  0: 'Unknown',
+  1: 'Pending',
+  2: 'Running',
+  3: 'Completed',
+  4: 'Failed',
+}
+
+const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }) => {
+  const [imageId, setImageId] = useState()
+  const [images, setImages] = useState(uploadedFiles)
+  const [polling, setPolling] = useState(false)
+  const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
+  const { projectId, recordId } = useParams()
+  const [imagesDoneProcessing, setImagesDoneProcessing] = useState(false)
+
+  const isImageProcessed = (status) => status === 3
+
+  const handleImageClick = (file) => {
+    if (isImageProcessed(file.classification_status.status)) {
+      setImageId(file.id)
+    }
+  }
+
+  // Poll every 5 seconds after the first image is uploaded
+  const _pollImageStatuses = useEffect(() => {
+    let intervalId
+    const startPolling = async () => {
+      try {
+        const response = await databaseSwitchboardInstance.getAllImagesInCollectRecord(
+          projectId,
+          recordId,
+          EXCLUDE_PARAMS,
+        )
+        setImages(response.results)
+
+        // Check if all images are processed
+        const allProcessed = response.results.every((file) =>
+          isImageProcessed(file.classification_status.status),
+        )
+
+        if (allProcessed) {
+          clearInterval(intervalId) // Stop polling when all images are processed
+          setPolling(false)
+          setImagesDoneProcessing(true)
+        }
+      } catch (error) {
+        console.error('Error polling images:', error)
+      }
+    }
+
+    if (polling) {
+      intervalId = setInterval(startPolling, 5000)
+    }
+
+    return () => {
+      if (intervalId) {
+        clearInterval(intervalId)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [polling, projectId])
+
+  const _beginPollingAfterFirstImageIsUploaded = useEffect(() => {
+    if (uploadedFiles.length > 0 && !polling && !imagesDoneProcessing) {
+      setPolling(true)
+    }
+  }, [uploadedFiles, polling, images, imagesDoneProcessing])
+
+  return (
+    <>
+      <InputWrapper>
+        <H2 id="table-label">Observations</H2>
+        <StyledOverflowWrapper>
+          <StickyObservationTable aria-labelledby="table-label">
+            <thead>
+              <TableHeaderRow />
+              <SubHeaderRow />
+            </thead>
+            <tbody>
+              {images.map((file, index) => (
+                <Tr key={index}>
+                  <StyledTd>{index + 1}</StyledTd>
+                  <TdWithHoverText
+                    data-tooltip={file.original_image_name}
+                    onClick={() => handleImageClick(file)}
+                    cursor={
+                      isImageProcessed(file.classification_status.status) ? 'pointer' : 'default'
+                    }
+                  >
+                    <Thumbnail imageUrl={file.thumbnail || file.image} />
+                  </TdWithHoverText>
+                  <StyledTd>{statusLabels[file.classification_status.status]}</StyledTd>
+                  <StyledTd></StyledTd>
+                  <StyledTd></StyledTd>
+                  <StyledTd></StyledTd>
+                  <StyledTd>{file.num_confirmed}</StyledTd>
+                  <StyledTd>{file.num_unconfirmed}</StyledTd>
+                  <StyledTd>{file.num_unclassified}</StyledTd>
+                  <StyledTd></StyledTd>
+                  <StyledTd>
+                    <ButtonPrimary
+                      type="button"
+                      onClick={() => setImageId(file.id)}
+                      disabled={!isImageProcessed(file.classification_status.status)}
+                    >
+                      Review
+                    </ButtonPrimary>
+                  </StyledTd>
+                  <StyledTd>
+                    <ButtonCaution type="button" onClick={() => handleRemoveFile(file)}>
+                      <IconClose aria-label="close" />
+                    </ButtonCaution>
+                  </StyledTd>
+                </Tr>
+              ))}
+            </tbody>
+          </StickyObservationTable>
+        </StyledOverflowWrapper>
+      </InputWrapper>
+      {imageId ? <ImageAnnotationModal imageId={imageId} setImageId={setImageId} /> : undefined}
+    </>
+  )
+}
+
+ImageClassificationObservationTable.propTypes = {
+  uploadedFiles: PropTypes.arrayOf(PropTypes.object),
+  handleRemoveFile: PropTypes.func,
+  projectId: PropTypes.string.isRequired,
+}
+
+export default ImageClassificationObservationTable


### PR DESCRIPTION
[trello ticket](https://trello.com/c/0U9dK0sX/1013-add-new-site-error)

console error `layer with id clusters does not exist on map` no longer appears. Added check to ensure clusters are loaded before adding layers.

to test, go to single site map, add site, open up console

I did notice another error that is currently on dev on sites and now appears on single site map: `Error: Could not load image because of The source image could not be decoded.. Please make sure to use a supported image type such as PNG or JPEG. Note that SVGs are not supported.`

it seems to be happening within this code block in `loadACALayers` (if I comment it out it goes away):

```
  map.addLayer(
    {
      id: 'atlas-planet',
      type: 'raster',
      source: 'atlas-planet',
      'source-layer': 'planet',
      paint: {
        'raster-opacity': rasterOpacityExpression,
      },
    },
    beforeLayerId,
  )
```

I've noticed a couple documented issues related to it [here](https://github.com/mapbox/mapbox-gl-js/issues/10277) and [here](https://github.com/mapbox/mapbox-gl-js/issues/11465) in mapbox-gl GH but haven't found a solution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced map service functionality for improved layer management and error handling.
	- Introduced a new component for displaying and managing image classification observations, featuring real-time status updates and user interaction options.

- **Bug Fixes**
	- Improved error handling in the image loading process to prevent application crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->