### PR TITLE
M1098 pqt summaries

### DIFF
--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -7,7 +7,7 @@ import {
   StyledOverflowWrapper,
   StickyObservationTable,
 } from '../../collectRecordFormPages/CollectingFormPage.Styles'
-import { Tr, Th, ObservationsSummaryStats } from '../../../generic/Table/table'
+import { Tr, Th, ObservationsSummaryStats, Td } from '../../../generic/Table/table'
 import PropTypes from 'prop-types'
 import {
   StyledTd,
@@ -466,7 +466,7 @@ const ImageClassificationObservationTable = ({ uploadedFiles, setUploadedFiles }
                 return obs !== 'total' ? (
                   <Tr key={obs}>
                     <Th>% {obs}</Th>
-                    <Th>{percentage}</Th>
+                    <Td>{percentage}</Td>
                   </Tr>
                 ) : null
               })}


### PR DESCRIPTION
[Trello Card](https://trello.com/c/RfC5QxJH/1098-pqt-summaries)

**Changes**
- Added percentages of top level attributes underneath image classification table.

**To test**
_Collect Record_
- Go to a image classification collect record.
- upload a photo if there isn't one uploaded already
- ensure that there are percentages below the table
_Submitted Record_
- Go to a submitted benthic photo quadrat record that was submitted via image classification
- ensure that there are percentages below the observation table

**Screenshot**
<img width="1512" alt="Screenshot 2024-11-06 at 1 40 44 PM" src="https://github.com/user-attachments/assets/87481593-808d-4a18-a922-40cc323734b7">
