### PR TITLE
[1058] update table index rows

### DIFF
--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -301,6 +301,8 @@ const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }
     }
   }, [uploadedFiles, polling, images])
 
+  let rowIndex = 1
+
   return (
     <>
       <InputWrapper>
@@ -313,14 +315,14 @@ const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }
             </thead>
 
             <tbody>
-              {distilledImages.map((image, imageIndex) => {
+              {distilledImages.map((image) => {
                 const { file, distilledAnnotationData, numSubRows } = image
 
                 if (numSubRows === 0) {
                   // If no subrows exist (image not processed), display a single row with thumbnail, status
                   return (
                     <Tr key={file.id}>
-                      <StyledTd>{imageIndex + 1}</StyledTd>
+                      <StyledTd>{rowIndex++}</StyledTd>
                       <TdWithHoverText
                         data-tooltip={file.original_image_name}
                         onClick={() => handleImageClick(file)}
@@ -328,7 +330,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }
                       >
                         <Thumbnail imageUrl={file.thumbnail} />
                       </TdWithHoverText>
-
                       <StyledTd
                         colSpan={8}
                         textAlign={file.classification_status.status === 3 ? 'left' : 'center'}
@@ -342,9 +343,9 @@ const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }
                 // If there are subrows (processed image), render annotation data
                 return distilledAnnotationData.map((annotation, subIndex) => (
                   <Tr key={`${file.id}-${subIndex}`}>
+                    <StyledTd>{rowIndex++}</StyledTd>
                     {subIndex === 0 && (
                       <>
-                        <StyledTd rowSpan={numSubRows}>{imageIndex + 1}</StyledTd>
                         <TdWithHoverText
                           rowSpan={numSubRows}
                           data-tooltip={file.original_image_name}
@@ -355,20 +356,17 @@ const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }
                         </TdWithHoverText>
                       </>
                     )}
-
                     <StyledTd textAlign="right">{annotation?.quadrat}</StyledTd>
                     <StyledTd>{annotation?.benthicAttributeLabel}</StyledTd>
                     <StyledTd>{annotation?.growthFormLabel || ''}</StyledTd>
                     <StyledTd textAlign="right">{annotation?.confirmedCount}</StyledTd>
-
-                    {/* First row only: Unconfirmed, Unclassified, Review, Delete */}
                     {subIndex === 0 && (
                       <>
                         <StyledTd textAlign="right" rowSpan={numSubRows}>
                           {file.num_unconfirmed}
                         </StyledTd>
                         <StyledTd textAlign="right" rowSpan={numSubRows}>
-                          {file.num_unclassified}
+                          {file.num_unknown}
                         </StyledTd>
                         <StyledTd rowSpan={numSubRows}>
                           <ButtonPrimary

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -366,7 +366,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }
                           {file.num_unconfirmed}
                         </StyledTd>
                         <StyledTd textAlign="right" rowSpan={numSubRows}>
-                          {file.num_unknown}
+                          {file.num_unclassified}
                         </StyledTd>
                         <StyledTd rowSpan={numSubRows}>
                           <ButtonPrimary


### PR DESCRIPTION
now rows increment by row number instead of image index number

to test:

- upload images 
- ensure # column values increment by row number
- add images, ensure row number is consistent

<img width="499" alt="Screenshot 2024-09-25 at 4 13 13 PM" src="https://github.com/user-attachments/assets/1bca6625-3fe8-4a1c-8075-7a4bea2d249a">
