### PR TITLE
[M1013] add check for clusters before adding layers

### DIFF
--- a/src/components/mermaidMap/mapService.js
+++ b/src/components/mermaidMap/mapService.js
@@ -225,6 +225,9 @@ export const loadACALayers = (map) => {
     ? benthicOpacityExpression
     : fillBenthicOpacityValue
 
+  // Check if 'clusters' layer exists before adding layers before it
+  const beforeLayerId = map.getLayer('clusters') ? 'clusters' : undefined
+
   map.addSource('atlas-planet', {
     type: 'raster',
     tiles: [
@@ -256,8 +259,8 @@ export const loadACALayers = (map) => {
         'raster-opacity': rasterOpacityExpression,
       },
     },
-    'clusters',
-  ) // Add this layer before the clusters layer to prevent overlapping
+    beforeLayerId,
+  )
 
   map.addLayer(
     {
@@ -270,7 +273,7 @@ export const loadACALayers = (map) => {
         'fill-opacity': fillGeomorphicOpacityExpression,
       },
     },
-    'clusters',
+    beforeLayerId,
   )
 
   map.addLayer(
@@ -284,7 +287,7 @@ export const loadACALayers = (map) => {
         'fill-opacity': fillBenthicOpacityExpression,
       },
     },
-    'clusters',
+    beforeLayerId,
   )
 }
 
@@ -322,7 +325,8 @@ export const getMapMarkersFeature = (records) => {
 export const loadMapMarkersLayer = (map) => {
   map.loadImage(mapPin, (error, image) => {
     if (error) {
-      throw error
+      console.error('Error loading image: ', error)
+      return
     }
 
     map.addImage('custom-marker', image)


### PR DESCRIPTION
[trello ticket](https://trello.com/c/0U9dK0sX/1013-add-new-site-error)

console error `layer with id clusters does not exist on map` no longer appears. Added check to ensure clusters are loaded before adding layers.

to test, go to single site map, add site, open up console

I did notice another error that is currently on dev on sites and now appears on single site map: `Error: Could not load image because of The source image could not be decoded.. Please make sure to use a supported image type such as PNG or JPEG. Note that SVGs are not supported.`

it seems to be happening within this code block in `loadACALayers` (if I comment it out it goes away):

```
  map.addLayer(
    {
      id: 'atlas-planet',
      type: 'raster',
      source: 'atlas-planet',
      'source-layer': 'planet',
      paint: {
        'raster-opacity': rasterOpacityExpression,
      },
    },
    beforeLayerId,
  )
```

I've noticed a couple documented issues related to it [here](https://github.com/mapbox/mapbox-gl-js/issues/10277) and [here](https://github.com/mapbox/mapbox-gl-js/issues/11465) in mapbox-gl GH but haven't found a solution