### PR TITLE
M1108: Bug when redirecting after move to collecting

### DIFF
--- a/src/App/mermaidData/databaseSwitchboard/SubmittedRecordsMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/SubmittedRecordsMixin.js
@@ -107,7 +107,13 @@ const SubmittedRecordsMixin = (Base) =>
               {},
               await getAuthorizationHeaders(this._getAccessToken),
             )
-            .then(() => this._apiSyncInstance.pushThenPullAllProjectDataExceptChoices(projectId))
+            .then((res) => {
+              return this._apiSyncInstance
+                .pushThenPullAllProjectDataExceptChoices(projectId)
+                .then(() => {
+                  return res.data
+                })
+            })
         : Promise.reject(this._notAuthenticatedAndReadyError)
     }
 

--- a/src/components/pages/submittedRecordPages/SubmittedBenthicLit/SubmittedBenthicLit.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBenthicLit/SubmittedBenthicLit.js
@@ -126,11 +126,9 @@ const SubmittedBenthicLit = () => {
         submittedRecordId,
         sampleUnitMethod: 'benthiclittransectmethods',
       })
-      .then(() => {
+      .then(({ id }) => {
         toast.success(...getToastArguments(language.success.submittedRecordMoveToCollect))
-        navigate(
-          `${ensureTrailingSlash(currentProjectPath)}collecting/benthiclit/${submittedRecordId}`,
-        )
+        navigate(`${ensureTrailingSlash(currentProjectPath)}collecting/benthiclit/${id}`)
       })
       .catch((error) => {
         handleHttpResponseError({

--- a/src/components/pages/submittedRecordPages/SubmittedBenthicPhotoQuadrat/SubmittedBenthicPhotoQuadrat.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBenthicPhotoQuadrat/SubmittedBenthicPhotoQuadrat.js
@@ -126,11 +126,9 @@ const SubmittedBenthicPhotoQuadrat = () => {
         submittedRecordId,
         sampleUnitMethod: 'benthicphotoquadrattransectmethods',
       })
-      .then(() => {
+      .then(({ id }) => {
         toast.success(...getToastArguments(language.success.submittedRecordMoveToCollect))
-        navigate(
-          `${ensureTrailingSlash(currentProjectPath)}collecting/benthicpqt/${submittedRecordId}`,
-        )
+        navigate(`${ensureTrailingSlash(currentProjectPath)}collecting/benthicpqt/${id}`)
       })
       .catch((error) => {
         handleHttpResponseError({

--- a/src/components/pages/submittedRecordPages/SubmittedBenthicPit/SubmittedBenthicPit.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBenthicPit/SubmittedBenthicPit.js
@@ -126,11 +126,9 @@ const SubmittedBenthicPit = () => {
         submittedRecordId,
         sampleUnitMethod: 'benthicpittransectmethods',
       })
-      .then(() => {
+      .then(({ id }) => {
         toast.success(...getToastArguments(language.success.submittedRecordMoveToCollect))
-        navigate(
-          `${ensureTrailingSlash(currentProjectPath)}collecting/benthicpit/${submittedRecordId}`,
-        )
+        navigate(`${ensureTrailingSlash(currentProjectPath)}collecting/benthicpit/${id}`)
       })
       .catch((error) => {
         handleHttpResponseError({

--- a/src/components/pages/submittedRecordPages/SubmittedBleaching/SubmittedBleaching.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBleaching/SubmittedBleaching.js
@@ -127,11 +127,9 @@ const SubmittedBleaching = () => {
         submittedRecordId,
         sampleUnitMethod: 'bleachingquadratcollectionmethods',
       })
-      .then(() => {
+      .then(({ id }) => {
         toast.success(...getToastArguments(language.success.submittedRecordMoveToCollect))
-        navigate(
-          `${ensureTrailingSlash(currentProjectPath)}collecting/bleachingqc/${submittedRecordId}`,
-        )
+        navigate(`${ensureTrailingSlash(currentProjectPath)}collecting/bleachingqc/${id}`)
       })
       .catch((error) => {
         handleHttpResponseError({

--- a/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
+++ b/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
@@ -145,11 +145,9 @@ const SubmittedFishBelt = () => {
     setIsMoveToButtonDisabled(true)
     databaseSwitchboardInstance
       .moveToCollect({ projectId, submittedRecordId, sampleUnitMethod: 'beltfishtransectmethods' })
-      .then(() => {
+      .then(({ id }) => {
         toast.success(...getToastArguments(language.success.submittedRecordMoveToCollect))
-        navigate(
-          `${ensureTrailingSlash(currentProjectPath)}collecting/fishbelt/${submittedRecordId}`,
-        )
+        navigate(`${ensureTrailingSlash(currentProjectPath)}collecting/fishbelt/${id}`)
       })
       .catch((error) => {
         handleHttpResponseError({

--- a/src/components/pages/submittedRecordPages/SubmittedHabitatComplexity/SubmittedHabitatComplexity.js
+++ b/src/components/pages/submittedRecordPages/SubmittedHabitatComplexity/SubmittedHabitatComplexity.js
@@ -126,13 +126,9 @@ const SubmittedHabitatComplexity = () => {
         submittedRecordId,
         sampleUnitMethod: 'habitatcomplexitytransectmethods',
       })
-      .then(() => {
+      .then(({ id }) => {
         toast.success(...getToastArguments(language.success.submittedRecordMoveToCollect))
-        navigate(
-          `${ensureTrailingSlash(
-            currentProjectPath,
-          )}collecting/habitatcomplexity/${submittedRecordId}`,
-        )
+        navigate(`${ensureTrailingSlash(currentProjectPath)}collecting/habitatcomplexity/${id}`)
       })
       .catch((error) => {
         handleHttpResponseError({


### PR DESCRIPTION
[Trello card](https://trello.com/c/BGs65ti5/1108-redirect-to-returned-id-after-move-to-collecting)

Updated so that we use the ID from the response. 


**To Test:**
- Go to any submitted record
- Click the "Edit Sample Unit — move to Collecting" button
- Ensure that the page re-directs to collecting and the correct record is loaded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced promise handling and error management in the record submission process.
	- Improved navigation using the correct identifier after successful operations.

- **Bug Fixes**
	- Resolved issues with missing parameters leading to promise rejections in multiple methods.

- **Documentation**
	- Updated comments and documentation to reflect changes in error handling and response management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->