### PR TITLE
M1088: UI updates

### DIFF
--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -9,7 +9,11 @@ import {
 } from '../../collectRecordFormPages/CollectingFormPage.Styles'
 import { Tr, Th } from '../../../generic/Table/table'
 import PropTypes from 'prop-types'
-import { StyledTd, TdWithHoverText } from './ImageClassificationObservationTable.styles'
+import {
+  StyledTd,
+  TdWithHoverText,
+  ImageWrapper,
+} from './ImageClassificationObservationTable.styles'
 import { ButtonPrimary, ButtonCaution } from '../../../generic/buttons'
 import { IconClose } from '../../../icons'
 import ImageAnnotationModal from '../ImageAnnotationModal/ImageAnnotationModal'
@@ -332,7 +336,9 @@ const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }
                         onClick={() => handleImageClick(file)}
                         cursor={file.classification_status.status === 3 ? 'pointer' : 'default'}
                       >
-                        <Thumbnail imageUrl={file.thumbnail} />
+                        <ImageWrapper>
+                          <Thumbnail imageUrl={file.thumbnail} />
+                        </ImageWrapper>
                       </TdWithHoverText>
                       <StyledTd
                         colSpan={8}
@@ -356,7 +362,9 @@ const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }
                           onClick={() => handleImageClick(file)}
                           cursor={file.classification_status.status === 3 ? 'pointer' : 'default'}
                         >
-                          <Thumbnail imageUrl={file.thumbnail} />
+                          <ImageWrapper>
+                            <Thumbnail imageUrl={file.thumbnail} />
+                          </ImageWrapper>
                         </TdWithHoverText>
                       </>
                     )}

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -24,7 +24,7 @@ const tableHeaders = [
   { align: 'center', id: 'thumbnail-label', text: 'Thumbnail' },
   { align: 'right', id: 'quadrat-number-label', text: 'Quadrat' },
   { align: 'left', id: 'benthic-attribute-label', text: 'Benthic Attribute' },
-  { align: 'right', id: 'growth-form-label', text: 'Growth Form' },
+  { align: 'left', id: 'growth-form-label', text: 'Growth Form' },
   { colSpan: 3, align: 'center', id: 'number-of-points-label', text: 'Number of Points' },
   { align: 'right', id: 'review', text: '' },
   { align: 'right', id: 'remove', text: '' },
@@ -45,9 +45,9 @@ const TableHeaderRow = () => (
 )
 
 const subHeaderColumns = [
-  { align: 'center', text: 'Confirmed' },
-  { align: 'center', text: 'Unconfirmed' },
-  { align: 'center', text: 'Unknown' },
+  { align: 'right', text: 'Confirmed' },
+  { align: 'right', text: 'Unconfirmed' },
+  { align: 'right', text: 'Unknown' },
 ]
 
 const SubHeaderRow = () => (
@@ -64,8 +64,8 @@ const SubHeaderRow = () => (
 
 const statusLabels = {
   0: 'Unknown',
-  1: 'Pending',
-  2: 'Running',
+  1: 'Queued',
+  2: 'Processing',
   3: 'Completed',
   4: 'Failed',
 }

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -13,6 +13,7 @@ import {
   StyledTd,
   TdWithHoverText,
   ImageWrapper,
+  StyledTr,
 } from './ImageClassificationObservationTable.styles'
 import { ButtonPrimary, ButtonCaution } from '../../../generic/buttons'
 import { IconClose } from '../../../icons'

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.styles.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.styles.js
@@ -89,5 +89,12 @@ const TdWithHoverText = styled(StyledTd)`
   }
 `
 
-export { StyledColgroup, IconContainer, ButtonContainer, StyledTd, TdWithHoverText, ImageWrapper }
-
+export {
+  StyledColgroup,
+  IconContainer,
+  ButtonContainer,
+  StyledTd,
+  TdWithHoverText,
+  ImageWrapper,
+  StyledTr,
+}

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.styles.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.styles.js
@@ -62,7 +62,7 @@ const TdWithHoverText = styled(StyledTd)`
   }
 
   &:hover {
-    border: 2px solid ${theme.color.primaryColor};
+    outline: 2px solid ${theme.color.primaryColor};
   }
 
   &:hover::after {

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.styles.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.styles.js
@@ -41,11 +41,14 @@ const ButtonContainer = styled.div`
   margin-left: 1rem;
 `
 
+const ImageWrapper = styled('div')`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
 const TdWithHoverText = styled(StyledTd)`
   cursor: ${(props) => props.cursor};
-  display: flex;
-  align-items: center;
-  justify-content: center;
 
   &::after {
     content: attr(data-tooltip);
@@ -74,4 +77,4 @@ const TdWithHoverText = styled(StyledTd)`
   }
 `
 
-export { StyledColgroup, IconContainer, ButtonContainer, StyledTd, TdWithHoverText }
+export { StyledColgroup, IconContainer, ButtonContainer, StyledTd, TdWithHoverText, ImageWrapper }

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.styles.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.styles.js
@@ -43,6 +43,9 @@ const ButtonContainer = styled.div`
 
 const TdWithHoverText = styled(StyledTd)`
   cursor: ${(props) => props.cursor};
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   &::after {
     content: attr(data-tooltip);

--- a/src/components/pages/collectRecordFormPages/CollectingFormPage.Styles.js
+++ b/src/components/pages/collectRecordFormPages/CollectingFormPage.Styles.js
@@ -62,17 +62,31 @@ export const StyledOverflowWrapper = styled(TableOverflowWrapper)`
 `
 
 export const StickyObservationTable = styled(GenericStickyTable)`
+  thead tr:nth-child(1) th {
+    position: sticky;
+    top: calc(
+      ${theme.spacing.headerHeight} + ${theme.spacing.toolbarHeight} + ${theme.spacing.small}
+    );
+    z-index: 4; /* Ensure the first row is above the second */
+    background-color: white;
+  }
+
+  thead tr:nth-child(2) th {
+    position: sticky;
+    top: calc(
+      ${theme.spacing.headerHeight} + ${theme.spacing.toolbarHeight} + ${theme.spacing.small} + 4rem
+    ); /* Adjust for the height of the first row */
+    z-index: 3; /* Ensure the second row is below the first */
+    background-color: white;
+  }
+
   tr {
     &:focus-within button,
     &:hover button {
       display: inline;
       cursor: pointer;
     }
-    th {
-      top: calc(
-        ${theme.spacing.headerHeight} + ${theme.spacing.toolbarHeight} + ${theme.spacing.small}
-      );
-    }
+
     td {
       padding: 0rem;
       & > div {


### PR DESCRIPTION
[trello card](https://trello.com/c/zLTcNJIN/1088-minor-ui-updates-for-observation-table)

updates:

- Center the thumbnail vertically and horizontally
- The border on thumbnail hover shouldn’t shift the layout. Try using outline instead of border.
- The sticky table header should include both header rows. Currently just the Confirmed Unconfirmed Unknown are sticky
- Table headers should align with the content in the columns. Numbers are aligned right, text left.
- Growth Form header should be aligned left
- Confirmed, Unconfirmed, and Unknown should be aligned right, but keep Number of Points centered

 **need clarification - uploads happen in the upload status bar (toast)**
updated remaining statuses (queued, processing)

Statuses need to be updated

Before being uploaded: “Queued”
While being uploaded: “Uploading…”
While being classified: “Processing…”