### PR TITLE
[M1069] set updated_on as default Projects list sort

### DIFF
--- a/src/components/ProjectToolBarSection/ProjectToolBarSection.js
+++ b/src/components/ProjectToolBarSection/ProjectToolBarSection.js
@@ -126,10 +126,10 @@ const ProjectToolBarSection = ({
         <SortByLabelWrapper htmlFor="sort_by">
           Sort By
           <select id="sort_by" onChange={setSortBy} value={projectSortKey}>
+            <option value="updated_on">Last Updated Date</option>
             <option value="name">Project Name</option>
             <option value="countries">Country</option>
             <option value="num_sites">Number of Sites</option>
-            <option value="updated_on">Last Updated Date</option>
           </select>
         </SortByLabelWrapper>
         <ButtonSecondary

--- a/src/components/ProjectToolBarSection/ProjectToolBarSection.js
+++ b/src/components/ProjectToolBarSection/ProjectToolBarSection.js
@@ -7,8 +7,7 @@ import {
   mediaQueryPhoneOnly,
   mediaQueryTabletLandscapeOnly,
 } from '../../library/styling/mediaQueries'
-import { ButtonCallout, ButtonSecondary } from '../generic/buttons'
-import { IconSortDown, IconSortUp } from '../icons'
+import { ButtonCallout } from '../generic/buttons'
 import { Input, inputStyles } from '../generic/form'
 import OfflineHide from '../generic/OfflineHide'
 import ProjectModal from '../ProjectCard/ProjectModal'
@@ -82,7 +81,6 @@ const ProjectToolBarSection = ({
   setProjectFilter,
   projectSortKey,
   setProjectSortKey,
-  isProjectSortAsc,
   setIsProjectSortAsc,
   addProjectToProjectsPage,
 }) => {
@@ -94,6 +92,15 @@ const ProjectToolBarSection = ({
 
   const setSortBy = (event) => {
     setProjectSortKey(event.target.value)
+    if (event.target.value === 'updated_on') {
+      setIsProjectSortAsc(false)
+    }
+    if (event.target.value === 'name') {
+      setIsProjectSortAsc(true)
+    }
+    if (event.target.value === 'countries') {
+      setIsProjectSortAsc(true)
+    }
   }
 
   const [isNewProjectModalOpen, setIsNewProjectModalOpen] = useState(false)
@@ -129,15 +136,8 @@ const ProjectToolBarSection = ({
             <option value="updated_on">Last Updated Date</option>
             <option value="name">Project Name</option>
             <option value="countries">Country</option>
-            <option value="num_sites">Number of Sites</option>
           </select>
         </SortByLabelWrapper>
-        <ButtonSecondary
-          aria-label="sort-projects"
-          onClick={() => setIsProjectSortAsc(!isProjectSortAsc)}
-        >
-          {isProjectSortAsc ? <IconSortDown /> : <IconSortUp />}
-        </ButtonSecondary>
       </FilterRowWrapper>
     </GlobalWrapper>
   )
@@ -150,7 +150,6 @@ ProjectToolBarSection.propTypes = {
   setProjectFilter: PropTypes.func.isRequired,
   projectSortKey: PropTypes.string.isRequired,
   setProjectSortKey: PropTypes.func.isRequired,
-  isProjectSortAsc: PropTypes.bool.isRequired,
   setIsProjectSortAsc: PropTypes.func.isRequired,
   addProjectToProjectsPage: PropTypes.func.isRequired,
 }

--- a/src/components/pages/Projects/Projects.js
+++ b/src/components/pages/Projects/Projects.js
@@ -28,7 +28,7 @@ const Projects = () => {
   const [offlineReadyProjectIds, setOfflineReadyProjectIds] = useState([])
   const [projectFilter, setProjectFilter] = useState('')
   const [projects, setProjects] = useState([])
-  const [projectSortKey, setProjectSortKey] = useState('name')
+  const [projectSortKey, setProjectSortKey] = useState('updated_on')
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
   const { isAppOnline } = useOnlineStatus()
   const { isSyncInProgress } = useSyncStatus()

--- a/src/components/pages/Projects/Projects.js
+++ b/src/components/pages/Projects/Projects.js
@@ -24,7 +24,7 @@ import { useHttpResponseErrorHandler } from '../../../App/HttpResponseErrorHandl
  */
 const Projects = () => {
   const [isLoading, setIsLoading] = useState(true)
-  const [isProjectSortAsc, setIsProjectSortAsc] = useState(true)
+  const [isProjectSortAsc, setIsProjectSortAsc] = useState(false)
   const [offlineReadyProjectIds, setOfflineReadyProjectIds] = useState([])
   const [projectFilter, setProjectFilter] = useState('')
   const [projects, setProjects] = useState([])

--- a/src/components/pages/Projects/Projects.js
+++ b/src/components/pages/Projects/Projects.js
@@ -156,7 +156,6 @@ const Projects = () => {
           setProjectFilter={setProjectFilter}
           projectSortKey={projectSortKey}
           setProjectSortKey={setProjectSortKey}
-          isProjectSortAsc={isProjectSortAsc}
           setIsProjectSortAsc={setIsProjectSortAsc}
           addProjectToProjectsPage={addProjectToProjectsPage}
         />


### PR DESCRIPTION
[trello card](https://trello.com/c/yhvzIIac/1069-make-last-updated-date-default-sort-for-projects-list)

to test:

1. go to projects list page
2. ensure asc/desc button is removed
3. sort by last updates date (sort is desc)
4. sort by project name and country (sort is asc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated sorting options in the project toolbar, with "Last Updated Date" now as the first option.
	- Default sorting of projects has changed to prioritize the last updated timestamp, now sorting in descending order by default.

- **Bug Fixes**
	- No reported bugs were addressed in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->