### PR TITLE
[M1090] bug fix: project users not showing after switching projects

### DIFF
--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -842,16 +842,14 @@ const Users = () => {
           <tbody {...getTableBodyProps()}>
             {page.map((row) => {
               prepareRow(row)
-
+              const { key: _, ...restRowProps } = row.getRowProps()
               return (
-                <Tr key={row.id} {...row.getRowProps()}>
+                <Tr key={row.id} {...restRowProps}>
                   {row.cells.map((cell) => {
+                    const { key: _, ...restCellProps } = cell.getCellProps()
+                    const uniqueKey = `${row.id}-${cell.column.id}`
                     return (
-                      <UserTableTd
-                        key={cell.column.id}
-                        {...cell.getCellProps()}
-                        align={cell.column.align}
-                      >
+                      <UserTableTd key={uniqueKey} {...restCellProps} align={cell.column.align}>
                         {cell.render('Cell')}
                       </UserTableTd>
                     )


### PR DESCRIPTION
[trello card](https://trello.com/c/MC77bunU/1090-project-users-not-showing-after-switching-projects)

- was seeing a jsx warning on the Users table: 

`Users.js:817 Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, role: ..., children: ...};
  <table__Tr {...props} />
React keys must be passed directly to JSX without using spread:
  let props = {role: ..., children: ...};
  <table__Tr key={someKey} {...props} />`
  
  - to fix this, I extracted the key prop from the spread
  - this seems to have fixed the warning, and the issue of users disappearing from the table
  
  to test:
 1. Navigate to Project->Admin of Project A; observer list of users who are part of Project A
2. Navigate to Project->Admin of Project B; observe users who are part of Project B (previously users disappeared)
  
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the rendering of table rows and cells in the Users component for better clarity and maintainability.
	- Enhanced the uniqueness of keys used in rendering without changing the component's functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->