### PR TITLE
M1041: Sort By Latest

### DIFF
--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -31,6 +31,8 @@ const tableHeaders = [
 ]
 
 const sortByLatest = (a, b) => new Date(a.file.created_on) - new Date(b.file.created_on)
+const sortAlphabetically = (a, b) => a.benthicAttributeLabel.localeCompare(b.benthicAttributeLabel)
+const prioritizeConfirmedAnnotations = (a, b) => b.is_confirmed - a.is_confirmed
 
 const TableHeaderRow = () => (
   <Tr>
@@ -126,7 +128,6 @@ const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }
     },
     [growthForms],
   )
-  const prioritizeConfirmedAnnotations = (a, b) => b.is_confirmed - a.is_confirmed
 
   const fetchImages = async () => {
     try {
@@ -207,9 +208,9 @@ const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }
 
         const numSubRows = Object.keys(imageAnnotationData).length
 
-        const distilledAnnotationData = Object.keys(imageAnnotationData).map((key) =>
-          distillAnnotationData(imageAnnotationData[key], index),
-        )
+        const distilledAnnotationData = Object.keys(imageAnnotationData)
+          .map((key) => distillAnnotationData(imageAnnotationData[key], index))
+          .sort(sortAlphabetically)
 
         return {
           file,


### PR DESCRIPTION
Relates to [Ticket 1041](https://trello.com/c/pwi5aQnW/1041-sort-images-by-createdon-in-imageclassificationobservationtable?filter=label:classification,member:parmvirthind1) and [1059](https://trello.com/c/qxS8QGA0/1059-sort-attributes-alphabetically-in-table)

**changes**
- Removed `created_on` from `EXCLUDE_PARAMS`
- Sort `distilledImages` by `created_on` to have latest at the bottom
- Sort annotations alphabetically inside `distillImagesData` callback.
- Move `prioritizeConfirmedAnnotations` outside of component