### PR TITLE
[1057] fetch new table data when annotation modal updates

### DIFF
--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
@@ -29,7 +29,13 @@ const EXCLUDE_PARAMS =
 
 const prioritizeConfirmedAnnotations = (a, b) => b.is_confirmed - a.is_confirmed
 
-const ImageAnnotationModal = ({ imageId, setImageId, benthicAttributes, growthForms }) => {
+const ImageAnnotationModal = ({
+  imageId,
+  setImageId,
+  benthicAttributes,
+  growthForms,
+  onAnnotationSaveSuccess,
+}) => {
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
   const { projectId } = useParams()
   const [dataToReview, setDataToReview] = useState()
@@ -82,6 +88,7 @@ const ImageAnnotationModal = ({ imageId, setImageId, benthicAttributes, growthFo
       .saveAnnotationsForImage(projectId, imageId, dataToReview.points)
       .then(() => {
         setImageId()
+        onAnnotationSaveSuccess()
         toast.success('Successfully saved image annotations')
       })
       .catch(() => {
@@ -152,6 +159,7 @@ ImageAnnotationModal.propTypes = {
   setImageId: PropTypes.func.isRequired,
   benthicAttributes: PropTypes.arrayOf(PropTypes.object).isRequired,
   growthForms: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onAnnotationSaveSuccess: PropTypes.func.isRequired,
 }
 
 export default ImageAnnotationModal

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.styles.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.styles.js
@@ -42,10 +42,6 @@ const ButtonContainer = styled.div`
 `
 
 const TdWithHoverText = styled(StyledTd)`
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   cursor: ${(props) => props.cursor};
 
   &::after {


### PR DESCRIPTION
[trello card](https://trello.com/c/idLGnJEt/1057-ic-update-table-when-annotation-modal-saves-new-updates)

- added image data fetch when annotation save success
- re-enabled image thumbnail click when ready-for-review (got accidentally disabled before in a table design update)

to test:
1. upload images
2. save annotation table
3. see updated data in image classification table after modal closes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced image classification functionality, including image annotation management through a new modal interface.
  - Added components for uploading images and displaying image classification observations.
  - Implemented a sample unit input selector to manage image classification states.

- **Enhancements**
  - Improved modal configurations for user interactions, including customizable padding and close options.
  - Added new styled components for better visual representation of image classification data.

- **Documentation**
  - Comprehensive API documentation for image classification workflows has been added.

- **Bug Fixes**
  - Resolved issues related to file validation during image uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->