### PR TITLE
[1040] IC table design updates

### DIFF
--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -74,6 +74,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   const [distilledImages, setDistilledImages] = useState([])
   const [isFetching, setIsFetching] = useState(false)
   const isFirstLoad = useRef(true)
+  const pollTimeoutRef = useRef(null)
 
   const isImageProcessed = (status) => status === 3 || status === 4
 
@@ -158,6 +159,32 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
     })
   }, [distillAnnotationData, images])
 
+  const pollImageStatuses = useCallback(async () => {
+    try {
+      const response = await databaseSwitchboardInstance.getAllImagesInCollectRecord(
+        projectId,
+        recordId,
+        EXCLUDE_PARAMS,
+      )
+
+      setImages(response.results)
+
+      const allProcessed = response.results.every((file) =>
+        isImageProcessed(file.classification_status.status),
+      )
+
+      if (!allProcessed) {
+        pollTimeoutRef.current = setTimeout(pollImageStatuses, 5000)
+      } else {
+        setPolling(false)
+      }
+    } catch (error) {
+      console.error('Error polling images:', error)
+      pollTimeoutRef.current = setTimeout(pollImageStatuses, 5000)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId, recordId])
+
   const _fetchImagesOnLoad = useEffect(() => {
     const fetchImages = async () => {
       if (!recordId || !projectId || isFetching || !isFirstLoad.current) {
@@ -230,51 +257,10 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
 
       if (!polling) {
         setPolling(true)
+        pollImageStatuses()
       }
     }
-  }, [uploadedFiles, images, polling, distillImagesData])
-
-  // Poll every 5 seconds after the first image is uploaded
-  const _pollImageStatuses = useEffect(() => {
-    let intervalId
-
-    const startPolling = async () => {
-      try {
-        const response = await databaseSwitchboardInstance.getAllImagesInCollectRecord(
-          projectId,
-          recordId,
-          EXCLUDE_PARAMS,
-        )
-
-        setImages(response.results)
-
-        const allProcessed = response.results.every((file) =>
-          isImageProcessed(file.classification_status.status),
-        )
-
-        if (allProcessed) {
-          setPolling(false)
-        } else {
-          // Schedule the next polling only after the current one completes
-          intervalId = setTimeout(startPolling, 5000)
-        }
-      } catch (error) {
-        console.error('Error polling images:', error)
-        intervalId = setTimeout(startPolling, 5000)
-      }
-    }
-
-    if (polling) {
-      startPolling()
-    }
-
-    return () => {
-      if (intervalId) {
-        clearTimeout(intervalId)
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [polling, projectId, recordId])
+  }, [uploadedFiles, images, polling, distillImagesData, pollImageStatuses])
 
   return (
     <>

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -74,7 +74,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   const [distilledImages, setDistilledImages] = useState([])
   const [isFetching, setIsFetching] = useState(false)
   const isFirstLoad = useRef(true)
-  // const pollTimeoutRef = useRef(null)
 
   const isImageProcessed = (status) => status === 3 || status === 4
 

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -23,7 +23,7 @@ const tableHeaders = [
   { align: 'right', id: 'quadrat-number-label', text: 'Quadrat' },
   { align: 'left', id: 'benthic-attribute-label', text: 'Benthic Attribute' },
   { align: 'right', id: 'growth-form-label', text: 'Growth Form' },
-  { colSpan: 3, align: 'center', id: 'number-of-points-label', text: 'Number of Points' },
+  { colSpan: 4, align: 'center', id: 'number-of-points-label', text: 'Number of Points' },
   { align: 'right', id: 'validations', text: 'Validations' },
   { align: 'right', id: 'review', text: '' },
   { align: 'right', id: 'remove', text: '' },
@@ -37,8 +37,11 @@ const TableHeaderRow = ({ hideStatus }) => (
         return null
       }
 
+      const colSpan =
+        header.id === 'number-of-points-label' ? (hideStatus ? 4 : 3) : header.colSpan || 1
+
       return (
-        <Th key={header.id} align={header.align} id={header.id} colSpan={header.colSpan || 1}>
+        <Th key={header.id} align={header.align} id={header.id} colSpan={colSpan}>
           <span>{header.text}</span>
         </Th>
       )
@@ -56,9 +59,9 @@ const subHeaderColumns = [
   { align: 'center', text: 'Unknown' },
 ]
 
-const SubHeaderRow = () => (
+const SubHeaderRow = ({ hideStatus }) => (
   <Tr>
-    <Th colSpan={6} />
+    <Th colSpan={hideStatus ? 5 : 6} />
     {subHeaderColumns.map((col, index) => (
       <Th key={index} align={col.align}>
         <span>{col.text}</span>
@@ -67,6 +70,10 @@ const SubHeaderRow = () => (
     <Th colSpan={4} />
   </Tr>
 )
+
+SubHeaderRow.propTypes = {
+  hideStatus: PropTypes.bool.isRequired,
+}
 
 const statusLabels = {
   0: 'Unknown',
@@ -204,9 +211,8 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
         <StyledOverflowWrapper>
           <StickyObservationTable aria-labelledby="table-label">
             <thead>
-              {/* Pass imagesDoneProcessing to TableHeaderRow to hide/show the status column */}
               <TableHeaderRow hideStatus={imagesDoneProcessing} />
-              <SubHeaderRow />
+              <SubHeaderRow hideStatus={imagesDoneProcessing} />
             </thead>
             <tbody>
               {images.map((file, index) => {
@@ -235,7 +241,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                       >
                         <Thumbnail imageUrl={file.thumbnail || file.image} />
                       </TdWithHoverText>
-                      {/* Conditionally render the "Status" column */}
                       {!imagesDoneProcessing && (
                         <StyledTd>{statusLabels[file.classification_status.status]}</StyledTd>
                       )}
@@ -278,7 +283,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
 
                       return (
                         <Tr key={`${file.id}-sub-${idx}`}>
-                          <StyledTd colSpan={4} />
+                          <StyledTd colSpan={imagesDoneProcessing ? 3 : 4} />
                           <StyledTd>
                             {getBenthicAttributeLabel(
                               imageAnnotationData[key][0].annotations[0].benthic_attribute,

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -260,6 +260,12 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
         pollImageStatuses()
       }
     }
+
+    return () => {
+      if (pollTimeoutRef.current) {
+        clearTimeout(pollTimeoutRef.current)
+      }
+    }
   }, [uploadedFiles, images, polling, distillImagesData, pollImageStatuses])
 
   return (

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -135,7 +135,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
     [getBenthicAttributeLabel, getGrowthFormLabel, benthicAttributes, growthForms],
   )
 
-  const distillImagesObject = useCallback(
+  const distillImagesData = useCallback(
     (images) => {
       return images.map((file, index) => {
         const classifiedPoints = file.points.filter(({ annotations }) => annotations.length > 0)
@@ -205,12 +205,12 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId, recordId, benthicAttributes, growthForms])
 
-  const _distillImageData = useEffect(() => {
+  const _distillImagseData = useEffect(() => {
     if (benthicAttributes && growthForms && images.length > 0) {
-      const distilled = distillImagesObject(images)
+      const distilled = distillImagesData(images)
       setDistilledImages(distilled)
     }
-  }, [benthicAttributes, growthForms, images, distillImagesObject])
+  }, [benthicAttributes, growthForms, images, distillImagesData])
 
   const _startPollingOnUpload = useEffect(() => {
     const hasNewImages = uploadedFiles.some((file) => !images.some((img) => img.id === file.id))
@@ -228,7 +228,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
           }
         })
 
-        setDistilledImages(distillImagesObject(mergedImages))
+        setDistilledImages(distillImagesData(mergedImages))
 
         return mergedImages
       })
@@ -237,7 +237,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
         setPolling(true)
       }
     }
-  }, [uploadedFiles, images, polling, distillImagesObject])
+  }, [uploadedFiles, images, polling, distillImagesData])
 
   // Poll every 5 seconds after the first image is uploaded
   const _pollImageStatuses = useEffect(() => {
@@ -252,7 +252,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
         )
 
         setImages(response.results)
-        setDistilledImages(distillImagesObject(response.results))
+        setDistilledImages(distillImagesData(response.results))
 
         const allProcessed = response.results.every((file) =>
           isImageProcessed(file.classification_status.status),

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -29,15 +29,11 @@ const tableHeaders = [
 
 const TableHeaderRow = () => (
   <Tr>
-    {tableHeaders.map((header) => {
-      const colSpan = header.id === 'number-of-points-label' ? 3 : header.colSpan || 1
-
-      return (
-        <Th key={header.id} align={header.align} id={header.id} colSpan={colSpan}>
-          <span>{header.text}</span>
-        </Th>
-      )
-    })}
+    {tableHeaders.map((header) => (
+      <Th key={header.id} align={header.align} id={header.id} colSpan={header.colSpan || 1}>
+        <span>{header.text}</span>
+      </Th>
+    ))}
   </Tr>
 )
 
@@ -107,7 +103,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   const distillAnnotationData = useCallback(
     (items, index) => {
       if (!benthicAttributes || !growthForms) {
-        console.warn('Benthic Attributes or Growth Forms not available yet')
         return null
       }
 

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -135,31 +135,28 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
     [getBenthicAttributeLabel, getGrowthFormLabel, benthicAttributes, growthForms],
   )
 
-  const distillImagesData = useCallback(
-    (images) => {
-      return images.map((file, index) => {
-        const classifiedPoints = file.points.filter(({ annotations }) => annotations.length > 0)
+  const distillImagesData = useCallback(() => {
+    return images.map((file, index) => {
+      const classifiedPoints = file.points.filter(({ annotations }) => annotations.length > 0)
 
-        const imageAnnotationData = Object.groupBy(
-          classifiedPoints,
-          ({ annotations }) => annotations[0].benthic_attribute + '_' + annotations[0].growth_form,
-        )
+      const imageAnnotationData = Object.groupBy(
+        classifiedPoints,
+        ({ annotations }) => annotations[0].benthic_attribute + '_' + annotations[0].growth_form,
+      )
 
-        const numSubRows = Object.keys(imageAnnotationData).length
+      const numSubRows = Object.keys(imageAnnotationData).length
 
-        const distilledAnnotationData = Object.keys(imageAnnotationData).map((key) =>
-          distillAnnotationData(imageAnnotationData[key], index),
-        )
+      const distilledAnnotationData = Object.keys(imageAnnotationData).map((key) =>
+        distillAnnotationData(imageAnnotationData[key], index),
+      )
 
-        return {
-          file,
-          numSubRows,
-          distilledAnnotationData,
-        }
-      })
-    },
-    [distillAnnotationData],
-  )
+      return {
+        file,
+        numSubRows,
+        distilledAnnotationData,
+      }
+    })
+  }, [distillAnnotationData, images])
 
   const _fetchImagesOnLoad = useEffect(() => {
     const fetchImages = async () => {
@@ -205,7 +202,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId, recordId, benthicAttributes, growthForms])
 
-  const _distillImagseData = useEffect(() => {
+  const _distillImagesData = useEffect(() => {
     if (benthicAttributes && growthForms && images.length > 0) {
       const distilled = distillImagesData(images)
       setDistilledImages(distilled)
@@ -227,8 +224,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
             mergedImages.push(file)
           }
         })
-
-        setDistilledImages(distillImagesData(mergedImages))
 
         return mergedImages
       })
@@ -252,7 +247,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
         )
 
         setImages(response.results)
-        setDistilledImages(distillImagesData(response.results))
 
         const allProcessed = response.results.every((file) =>
           isImageProcessed(file.classification_status.status),

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -307,19 +307,12 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                       </TdWithHoverText>
 
                       <StyledTd
-                        colSpan={6}
+                        colSpan={8}
                         textAlign={
                           isImageProcessed(file.classification_status.status) ? 'left' : 'center'
                         }
                       >
                         {statusLabels[file.classification_status.status]}
-                      </StyledTd>
-
-                      <StyledTd>
-                        <button>Review</button>
-                      </StyledTd>
-                      <StyledTd>
-                        <button>Delete</button>
                       </StyledTd>
                     </Tr>
                   )
@@ -348,10 +341,18 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                         <StyledTd rowSpan={numSubRows}>{file.num_unconfirmed}</StyledTd>
                         <StyledTd rowSpan={numSubRows}>{file.num_unclassified}</StyledTd>
                         <StyledTd rowSpan={numSubRows}>
-                          <button>Review</button>
+                          <ButtonPrimary
+                            type="button"
+                            onClick={() => setImageId(file.id)}
+                            disabled={!isImageProcessed(file.classification_status.status)}
+                          >
+                            Review
+                          </ButtonPrimary>
                         </StyledTd>
                         <StyledTd rowSpan={numSubRows}>
-                          <button>Delete</button>
+                          <ButtonCaution type="button" onClick={() => handleRemoveFile(file)}>
+                            <IconClose aria-label="close" />
+                          </ButtonCaution>
                         </StyledTd>
                       </>
                     )}

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -73,6 +73,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   const [benthicAttributes, setBenthicAttributes] = useState()
   const [distilledImages, setDistilledImages] = useState([])
   const [isFetching, setIsFetching] = useState(false)
+  const isFirstLoad = useRef(true)
   const pollTimeoutRef = useRef(null)
 
   const isImageProcessed = (status) => status === 3 || status === 4
@@ -186,10 +187,11 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
 
   const _fetchImagesOnLoad = useEffect(() => {
     const fetchImages = async () => {
-      if (!recordId || !projectId || isFetching) {
+      if (!recordId || !projectId || isFetching || !isFirstLoad.current) {
         return
       }
       setIsFetching(true)
+      isFirstLoad.current = false
 
       try {
         const [choicesResponse, benthicAttributesResponse] = await Promise.all([

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -127,8 +127,8 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
 
       return {
         confirmedCount,
-        benthic_attribute: benthic_attribute_label,
-        growth_form: growth_form_label,
+        benthicAttributeLabel: benthic_attribute_label,
+        growthFormLabel: growth_form_label,
         quadrat: index + 1,
       }
     },
@@ -137,7 +137,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
 
   const distillImagesObject = useCallback(
     (images) => {
-      const distilledImages = images.map((file, index) => {
+      return images.map((file, index) => {
         const classifiedPoints = file.points.filter(({ annotations }) => annotations.length > 0)
 
         const imageAnnotationData = Object.groupBy(
@@ -157,8 +157,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
           distilledAnnotationData,
         }
       })
-
-      return distilledImages
     },
     [distillAnnotationData],
   )
@@ -340,16 +338,20 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                       </>
                     )}
 
-                    <StyledTd>{annotation?.quadrat}</StyledTd>
-                    <StyledTd>{annotation?.benthic_attribute}</StyledTd>
-                    <StyledTd>{annotation?.growth_form || 'N/A'}</StyledTd>
-                    <StyledTd>{annotation?.confirmedCount}</StyledTd>
+                    <StyledTd textAlign="right">{annotation?.quadrat}</StyledTd>
+                    <StyledTd>{annotation?.benthicAttributeLabel}</StyledTd>
+                    <StyledTd>{annotation?.growthFormLabel || ''}</StyledTd>
+                    <StyledTd textAlign="right">{annotation?.confirmedCount}</StyledTd>
 
                     {/* First row only: Unconfirmed, Unclassified, Review, Delete */}
                     {subIndex === 0 && (
                       <>
-                        <StyledTd rowSpan={numSubRows}>{file.num_unconfirmed}</StyledTd>
-                        <StyledTd rowSpan={numSubRows}>{file.num_unclassified}</StyledTd>
+                        <StyledTd textAlign="right" rowSpan={numSubRows}>
+                          {file.num_unconfirmed}
+                        </StyledTd>
+                        <StyledTd textAlign="right" rowSpan={numSubRows}>
+                          {file.num_unclassified}
+                        </StyledTd>
                         <StyledTd rowSpan={numSubRows}>
                           <ButtonPrimary
                             type="button"

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -23,8 +23,7 @@ const tableHeaders = [
   { align: 'right', id: 'quadrat-number-label', text: 'Quadrat' },
   { align: 'left', id: 'benthic-attribute-label', text: 'Benthic Attribute' },
   { align: 'right', id: 'growth-form-label', text: 'Growth Form' },
-  { colSpan: 4, align: 'center', id: 'number-of-points-label', text: 'Number of Points' },
-  { align: 'right', id: 'validations', text: 'Validations' },
+  { colSpan: 3, align: 'center', id: 'number-of-points-label', text: 'Number of Points' },
   { align: 'right', id: 'review', text: '' },
   { align: 'right', id: 'remove', text: '' },
 ]
@@ -32,13 +31,11 @@ const tableHeaders = [
 const TableHeaderRow = ({ hideStatus }) => (
   <Tr>
     {tableHeaders.map((header) => {
-      // Skip rendering the "Status" header if hideStatus is true
       if (hideStatus && header.id === 'status-label') {
         return null
       }
 
-      const colSpan =
-        header.id === 'number-of-points-label' ? (hideStatus ? 4 : 3) : header.colSpan || 1
+      const colSpan = header.id === 'number-of-points-label' ? 3 : header.colSpan || 1
 
       return (
         <Th key={header.id} align={header.align} id={header.id} colSpan={colSpan}>
@@ -156,6 +153,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
 
   const _updateFilesOnUpload = useEffect(() => {
     setImages(uploadedFiles)
+    setImagesDoneProcessing(false)
   }, [uploadedFiles])
 
   // Poll every 5 seconds after the first image is uploaded
@@ -250,7 +248,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                       <StyledTd>{file.num_confirmed}</StyledTd>
                       <StyledTd>{file.num_unconfirmed}</StyledTd>
                       <StyledTd>{file.num_unclassified}</StyledTd>
-                      <StyledTd></StyledTd>
                       <StyledTd>
                         <ButtonPrimary
                           type="button"

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -287,10 +287,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                 const { file, distilledAnnotationData, numSubRows } = image
 
                 if (numSubRows === 0) {
-                  // If no subrows exist (image not processed), display a single row with thumbnail, status, review, and delete
-                  {
-                    console.log(isImageProcessed(file.classification_status.status))
-                  }
+                  // If no subrows exist (image not processed), display a single row with thumbnail, status
                   return (
                     <Tr key={file.id}>
                       <StyledTd>{imageIndex + 1}</StyledTd>
@@ -318,7 +315,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                   )
                 }
 
-                // If there are subrows (processed image), render the rows with distilledAnnotationData
+                // If there are subrows (processed image), render annotation data
                 return distilledAnnotationData.map((annotation, subIndex) => (
                   <Tr key={`${file.id}-${subIndex}`}>
                     {subIndex === 0 && (
@@ -360,95 +357,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                 ))
               })}
             </tbody>
-
-            {/* <tbody>
-              {images.map((file, index) => {
-                const classifiedPoints = file.points.filter(
-                  ({ annotations }) => annotations.length > 0,
-                )
-
-                const imageAnnotationData = Object.groupBy(
-                  classifiedPoints,
-                  ({ annotations }) =>
-                    annotations[0].benthic_attribute + '_' + annotations[0].growth_form,
-                )
-
-                const numSubRows = Object.keys(imageAnnotationData).length
-
-                return (
-                  <React.Fragment key={index}>
-                    <Tr>
-                      <StyledTd>{index + 1}</StyledTd>
-                      <TdWithHoverText
-                        data-tooltip={file.original_image_name}
-                        onClick={() => handleImageClick(file)}
-                        cursor={
-                          isImageProcessed(file.classification_status.status)
-                            ? 'pointer'
-                            : 'default'
-                        }
-                        rowspan={numSubRows}
-                      >
-                        <Thumbnail imageUrl={file.thumbnail} />
-                      </TdWithHoverText>
-                      {!!polling && (
-                        <StyledTd>{statusLabels[file.classification_status.status]}</StyledTd>
-                      )}
-                      <StyledTd></StyledTd>
-                      <StyledTd></StyledTd>
-                      <StyledTd></StyledTd>
-                      <StyledTd></StyledTd>
-                      <StyledTd>{file.num_unconfirmed}</StyledTd>
-                      <StyledTd>{file.num_unclassified}</StyledTd>
-                      <StyledTd>
-                        <ButtonPrimary
-                          type="button"
-                          onClick={() => setImageId(file.id)}
-                          disabled={!isImageProcessed(file.classification_status.status)}
-                        >
-                          Review
-                        </ButtonPrimary>
-                      </StyledTd>
-                      <StyledTd>
-                        <ButtonCaution type="button" onClick={() => handleRemoveFile(file)}>
-                          <IconClose aria-label="close" />
-                        </ButtonCaution>
-                      </StyledTd>
-                    </Tr>
-
-                    {Object.keys(imageAnnotationData).map((key, idx) => {
-                      const { confirmedCount } = imageAnnotationData[key].reduce(
-                        (counts, item) => {
-                          if (item.annotations[0].is_confirmed) {
-                            counts.confirmedCount += 1
-                          }
-                          return counts
-                        },
-                        { confirmedCount: 0 },
-                      )
-
-                      return (
-                        <Tr key={`${file.id}-sub-${idx}`}>
-                          <StyledTd colSpan={!polling ? 2 : 3} />
-                          <StyledTd>{index + 1}</StyledTd>
-                          <StyledTd>
-                            {getBenthicAttributeLabel(
-                              imageAnnotationData[key][0].annotations[0].benthic_attribute,
-                            )}
-                          </StyledTd>
-                          <StyledTd>
-                            {getGrowthFormLabel(
-                              imageAnnotationData[key][0].annotations[0].growth_form,
-                            )}
-                          </StyledTd>
-                          <StyledTd>{confirmedCount}</StyledTd>
-                        </Tr>
-                      )
-                    })}
-                  </React.Fragment>
-                )
-              })}
-            </tbody> */}
           </StickyObservationTable>
         </StyledOverflowWrapper>
       </InputWrapper>

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -242,10 +242,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                       {!imagesDoneProcessing && (
                         <StyledTd>{statusLabels[file.classification_status.status]}</StyledTd>
                       )}
-                      <StyledTd>{index + 1}</StyledTd>
-                      <StyledTd></StyledTd>
-                      <StyledTd></StyledTd>
-                      <StyledTd>{file.num_confirmed}</StyledTd>
+                      <StyledTd colSpan={4}></StyledTd>
                       <StyledTd>{file.num_unconfirmed}</StyledTd>
                       <StyledTd>{file.num_unclassified}</StyledTd>
                       <StyledTd>
@@ -266,21 +263,20 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
 
                     {/* Subrows based on imageAnnotationData */}
                     {Object.keys(imageAnnotationData).map((key, idx) => {
-                      const { confirmedCount, unconfirmedCount } = imageAnnotationData[key].reduce(
+                      const { confirmedCount } = imageAnnotationData[key].reduce(
                         (counts, item) => {
                           if (item.annotations[0].is_confirmed) {
                             counts.confirmedCount += 1
-                          } else {
-                            counts.unconfirmedCount += 1
                           }
                           return counts
                         },
-                        { confirmedCount: 0, unconfirmedCount: 0 },
+                        { confirmedCount: 0 },
                       )
 
                       return (
                         <Tr key={`${file.id}-sub-${idx}`}>
-                          <StyledTd colSpan={imagesDoneProcessing ? 3 : 4} />
+                          <StyledTd colSpan={imagesDoneProcessing ? 2 : 3} />
+                          <StyledTd>{index + 1}</StyledTd>
                           <StyledTd>
                             {getBenthicAttributeLabel(
                               imageAnnotationData[key][0].annotations[0].benthic_attribute,
@@ -292,7 +288,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                             )}
                           </StyledTd>
                           <StyledTd>{confirmedCount}</StyledTd>
-                          <StyledTd>{unconfirmedCount}</StyledTd>
                         </Tr>
                       )
                     })}

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -224,6 +224,8 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                     annotations[0].benthic_attribute + '_' + annotations[0].growth_form,
                 )
 
+                const numSubRows = Object.keys(imageAnnotationData).length
+
                 return (
                   <React.Fragment key={index}>
                     <Tr>
@@ -236,13 +238,17 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                             ? 'pointer'
                             : 'default'
                         }
+                        rowspan={numSubRows}
                       >
                         <Thumbnail imageUrl={file.thumbnail || file.image} />
                       </TdWithHoverText>
                       {!imagesDoneProcessing && (
                         <StyledTd>{statusLabels[file.classification_status.status]}</StyledTd>
                       )}
-                      <StyledTd colSpan={4}></StyledTd>
+                      <StyledTd></StyledTd>
+                      <StyledTd></StyledTd>
+                      <StyledTd></StyledTd>
+                      <StyledTd></StyledTd>
                       <StyledTd>{file.num_unconfirmed}</StyledTd>
                       <StyledTd>{file.num_unclassified}</StyledTd>
                       <StyledTd>

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -29,15 +29,26 @@ const tableHeaders = [
   { align: 'right', id: 'remove', text: '' },
 ]
 
-const TableHeaderRow = () => (
+const TableHeaderRow = ({ hideStatus }) => (
   <Tr>
-    {tableHeaders.map((header) => (
-      <Th key={header.id} align={header.align} id={header.id} colSpan={header.colSpan || 1}>
-        <span>{header.text}</span>
-      </Th>
-    ))}
+    {tableHeaders.map((header) => {
+      // Skip rendering the "Status" header if hideStatus is true
+      if (hideStatus && header.id === 'status-label') {
+        return null
+      }
+
+      return (
+        <Th key={header.id} align={header.align} id={header.id} colSpan={header.colSpan || 1}>
+          <span>{header.text}</span>
+        </Th>
+      )
+    })}
   </Tr>
 )
+
+TableHeaderRow.propTypes = {
+  hideStatus: PropTypes.bool.isRequired,
+}
 
 const subHeaderColumns = [
   { align: 'center', text: 'Confirmed' },
@@ -193,7 +204,8 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
         <StyledOverflowWrapper>
           <StickyObservationTable aria-labelledby="table-label">
             <thead>
-              <TableHeaderRow />
+              {/* Pass imagesDoneProcessing to TableHeaderRow to hide/show the status column */}
+              <TableHeaderRow hideStatus={imagesDoneProcessing} />
               <SubHeaderRow />
             </thead>
             <tbody>
@@ -223,7 +235,10 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                       >
                         <Thumbnail imageUrl={file.thumbnail || file.image} />
                       </TdWithHoverText>
-                      <StyledTd>{statusLabels[file.classification_status.status]}</StyledTd>
+                      {/* Conditionally render the "Status" column */}
+                      {!imagesDoneProcessing && (
+                        <StyledTd>{statusLabels[file.classification_status.status]}</StyledTd>
+                      )}
                       <StyledTd>{index + 1}</StyledTd>
                       <StyledTd></StyledTd>
                       <StyledTd></StyledTd>
@@ -276,7 +291,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                           </StyledTd>
                           <StyledTd>{confirmedCount}</StyledTd>
                           <StyledTd>{unconfirmedCount}</StyledTd>
-                          {/* Additional columns for subrow */}
                         </Tr>
                       )
                     })}

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -291,20 +291,14 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                       <TdWithHoverText
                         data-tooltip={file.original_image_name}
                         onClick={() => handleImageClick(file)}
-                        cursor={
-                          isImageProcessed(file.classification_status.status)
-                            ? 'pointer'
-                            : 'default'
-                        }
+                        cursor={file.classification_status.status === 3 ? 'pointer' : 'default'}
                       >
                         <Thumbnail imageUrl={file.thumbnail} />
                       </TdWithHoverText>
 
                       <StyledTd
                         colSpan={8}
-                        textAlign={
-                          isImageProcessed(file.classification_status.status) ? 'left' : 'center'
-                        }
+                        textAlign={file.classification_status.status === 3 ? 'left' : 'center'}
                       >
                         {statusLabels[file.classification_status.status]}
                       </StyledTd>
@@ -338,15 +332,13 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
                         <StyledTd textAlign="right" rowSpan={numSubRows}>
                           {file.num_unclassified}
                         </StyledTd>
-                        <StyledTd rowSpan={numSubRows}>
-                          <ButtonPrimary
-                            type="button"
-                            onClick={() => setImageId(file.id)}
-                            disabled={!isImageProcessed(file.classification_status.status)}
-                          >
-                            Review
-                          </ButtonPrimary>
-                        </StyledTd>
+                        {file.classification_status.status === 3 && (
+                          <StyledTd colSpan={8} textAlign="right">
+                            <ButtonPrimary type="button" onClick={() => setImageId(file.id)}>
+                              Review
+                            </ButtonPrimary>
+                          </StyledTd>
+                        )}
                         <StyledTd rowSpan={numSubRows}>
                           <ButtonCaution type="button" onClick={() => handleRemoveFile(file)}>
                             <IconClose aria-label="close" />

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -73,7 +73,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
   const [benthicAttributes, setBenthicAttributes] = useState()
   const [distilledImages, setDistilledImages] = useState([])
   const [isFetching, setIsFetching] = useState(false)
-  const isFirstLoad = useRef(true)
   const pollTimeoutRef = useRef(null)
 
   const isImageProcessed = (status) => status === 3 || status === 4
@@ -187,11 +186,10 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
 
   const _fetchImagesOnLoad = useEffect(() => {
     const fetchImages = async () => {
-      if (!recordId || !projectId || isFetching || !isFirstLoad.current) {
+      if (!recordId || !projectId || isFetching) {
         return
       }
       setIsFetching(true)
-      isFirstLoad.current = false
 
       try {
         const [choicesResponse, benthicAttributesResponse] = await Promise.all([
@@ -227,7 +225,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, handleRemoveFile }
     fetchImages()
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectId, recordId, benthicAttributes, growthForms])
+  }, [])
 
   const _distillImagesData = useEffect(() => {
     if (benthicAttributes && growthForms && images.length > 0) {

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.styles.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.styles.js
@@ -30,6 +30,7 @@ const StyledColgroup = styled('colgroup')`
 
 const StyledTd = styled(Td)`
   padding: 0.5em !important;
+  text-align: ${(props) => props.textAlign};
 `
 
 const IconContainer = styled('span')`


### PR DESCRIPTION
[trello card](https://trello.com/c/84z4ha0o/1040-ic-observation-table-design-updates)

- fixed bug where initial fetch was being called several times
- added functions to reformat/distill images and annotation data for easier table use
- got rid of status column and stretched the status across columns when its processing
- reformatted table so it no longer has header/subheader rows


todo:
- fix row highlight to match[ codepen](https://codepen.io/alanjleonard/pen/dyBBdLL?editors=1100) example
- adjust row numbers to increase for each row rather than each image

to test:
- upload images
- notice new status bar
- refresh after images are processed