### PR TITLE
[M1076] handle validate

### DIFF
--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
@@ -376,7 +376,7 @@ const ImageAnnotationModalMap = ({
         ['get', 'id'],
         selectedPoint.id,
       ],
-      POLYGON_LINE_WIDTH, 
+      POLYGON_LINE_WIDTH,
 
       POLYGON_LINE_WIDTH, // fallback to default width
     ])

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationContainer.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationContainer.js
@@ -5,7 +5,7 @@ import { ButtonPrimary } from '../../../generic/buttons'
 import { IconUpload } from '../../../icons'
 import { ButtonContainer, IconContainer } from './ImageClassificationObservationTable.styles'
 
-const ImageClassificationContainer = () => {
+const ImageClassificationContainer = (props) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [uploadedFiles, setUploadedFiles] = useState([])
 
@@ -19,6 +19,7 @@ const ImageClassificationContainer = () => {
       <ImageClassificationObservationTable
         uploadedFiles={uploadedFiles}
         setUploadedFiles={setUploadedFiles}
+        {...props}
       />
       <ButtonContainer>
         <ButtonPrimary type="button" onClick={() => setIsModalOpen(true)}>

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -473,21 +473,23 @@ const ImageClassificationObservationTable = ({
                             <>
                               {areValidationsShowing ? (
                                 <StyledTd>
-                                  <ObservationValidationInfo
-                                    hasObservationErrorValidation={hasObservationErrorValidation}
-                                    hasObservationIgnoredValidation={
-                                      hasObservationIgnoredValidation
-                                    }
-                                    hasObservationWarningValidation={
-                                      hasObservationWarningValidation
-                                    }
-                                    ignoreObservationValidations={ignoreObservationValidations}
-                                    isObservationValid={isObservationValid}
-                                    observationId={obsId}
-                                    observationValidationMessages={observationValidationMessages}
-                                    observationValidationType={observationValidationType}
-                                    resetObservationValidations={resetObservationValidations}
-                                  />
+                                  {hasObservationErrorValidation && annotation?.unconfirmedCount ? (
+                                    <ObservationValidationInfo
+                                      hasObservationErrorValidation={hasObservationErrorValidation}
+                                      hasObservationIgnoredValidation={
+                                        hasObservationIgnoredValidation
+                                      }
+                                      hasObservationWarningValidation={
+                                        hasObservationWarningValidation
+                                      }
+                                      ignoreObservationValidations={ignoreObservationValidations}
+                                      isObservationValid={isObservationValid}
+                                      observationId={obsId}
+                                      observationValidationMessages={observationValidationMessages}
+                                      observationValidationType={observationValidationType}
+                                      resetObservationValidations={resetObservationValidations}
+                                    />
+                                  ) : null}
                                 </StyledTd>
                               ) : null}
                               <StyledTd rowSpan={numSubRows + (totalUnknown > 0 ? 1 : 0)}>
@@ -515,17 +517,19 @@ const ImageClassificationObservationTable = ({
                           )}
                           {areValidationsShowing && subIndex >= 1 ? (
                             <StyledTd>
-                              <ObservationValidationInfo
-                                hasObservationErrorValidation={hasObservationErrorValidation}
-                                hasObservationIgnoredValidation={hasObservationIgnoredValidation}
-                                hasObservationWarningValidation={hasObservationWarningValidation}
-                                ignoreObservationValidations={ignoreObservationValidations}
-                                isObservationValid={isObservationValid}
-                                observationId={obsId}
-                                observationValidationMessages={observationValidationMessages}
-                                observationValidationType={observationValidationType}
-                                resetObservationValidations={resetObservationValidations}
-                              />
+                              {hasObservationErrorValidation && annotation?.unconfirmedCount ? (
+                                <ObservationValidationInfo
+                                  hasObservationErrorValidation={hasObservationErrorValidation}
+                                  hasObservationIgnoredValidation={hasObservationIgnoredValidation}
+                                  hasObservationWarningValidation={hasObservationWarningValidation}
+                                  ignoreObservationValidations={ignoreObservationValidations}
+                                  isObservationValid={isObservationValid}
+                                  observationId={obsId}
+                                  observationValidationMessages={observationValidationMessages}
+                                  observationValidationType={observationValidationType}
+                                  resetObservationValidations={resetObservationValidations}
+                                />
+                              ) : null}
                             </StyledTd>
                           ) : null}
                         </StyledTr>

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -33,7 +33,7 @@ const tableHeaders = [
   { align: 'right', id: 'quadrat-number-label', text: 'Quadrat' },
   { align: 'left', id: 'benthic-attribute-label', text: 'Benthic Attribute' },
   { align: 'left', id: 'growth-form-label', text: 'Growth Form' },
-  { colSpan: 3, align: 'center', id: 'number-of-points-label', text: 'Number of Points' },
+  { colSpan: 2, align: 'center', id: 'number-of-points-label', text: 'Number of Points' },
   { align: 'right', id: 'review', text: '' },
   { align: 'right', id: 'remove', text: '' },
   { align: 'left', id: 'validations', text: 'Validations' },
@@ -65,7 +65,6 @@ TableHeaderRow.propTypes = {
 const subHeaderColumns = [
   { align: 'right', text: 'Confirmed' },
   { align: 'right', text: 'Unconfirmed' },
-  { align: 'right', text: 'Unknown' },
 ]
 
 const SubHeaderRow = () => (
@@ -107,6 +106,7 @@ const ImageClassificationObservationTable = ({
   const [isFetching, setIsFetching] = useState(false)
   const isFirstLoad = useRef(true)
   const [deletingImage, setDeletingImage] = useState()
+  const numPointsPerQuadrat = collectRecord?.data?.quadrat_transect?.num_points_per_quadrat ?? 0
 
   const isImageProcessed = (status) => status === 3 || status === 4
 
@@ -422,9 +422,6 @@ const ImageClassificationObservationTable = ({
                     <StyledTd textAlign="right">{annotation?.unconfirmedCount}</StyledTd>
                     {subIndex === 0 && (
                       <>
-                        <StyledTd textAlign="right" rowSpan={numSubRows}>
-                          {file.num_unclassified}
-                        </StyledTd>
                         <StyledTd rowSpan={numSubRows}>
                           <ButtonPrimary
                             type="button"

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -22,6 +22,7 @@ import Thumbnail from './Thumbnail'
 import { useDatabaseSwitchboardInstance } from '../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 import getObservationValidationInfo from '../../collectRecordFormPages/CollectRecordFormPage/getObservationValidationInfo'
 import { benthicPhotoQuadratPropType } from '../../../../App/mermaidData/mermaidDataProptypes'
+import ObservationValidationInfo from '../../collectRecordFormPages/ObservationValidationInfo'
 
 const EXCLUDE_PARAMS =
   'data,created_by,updated_by,updated_on,original_image_width,original_image_height,location,comments,image,photo_timestamp'
@@ -83,6 +84,8 @@ const ImageClassificationObservationTable = ({
   setUploadedFiles,
   collectRecord = undefined,
   areValidationsShowing,
+  ignoreObservationValidations,
+  resetObservationValidations,
 }) => {
   const [imageId, setImageId] = useState()
   const [images, setImages] = useState([])
@@ -431,6 +434,19 @@ const ImageClassificationObservationTable = ({
                             <IconClose aria-label="close" />
                           </ButtonCaution>
                         </StyledTd>
+                        {areValidationsShowing ? (
+                          <ObservationValidationInfo
+                            hasObservationErrorValidation={hasObservationErrorValidation}
+                            hasObservationIgnoredValidation={hasObservationIgnoredValidation}
+                            hasObservationWarningValidation={hasObservationWarningValidation}
+                            ignoreObservationValidations={ignoreObservationValidations}
+                            isObservationValid={isObservationValid}
+                            observationId={id}
+                            observationValidationMessages={observationValidationMessages}
+                            observationValidationType={observationValidationType}
+                            resetObservationValidations={resetObservationValidations}
+                          />
+                        ) : null}
                       </>
                     )}
                   </StyledTr>
@@ -458,6 +474,8 @@ ImageClassificationObservationTable.propTypes = {
   setUploadedFiles: PropTypes.func.isRequired,
   areValidationsShowing: PropTypes.bool.isRequired,
   collectRecord: benthicPhotoQuadratPropType,
+  ignoreObservationValidations: PropTypes.func.isRequired,
+  resetObservationValidations: PropTypes.func.isRequired,
 }
 
 export default ImageClassificationObservationTable

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -437,6 +437,13 @@ const ImageClassificationObservationTable = ({
                     <StyledTr
                       key={`${file.id}-${subIndex}`}
                       $hasUnconfirmedPoint={annotation.hasUnconfirmedPoint}
+                      $messageType={
+                        hasObservationErrorValidation
+                          ? 'error'
+                          : hasObservationWarningValidation
+                          ? 'warning'
+                          : null
+                      }
                     >
                       <StyledTd>{rowIndex++}</StyledTd>
                       {subIndex === 0 && (

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -360,7 +360,7 @@ const ImageClassificationObservationTable = ({
                   observationValidationMessages,
                   observationValidationType,
                 } = getObservationValidationInfo({
-                  id,
+                  observationId: id,
                   collectRecord,
                   areValidationsShowing,
                   observationsPropertyName: 'images',

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -232,6 +232,9 @@ const ImageClassificationObservationTable = ({
     return images
       .map((file, index) => {
         const classifiedPoints = file.points.filter(({ annotations }) => annotations.length > 0)
+        let totalConfirmed = 0
+        let totalUnconfirmed = 0
+        let totalUnknown = 0
 
         const imageAnnotationData = Object.groupBy(
           classifiedPoints,
@@ -244,14 +247,24 @@ const ImageClassificationObservationTable = ({
           .map((key) => distillAnnotationData(imageAnnotationData[key], index))
           .sort(sortAlphabetically)
 
+        distilledAnnotationData.forEach((item) => {
+          totalConfirmed += item.confirmedCount
+          totalUnconfirmed += item.unconfirmedCount
+        })
+
+        totalUnknown = numPointsPerQuadrat - totalConfirmed - totalUnconfirmed
+
         return {
           file,
           numSubRows,
           distilledAnnotationData,
+          totalConfirmed,
+          totalUnconfirmed,
+          totalUnknown,
         }
       })
       .sort(sortByLatest)
-  }, [distillAnnotationData, images])
+  }, [distillAnnotationData, images, numPointsPerQuadrat])
 
   // Poll every 5 seconds after the first image is uploaded
   const _pollImageStatuses = useEffect(() => {

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -20,6 +20,8 @@ import { IconClose } from '../../../icons'
 import ImageAnnotationModal from '../ImageAnnotationModal/ImageAnnotationModal'
 import Thumbnail from './Thumbnail'
 import { useDatabaseSwitchboardInstance } from '../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
+import getObservationValidationInfo from '../../collectRecordFormPages/CollectRecordFormPage/getObservationValidationInfo'
+import { benthicPhotoQuadratPropType } from '../../../../App/mermaidData/mermaidDataProptypes'
 
 const EXCLUDE_PARAMS =
   'data,created_by,updated_by,updated_on,original_image_width,original_image_height,location,comments,image,photo_timestamp'
@@ -33,6 +35,7 @@ const tableHeaders = [
   { colSpan: 3, align: 'center', id: 'number-of-points-label', text: 'Number of Points' },
   { align: 'right', id: 'review', text: '' },
   { align: 'right', id: 'remove', text: '' },
+  { align: 'right', id: 'validations', text: 'Validations' },
 ]
 
 const sortByLatest = (a, b) => new Date(a.file.created_on) - new Date(b.file.created_on)
@@ -75,7 +78,12 @@ const statusLabels = {
   4: 'Failed',
 }
 
-const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }) => {
+const ImageClassificationObservationTable = ({
+  uploadedFiles,
+  setUploadedFiles,
+  collectRecord = undefined,
+  areValidationsShowing,
+}) => {
   const [imageId, setImageId] = useState()
   const [images, setImages] = useState([])
   const [polling, setPolling] = useState(false)
@@ -330,6 +338,21 @@ const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }
             <tbody>
               {distilledImages.map((image, imageIndex) => {
                 const { file, distilledAnnotationData, numSubRows } = image
+                const id = file.id
+
+                const {
+                  isObservationValid,
+                  hasObservationWarningValidation,
+                  hasObservationErrorValidation,
+                  hasObservationIgnoredValidation,
+                  observationValidationMessages,
+                  observationValidationType,
+                } = getObservationValidationInfo({
+                  id,
+                  collectRecord,
+                  areValidationsShowing,
+                  observationsPropertyName: 'images',
+                })
 
                 if (numSubRows === 0) {
                   // If no subrows exist (image not processed), display a single row with thumbnail, status
@@ -433,6 +456,8 @@ const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }
 ImageClassificationObservationTable.propTypes = {
   uploadedFiles: PropTypes.arrayOf(PropTypes.object).isRequired,
   setUploadedFiles: PropTypes.func.isRequired,
+  areValidationsShowing: PropTypes.bool.isRequired,
+  collectRecord: benthicPhotoQuadratPropType,
 }
 
 export default ImageClassificationObservationTable

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -36,22 +36,31 @@ const tableHeaders = [
   { colSpan: 3, align: 'center', id: 'number-of-points-label', text: 'Number of Points' },
   { align: 'right', id: 'review', text: '' },
   { align: 'right', id: 'remove', text: '' },
-  { align: 'right', id: 'validations', text: 'Validations' },
+  { align: 'left', id: 'validations', text: 'Validations' },
 ]
 
 const sortByLatest = (a, b) => new Date(a.file.created_on) - new Date(b.file.created_on)
 const sortAlphabetically = (a, b) => a.benthicAttributeLabel.localeCompare(b.benthicAttributeLabel)
 const prioritizeConfirmedAnnotations = (a, b) => b.is_confirmed - a.is_confirmed
 
-const TableHeaderRow = () => (
-  <Tr>
-    {tableHeaders.map((header) => (
-      <Th key={header.id} align={header.align} id={header.id} colSpan={header.colSpan || 1}>
-        <span>{header.text}</span>
-      </Th>
-    ))}
-  </Tr>
-)
+const TableHeaderRow = ({ areValidationsShowing }) => {
+  const filteredHeaders = tableHeaders.filter(
+    (header) => header.id !== 'validations' || areValidationsShowing,
+  )
+
+  return (
+    <Tr>
+      {filteredHeaders.map((header) => (
+        <Th key={header.id} align={header.align} id={header.id} colSpan={header.colSpan || 1}>
+          <span>{header.text}</span>
+        </Th>
+      ))}
+    </Tr>
+  )
+}
+TableHeaderRow.propTypes = {
+  areValidationsShowing: PropTypes.bool.isRequired,
+}
 
 const subHeaderColumns = [
   { align: 'right', text: 'Confirmed' },
@@ -102,7 +111,7 @@ const ImageClassificationObservationTable = ({
   const isImageProcessed = (status) => status === 3 || status === 4
 
   const handleImageClick = (file) => {
-    if (isImageProcessed(file.classification_status.status)) {
+    if (isImageProcessed(file.classification_status?.status)) {
       setImageId(file.id)
     }
   }
@@ -334,7 +343,7 @@ const ImageClassificationObservationTable = ({
         <StyledOverflowWrapper>
           <StickyObservationTable aria-labelledby="table-label">
             <thead>
-              <TableHeaderRow />
+              <TableHeaderRow areValidationsShowing={areValidationsShowing} />
               <SubHeaderRow />
             </thead>
 
@@ -435,17 +444,19 @@ const ImageClassificationObservationTable = ({
                           </ButtonCaution>
                         </StyledTd>
                         {areValidationsShowing ? (
-                          <ObservationValidationInfo
-                            hasObservationErrorValidation={hasObservationErrorValidation}
-                            hasObservationIgnoredValidation={hasObservationIgnoredValidation}
-                            hasObservationWarningValidation={hasObservationWarningValidation}
-                            ignoreObservationValidations={ignoreObservationValidations}
-                            isObservationValid={isObservationValid}
-                            observationId={id}
-                            observationValidationMessages={observationValidationMessages}
-                            observationValidationType={observationValidationType}
-                            resetObservationValidations={resetObservationValidations}
-                          />
+                          <StyledTd rowSpan={numSubRows}>
+                            <ObservationValidationInfo
+                              hasObservationErrorValidation={hasObservationErrorValidation}
+                              hasObservationIgnoredValidation={hasObservationIgnoredValidation}
+                              hasObservationWarningValidation={hasObservationWarningValidation}
+                              ignoreObservationValidations={ignoreObservationValidations}
+                              isObservationValid={isObservationValid}
+                              observationId={id}
+                              observationValidationMessages={observationValidationMessages}
+                              observationValidationType={observationValidationType}
+                              resetObservationValidations={resetObservationValidations}
+                            />
+                          </StyledTd>
                         ) : null}
                       </>
                     )}

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -34,9 +34,9 @@ const tableHeaders = [
   { align: 'left', id: 'benthic-attribute-label', text: 'Benthic Attribute' },
   { align: 'left', id: 'growth-form-label', text: 'Growth Form' },
   { colSpan: 2, align: 'center', id: 'number-of-points-label', text: 'Number of Points' },
+  { align: 'left', id: 'validations', text: 'Validations' },
   { align: 'right', id: 'review', text: '' },
   { align: 'right', id: 'remove', text: '' },
-  { align: 'left', id: 'validations', text: 'Validations' },
 ]
 
 const sortByLatest = (a, b) => new Date(a.file.created_on) - new Date(b.file.created_on)
@@ -460,6 +460,21 @@ const ImageClassificationObservationTable = ({
                       <StyledTd textAlign="right">{annotation?.unconfirmedCount}</StyledTd>
                       {subIndex === 0 && (
                         <>
+                          {areValidationsShowing ? (
+                            <StyledTd>
+                              <ObservationValidationInfo
+                                hasObservationErrorValidation={hasObservationErrorValidation}
+                                hasObservationIgnoredValidation={hasObservationIgnoredValidation}
+                                hasObservationWarningValidation={hasObservationWarningValidation}
+                                ignoreObservationValidations={ignoreObservationValidations}
+                                isObservationValid={isObservationValid}
+                                observationId={obsId}
+                                observationValidationMessages={observationValidationMessages}
+                                observationValidationType={observationValidationType}
+                                resetObservationValidations={resetObservationValidations}
+                              />
+                            </StyledTd>
+                          ) : null}
                           <StyledTd rowSpan={numSubRows}>
                             <ButtonPrimary
                               type="button"
@@ -480,21 +495,6 @@ const ImageClassificationObservationTable = ({
                               <IconClose aria-label="close" />
                             </ButtonCaution>
                           </StyledTd>
-                          {areValidationsShowing ? (
-                            <StyledTd>
-                              <ObservationValidationInfo
-                                hasObservationErrorValidation={hasObservationErrorValidation}
-                                hasObservationIgnoredValidation={hasObservationIgnoredValidation}
-                                hasObservationWarningValidation={hasObservationWarningValidation}
-                                ignoreObservationValidations={ignoreObservationValidations}
-                                isObservationValid={isObservationValid}
-                                observationId={obsId}
-                                observationValidationMessages={observationValidationMessages}
-                                observationValidationType={observationValidationType}
-                                resetObservationValidations={resetObservationValidations}
-                              />
-                            </StyledTd>
-                          ) : null}
                         </>
                       )}
                       {areValidationsShowing && subIndex >= 1 ? (

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -193,16 +193,19 @@ const ImageClassificationObservationTable = ({
       }
 
       let confirmedCount = 0
+      let unconfirmedCount = 0
       let hasUnconfirmedPoint = false
       let benthic_attribute_label = null
       let growth_form_label = null
 
       items.forEach((item) => {
         const firstAnnotation = item.annotations[0]
+
         if (firstAnnotation.is_confirmed) {
           confirmedCount += 1
         } else {
           hasUnconfirmedPoint = true
+          unconfirmedCount += 1
         }
 
         if (firstAnnotation.benthic_attribute) {
@@ -216,6 +219,7 @@ const ImageClassificationObservationTable = ({
 
       return {
         confirmedCount,
+        unconfirmedCount,
         hasUnconfirmedPoint,
         benthicAttributeLabel: benthic_attribute_label,
         growthFormLabel: growth_form_label,
@@ -415,11 +419,9 @@ const ImageClassificationObservationTable = ({
                     <StyledTd>{annotation?.benthicAttributeLabel}</StyledTd>
                     <StyledTd>{annotation?.growthFormLabel || ''}</StyledTd>
                     <StyledTd textAlign="right">{annotation?.confirmedCount}</StyledTd>
+                    <StyledTd textAlign="right">{annotation?.unconfirmedCount}</StyledTd>
                     {subIndex === 0 && (
                       <>
-                        <StyledTd textAlign="right" rowSpan={numSubRows}>
-                          {file.num_unconfirmed}
-                        </StyledTd>
                         <StyledTd textAlign="right" rowSpan={numSubRows}>
                           {file.num_unclassified}
                         </StyledTd>

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.js
@@ -239,7 +239,7 @@ const BenthicPhotoQuadratForm = ({ isNewRecord = true }) => {
           />
         )
       } else if (collectRecordBeingEdited && enableImageClassification) {
-        return <ImageClassificationContainer />
+        return <ImageClassificationContainer {...props} />
       }
       return null
     },

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/getObservationValidationInfo.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/getObservationValidationInfo.js
@@ -17,10 +17,15 @@ const getObservationValidations = ({ observationId, collectRecord, observationsP
 
   const justThisObservationsValidations = allObservationsValidations.flat().filter((validation) => {
     // api is inconsistent between id and observation_id
-    return (
-      validation.context?.observation_id === observationId ||
-      validation.context?.id === observationId
-    )
+
+    if (observationsPropertyName === 'images') {
+      return validation.context?.image_id === observationId
+    } else {
+      return (
+        validation.context?.observation_id === observationId ||
+        validation.context?.id === observationId
+      )
+    }
   })
 
   // if there are duplicate values, in context, there is an array of objects with the duplicate observations ids
@@ -57,6 +62,8 @@ const getObservationValidationInfo = ({
 
   const { validationType: observationValidationType } = observationValidationsToDisplay
   const observationValidationMessages = observationValidationsToDisplay?.validationMessages ?? []
+
+  // console.log('in func 2: ', { observationValidationMessages })
 
   const isObservationValid = observationValidationType === 'ok'
   const hasObservationWarningValidation = observationValidationType === 'warning'

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/getObservationValidationInfo.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/getObservationValidationInfo.js
@@ -63,8 +63,6 @@ const getObservationValidationInfo = ({
   const { validationType: observationValidationType } = observationValidationsToDisplay
   const observationValidationMessages = observationValidationsToDisplay?.validationMessages ?? []
 
-  // console.log('in func 2: ', { observationValidationMessages })
-
   const isObservationValid = observationValidationType === 'ok'
   const hasObservationWarningValidation = observationValidationType === 'warning'
   const hasObservationErrorValidation = observationValidationType === 'error'

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/getObservationValidationInfo.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/getObservationValidationInfo.js
@@ -18,14 +18,10 @@ const getObservationValidations = ({ observationId, collectRecord, observationsP
   const justThisObservationsValidations = allObservationsValidations.flat().filter((validation) => {
     // api is inconsistent between id and observation_id
 
-    if (observationsPropertyName === 'images') {
-      return validation.context?.image_id === observationId
-    } else {
-      return (
-        validation.context?.observation_id === observationId ||
-        validation.context?.id === observationId
-      )
-    }
+    return (
+      validation.context?.observation_id === observationId ||
+      validation.context?.id === observationId
+    )
   })
 
   // if there are duplicate values, in context, there is an array of objects with the duplicate observations ids

--- a/src/components/pages/collectRecordFormPages/CollectingFormPage.Styles.js
+++ b/src/components/pages/collectRecordFormPages/CollectingFormPage.Styles.js
@@ -134,7 +134,9 @@ export const UnderTableRowButtonArea = styled('div')`
   }
 `
 
-export const CellValidation = styled(Td)``
+export const CellValidation = styled(Td)`
+  border: none;
+`
 
 export const CellValidationButton = styled(ButtonSecondary)`
   font-size: smaller;

--- a/src/language.js
+++ b/src/language.js
@@ -1271,7 +1271,7 @@ const getValidationMessage = (validation, projectId = '') => {
     unsuccessful_dry_submit: () => getSystemValidationErrorMessage(context?.dry_submit_results),
     value_not_set: () => 'Value is not set',
     default: () => code || name,
-    wrong_num_confirmed_annos: () => 'Wrong number of confirmed annotations',
+    unconfirmed_annotation: () => 'Wrong number of confirmed annotations',
   }
 
   return (validationMessages[code] || validationMessages.default)()

--- a/src/language.js
+++ b/src/language.js
@@ -1271,6 +1271,7 @@ const getValidationMessage = (validation, projectId = '') => {
     unsuccessful_dry_submit: () => getSystemValidationErrorMessage(context?.dry_submit_results),
     value_not_set: () => 'Value is not set',
     default: () => code || name,
+    wrong_num_confirmed_annos: () => 'Wrong number of confirmed annotations',
   }
 
   return (validationMessages[code] || validationMessages.default)()


### PR DESCRIPTION
[trello card](https://trello.com/c/lSlVf7Hf/1076-handle-pqt-validation-on-frontend)

**summary**

-  added validations column to image classification
- removed unknown/unclassified column (now represented as a subrow for an image)
-  validations belong to each specific row
-  unconfirmed data points correspond to each row
-  warning/error colors  appear for each row depending on validation status
- if unknown/unclassified points for an image exist, an additional subrow will get added for that specific image, which will display how many unclassified points there are
- hide observation validation row error if unconfirmed count = 0

**to test**

- create a BPQ record
- select image classification
- upload some images
- click validate
- see validations column appear with corresponding messages
- open annotation modal
- confirm observation
- save
- check observation table to ensure validations that previously had unconfirmed count error, and are now at 0, no longer have errors

**note that validations do NOT currently get refreshed when making changes in the annotation modal and then going back to the table, you will need to click validate again**


if unknown points exist, it looks like this @alanjleonard 

<img width="1465" alt="Screenshot 2024-11-06 at 5 31 57 PM" src="https://github.com/user-attachments/assets/9a39d6b3-b4ff-4dcd-9f4f-329f07777aa9">


