### PR TITLE
[1008] add upload progress for images in toast (separate from polling statuses)

### DIFF
--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -157,8 +157,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
     }
   }, [uploadedFiles, polling, imagesDoneProcessing])
 
-  console.log({ polling, imagesDoneProcessing })
-
   // Poll every 5 seconds after the first image is uploaded
   const _pollImageStatuses = useEffect(() => {
     let intervalId

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -71,7 +71,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   const [polling, setPolling] = useState(false)
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
   const { projectId, recordId } = useParams()
-  const [imagesDoneProcessing, setImagesDoneProcessing] = useState(false)
+  // const [imagesDoneProcessing, setImagesDoneProcessing] = useState(false)
   const [growthForms, setGrowthForms] = useState()
   const [benthicAttributes, setBenthicAttributes] = useState()
 
@@ -136,24 +136,19 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId, recordId])
 
-  const _updateFilesOnUpload = useEffect(() => {
+  const _startPollingOnUpload = useEffect(() => {
+    if (!uploadedFiles.length && polling) {
+      return
+    }
+
     setPolling(true)
     setImages((prevImages) => {
       const existingImagesMap = new Map(prevImages.map((img) => [img.id, img]))
-
-      // Merge existing images with newly uploaded ones
-      const mergedImages = [...prevImages]
-
-      uploadedFiles.forEach((file) => {
-        // Only add new uploaded files if they don't already exist
-        if (!existingImagesMap.has(file.id)) {
-          mergedImages.push(file)
-        }
-      })
-
-      return mergedImages
+      // Merge only new images
+      const newImages = uploadedFiles.filter((file) => !existingImagesMap.has(file.id))
+      return [...prevImages, ...newImages]
     })
-  }, [uploadedFiles])
+  }, [uploadedFiles, polling])
 
   // Poll every 5 seconds after the first image is uploaded
   const _pollImageStatuses = useEffect(() => {
@@ -181,9 +176,9 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
         if (allProcessed) {
           clearInterval(intervalId)
           setPolling(false)
-          setImagesDoneProcessing(true)
+          // setImagesDoneProcessing(true)
         } else {
-          setImagesDoneProcessing(false)
+          // setImagesDoneProcessing(false)
         }
       } catch (error) {
         console.error('Error polling images:', error)
@@ -202,12 +197,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [polling, projectId])
-
-  const _beginPollingAfterFirstImageIsUploaded = useEffect(() => {
-    if (uploadedFiles.length > 0 && !polling && !imagesDoneProcessing) {
-      setPolling(true)
-    }
-  }, [uploadedFiles, polling, images, imagesDoneProcessing])
 
   return (
     <>

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -74,7 +74,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   const [growthForms, setGrowthForms] = useState()
   const [benthicAttributes, setBenthicAttributes] = useState()
 
-  const isImageProcessed = (status) => status === 3
+  const isImageProcessed = (status) => status === 3 || status === 4
 
   const handleImageClick = (file) => {
     if (isImageProcessed(file.classification_status.status)) {

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -171,6 +171,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
           recordId,
           EXCLUDE_PARAMS,
         )
+
         setImages(response.results)
 
         const allProcessed = response.results.every((file) =>
@@ -178,25 +179,28 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
         )
 
         if (allProcessed) {
-          clearInterval(intervalId)
           setPolling(false)
+        } else {
+          // Schedule the next polling only after the current one completes
+          intervalId = setTimeout(startPolling, 5000)
         }
       } catch (error) {
         console.error('Error polling images:', error)
+        intervalId = setTimeout(startPolling, 5000)
       }
     }
 
     if (polling) {
-      intervalId = setInterval(startPolling, 5000)
+      startPolling()
     }
 
     return () => {
       if (intervalId) {
-        clearInterval(intervalId)
+        clearTimeout(intervalId)
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [polling, projectId])
+  }, [polling, projectId, recordId])
 
   return (
     <>

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -158,12 +158,19 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   // Poll every 5 seconds after the first image is uploaded
   const _pollImageStatuses = useEffect(() => {
     let intervalId
+    let abortController = new AbortController()
+
     const startPolling = async () => {
       try {
+        // Cancel the previous request if any
+        abortController.abort()
+        abortController = new AbortController()
+
         const response = await databaseSwitchboardInstance.getAllImagesInCollectRecord(
           projectId,
           recordId,
           EXCLUDE_PARAMS,
+          { signal: abortController.signal },
         )
         setImages(response.results)
 
@@ -191,6 +198,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
       if (intervalId) {
         clearInterval(intervalId)
       }
+      abortController.abort()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [polling, projectId])

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -186,8 +186,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
     }
   }, [uploadedFiles, polling, images, imagesDoneProcessing])
 
-  console.log({ polling, imagesDoneProcessing, images })
-
   return (
     <>
       <InputWrapper>

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -71,9 +71,9 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   const [polling, setPolling] = useState(false)
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
   const { projectId, recordId } = useParams()
-  // const [imagesDoneProcessing, setImagesDoneProcessing] = useState(false)
   const [growthForms, setGrowthForms] = useState()
   const [benthicAttributes, setBenthicAttributes] = useState()
+  const [imagesDoneProcessing, setImagesDoneProcessing] = useState(false)
 
   const isImageProcessed = (status) => status === 3
 
@@ -137,35 +137,38 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   }, [projectId, recordId])
 
   const _startPollingOnUpload = useEffect(() => {
-    if (!uploadedFiles.length && polling) {
-      return
-    }
+    if (uploadedFiles.length > 0 && !polling && !imagesDoneProcessing) {
+      setPolling(true)
+      setImages((prevImages) => {
+        const existingImagesMap = new Map(prevImages.map((img) => [img.id, img]))
 
-    setPolling(true)
-    setImages((prevImages) => {
-      const existingImagesMap = new Map(prevImages.map((img) => [img.id, img]))
-      // Merge only new images
-      const newImages = uploadedFiles.filter((file) => !existingImagesMap.has(file.id))
-      return [...prevImages, ...newImages]
-    })
-  }, [uploadedFiles, polling])
+        // Merge existing images with newly uploaded ones
+        const mergedImages = [...prevImages]
+
+        uploadedFiles.forEach((file) => {
+          // Only add new uploaded files if they don't already exist
+          if (!existingImagesMap.has(file.id)) {
+            mergedImages.push(file)
+          }
+        })
+
+        return mergedImages
+      })
+    }
+  }, [uploadedFiles, polling, imagesDoneProcessing])
+
+  console.log({ polling, imagesDoneProcessing })
 
   // Poll every 5 seconds after the first image is uploaded
   const _pollImageStatuses = useEffect(() => {
     let intervalId
-    let abortController = new AbortController()
 
     const startPolling = async () => {
       try {
-        // Cancel the previous request if any
-        abortController.abort()
-        abortController = new AbortController()
-
         const response = await databaseSwitchboardInstance.getAllImagesInCollectRecord(
           projectId,
           recordId,
           EXCLUDE_PARAMS,
-          { signal: abortController.signal },
         )
         setImages(response.results)
 
@@ -176,9 +179,9 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
         if (allProcessed) {
           clearInterval(intervalId)
           setPolling(false)
-          // setImagesDoneProcessing(true)
+          setImagesDoneProcessing(true)
         } else {
-          // setImagesDoneProcessing(false)
+          setImagesDoneProcessing(false)
         }
       } catch (error) {
         console.error('Error polling images:', error)
@@ -193,7 +196,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
       if (intervalId) {
         clearInterval(intervalId)
       }
-      abortController.abort()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [polling, projectId])

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -136,6 +136,10 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId, recordId])
 
+  const _updateFilesOnUpload = useEffect(() => {
+    setImages(uploadedFiles)
+  }, [uploadedFiles])
+
   // Poll every 5 seconds after the first image is uploaded
   const _pollImageStatuses = useEffect(() => {
     let intervalId
@@ -181,6 +185,8 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
       setPolling(true)
     }
   }, [uploadedFiles, polling, images, imagesDoneProcessing])
+
+  console.log({ polling, imagesDoneProcessing, images })
 
   return (
     <>

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -137,7 +137,22 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   }, [projectId, recordId])
 
   const _updateFilesOnUpload = useEffect(() => {
-    setImages(uploadedFiles)
+    setPolling(true)
+    setImages((prevImages) => {
+      const existingImagesMap = new Map(prevImages.map((img) => [img.id, img]))
+
+      // Merge existing images with newly uploaded ones
+      const mergedImages = [...prevImages]
+
+      uploadedFiles.forEach((file) => {
+        // Only add new uploaded files if they don't already exist
+        if (!existingImagesMap.has(file.id)) {
+          mergedImages.push(file)
+        }
+      })
+
+      return mergedImages
+    })
   }, [uploadedFiles])
 
   // Poll every 5 seconds after the first image is uploaded

--- a/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
@@ -84,7 +84,7 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
 
     // Show the persistent uploading toast and store the toastId
     if (!toastId.current) {
-      toastId.current = toast.success(renderUploadProgress(0, files.length, handleCancelUpload))
+      toastId.current = toast.info(renderUploadProgress(0, files.length, handleCancelUpload))
     }
 
     isCancelledRef.current = false
@@ -139,7 +139,13 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
     }
 
     if (uploadedFiles.length > 0) {
-      toast.success(uploadText.success)
+      if (toastId.current) {
+        toast.update(toastId.current, {
+          render: uploadText.success,
+          type: toast.TYPE.SUCCESS,
+          autoClose: 5000,
+        })
+      }
     }
 
     if (toastId.current) {

--- a/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
@@ -74,7 +74,15 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
 
     // Show the persistent uploading toast and store the toastId
     if (!toastId.current) {
-      toastId.current = toast.success(`Uploading 0/${files.length} images...`, { autoClose: true })
+      toastId.current = toast.success(
+        <div>
+          <p>Uploading 0/{files.length} images...</p>
+          <ButtonCaution type="button" onClick={handleCancelUpload}>
+            Cancel Upload
+          </ButtonCaution>
+        </div>,
+        { autoClose: true },
+      )
     }
 
     setUploadingImages(true)
@@ -121,7 +129,16 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
 
         if (toastId.current) {
           toast.update(toastId.current, {
-            render: `Uploading ${processedCount}/${files.length} images...`,
+            render: (
+              <div>
+                <p>
+                  Uploading {processedCount}/{files.length} images...
+                </p>
+                <ButtonCaution type="button" onClick={handleCancelUpload}>
+                  Cancel Upload
+                </ButtonCaution>
+              </div>
+            ),
           })
         }
       }
@@ -197,15 +214,9 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
       }
       footerContent={
         <ButtonContainer>
-          {uploadingImages ? (
-            <ButtonCaution type="button" onClick={handleCancelUpload}>
-              Cancel Upload
-            </ButtonCaution>
-          ) : (
-            <ButtonSecondary type="button" onClick={onClose} disabled={uploadingImages}>
-              Close
-            </ButtonSecondary>
-          )}
+          <ButtonSecondary type="button" onClick={onClose} disabled={uploadingImages}>
+            Close
+          </ButtonSecondary>
         </ButtonContainer>
       }
     />

--- a/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useRef } from 'react'
 import { useParams } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import Modal from '../../../generic/Modal'
@@ -9,7 +9,6 @@ import language from '../../../../language'
 import { useDatabaseSwitchboardInstance } from '../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 
 const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => {
-  const [uploadingImages, setUploadingImages] = useState(false)
   const isCancelledRef = useRef(false)
   const fileInputRef = useRef(null)
   const { recordId, projectId } = useParams()
@@ -85,8 +84,6 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
       )
     }
 
-    setUploadingImages(true)
-
     isCancelledRef.current = false
 
     const uploadedFiles = []
@@ -94,7 +91,6 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
 
     for (const file of files) {
       if (isCancelledRef.current) {
-        setUploadingImages(false)
         return
       }
 
@@ -144,7 +140,6 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
       }
 
       if (isCancelledRef.current) {
-        setUploadingImages(false)
         return
       }
     }
@@ -157,8 +152,6 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
       toast.dismiss(toastId.current)
       toastId.current = null
     }
-
-    setUploadingImages(false)
   }
 
   const handleFileChange = (event) => {
@@ -182,7 +175,7 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
 
   const handleCancelUpload = () => {
     isCancelledRef.current = true
-    setUploadingImages(false)
+
     toast.info('Upload cancelled.')
   }
 
@@ -214,7 +207,7 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
       }
       footerContent={
         <ButtonContainer>
-          <ButtonSecondary type="button" onClick={onClose} disabled={uploadingImages}>
+          <ButtonSecondary type="button" onClick={onClose}>
             Close
           </ButtonSecondary>
         </ButtonContainer>

--- a/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
@@ -8,6 +8,17 @@ import { toast } from 'react-toastify'
 import language from '../../../../language'
 import { useDatabaseSwitchboardInstance } from '../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 
+const renderUploadProgress = (processedCount, totalFiles, handleCancelUpload) => (
+  <div>
+    <p>
+      Uploading {processedCount}/{totalFiles} images...
+    </p>
+    <ButtonCaution type="button" onClick={handleCancelUpload}>
+      Cancel Upload
+    </ButtonCaution>
+  </div>
+)
+
 const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => {
   const isCancelledRef = useRef(false)
   const fileInputRef = useRef(null)
@@ -73,14 +84,7 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
 
     // Show the persistent uploading toast and store the toastId
     if (!toastId.current) {
-      toastId.current = toast.success(
-        <div>
-          <p>Uploading 0/{files.length} images...</p>
-          <ButtonCaution type="button" onClick={handleCancelUpload}>
-            Cancel Upload
-          </ButtonCaution>
-        </div>,
-      )
+      toastId.current = toast.success(renderUploadProgress(0, files.length, handleCancelUpload))
     }
 
     isCancelledRef.current = false
@@ -124,16 +128,7 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
 
         if (toastId.current) {
           toast.update(toastId.current, {
-            render: (
-              <div>
-                <p>
-                  Uploading {processedCount}/{files.length} images...
-                </p>
-                <ButtonCaution type="button" onClick={handleCancelUpload}>
-                  Cancel Upload
-                </ButtonCaution>
-              </div>
-            ),
+            render: renderUploadProgress(processedCount, files.length, handleCancelUpload),
           })
         }
       }

--- a/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
@@ -80,7 +80,6 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
             Cancel Upload
           </ButtonCaution>
         </div>,
-        { autoClose: true },
       )
     }
 

--- a/src/language.js
+++ b/src/language.js
@@ -1477,7 +1477,6 @@ const imageClassification = {
       corruptFiles: 'Some files were not added because they appear to be corrupt.',
     },
     success: 'Files uploaded successfully.',
-    uploading: 'Uploading files...',
   },
 }
 

--- a/src/language.js
+++ b/src/language.js
@@ -1477,6 +1477,7 @@ const imageClassification = {
       corruptFiles: 'Some files were not added because they appear to be corrupt.',
     },
     success: 'Files uploaded successfully.',
+    uploading: 'Uploading files...',
   },
 }
 


### PR DESCRIPTION
[trello card](https://trello.com/c/y0LABUpz/1008-ic-add-queued-status-to-images-that-are-being-uploaded-in-table-automatically-close-modal-once-images-are-added)

- dynamically render upload progress in toast after dropping or selecting files
- automatically close upload modal once files are dropped
- set images in observation table as soon as a new image is validated and uploaded

to test:
1. upload images
2. modal automatically closes once images are dropped
3. observe toast with upload progress and cancel upload button
4. toasts clear after images are done uploading, followed by a success message
5. observe images appearing in table as they are uploaded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced image classification capabilities, including image upload, annotation management, and display of classifier guesses.
  - Added a user-friendly modal for reviewing and annotating images with interactive tables and maps.
  - Implemented a new component for selecting sample unit types in image classification.

- **Enhancements**
  - Improved modal functionality with customizable padding and close options.
  - Enhanced image upload interface with validation and real-time feedback.

- **Bug Fixes**
  - Resolved issues related to image processing status updates and user interactions.

- **Documentation**
  - Updated workflow documentation for image classification processes and API interactions.

- **Styles**
  - Added styled components for better UI consistency across image classification features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->