### PR TITLE
[M1083] bug fix for is ic getting reset

### DIFF
--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
@@ -50,7 +50,7 @@ const BenthicPhotoQuadratForm = ({ isNewRecord = true }) => {
   const isMounted = useIsMounted()
   const observationsReducer = useReducer(benthicpqtObservationReducer, [])
   const [sites, setSites] = useState([])
-  const [isImageClassification, setIsImageClassification] = useState(null)
+  const [isImageClassificationSelected, setIsImageClassification] = useState(null)
 
   const [observationsState, observationsDispatch] = observationsReducer // eslint-disable-line no-unused-vars
   const enableImageClassification = collectRecordBeingEdited?.data?.image_classification
@@ -265,7 +265,7 @@ const BenthicPhotoQuadratForm = ({ isNewRecord = true }) => {
         setIsNewBenthicAttributeModalOpen={setIsNewBenthicAttributeModalOpen}
         setObservationIdToAddNewBenthicAttributeTo={setObservationIdToAddNewBenthicAttributeTo}
         subNavNode={subNavNode}
-        isImageClassification={isImageClassification}
+        isImageClassification={isImageClassificationSelected}
       />
       {!!projectId && !!currentUser && (
         <NewAttributeModal

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
@@ -371,12 +371,20 @@ const CollectRecordFormPage = ({
   })
 
   const handleSave = () => {
+    const originalImageClassification = collectRecordBeingEdited?.data?.image_classification
+
+    // ensure image_classification is not overwritten after it has been saved the first time.
+    const imageClassificationToSave =
+      originalImageClassification === undefined || originalImageClassification === null
+        ? isImageClassification
+        : originalImageClassification
+
     const recordToSubmit = sampleUnitFormatSaveFunction({
       collectRecordBeingEdited,
       formikValues: formik.values,
       observationsTable1State,
       observationsTable2State,
-      image_classification: isImageClassification,
+      image_classification: imageClassificationToSave,
     })
 
     setSaveButtonState(buttonGroupStates.saving)


### PR DESCRIPTION
[trello card](https://trello.com/c/gM5BG5cj/1083-ic-bug-isimageclassification-gets-reset-when-a-user-validates-bpq-record-sample-unit-selector-shows-up-again)

- added check in `handleSave` to ensure `image_classification` does not get over written
- renamed var to differentiate between IC  stored value and the UI-driven state