### PR TITLE
[1072] revert fix for ic bug - needs more testing

### DIFF
--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
@@ -223,10 +223,7 @@ const BenthicPhotoQuadratForm = ({ isNewRecord = true }) => {
         return (
           <SampleUnitInputSelector setIsImageClassification={handleIsImageClassificationChange} />
         )
-      } else if (
-        collectRecordBeingEdited &&
-        (enableImageClassification === false || enableImageClassification === undefined)
-      ) {
+      } else if (collectRecordBeingEdited && enableImageClassification === false) {
         return (
           <BenthicPhotoQuadratObservationTable
             benthicAttributeSelectOptions={benthicAttributeSelectOptions}


### PR DESCRIPTION
[trello card](https://trello.com/c/3PHeCUWS/1072-ic-bug-bpq-observation-table-disappears-when-moving-a-submitted-su-to-collecting)

reverts previous bug fix where `enableImageClassification === undefined` was added to check which table type to display