### PR TITLE
M1121: Remove "None" from GFCR dropdowns

### DIFF
--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.js
@@ -275,7 +275,7 @@ const FinanceSolutionModal = ({
             id="used-an-incubator-select"
             {...formik.getFieldProps('used_an_incubator')}
             options={[
-              { value: 'none', label: modalLanguage.none },
+              { value: 'none', label: modalLanguage.no },
               ...getOptions(choices.incubatortypes.data),
             ]}
             helperText={modalLanguage.getUsedAnIncubatorHelper()}
@@ -289,7 +289,6 @@ const FinanceSolutionModal = ({
             id="local-enterprise-select"
             {...formik.getFieldProps('local_enterprise')}
             options={[
-              { value: 'none', label: modalLanguage.none },
               { value: 'true', label: modalLanguage.yes },
               { value: 'false', label: modalLanguage.no },
             ]}
@@ -304,7 +303,6 @@ const FinanceSolutionModal = ({
             id="gender-smart-select"
             {...formik.getFieldProps('gender_smart')}
             options={[
-              { value: 'none', label: modalLanguage.none },
               { value: 'true', label: modalLanguage.yes },
               { value: 'false', label: modalLanguage.no },
             ]}

--- a/src/language.js
+++ b/src/language.js
@@ -324,7 +324,6 @@ const gfcrFinanceSolutionModal = {
   save: 'Save Finance Solution Row',
   cancel: 'Cancel',
   remove: 'Remove Row',
-  none: 'None',
   yes: 'Yes',
   no: 'No',
 }
@@ -364,7 +363,6 @@ const gfcrInvestmentModal = {
   save: 'Save Investment Row',
   cancel: 'Cancel',
   remove: 'Remove Row',
-  none: 'None',
 }
 
 const gfcrRevenueModal = {
@@ -399,7 +397,6 @@ const gfcrRevenueModal = {
   save: 'Save Revenue Row',
   cancel: 'Cancel',
   remove: 'Remove Row',
-  none: 'None',
   yes: 'Yes',
   no: 'No',
 }


### PR DESCRIPTION
[Trello Card](https://trello.com/c/dcZ6QXym/1121-remove-none-as-an-option-for-all-gfcr-dropdowns)

**Changes**
- Removed "None" from language relating to GFCR models.
- Removed "None" options from "Gender 2X Criteria" and "Local Enterprise" dropdowns
- Updated "None" to "No" in "Used an Incubator?" dropdown

**To Test**
- Select a GFCR record
- Go to "Business / Finance Solutions"
- Select "Add Finance Solution"
- Ensure that there is no option for "None" in any of the dropdowns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced form validation for `FinanceSolutionModal` with clearer options for `used_an_incubator`, `local_enterprise`, and `gender_smart`.
	- Added toast notifications for success and error states during form submission.

- **Bug Fixes**
	- Removed confusing "none" options from relevant fields to streamline user selections.

- **Documentation**
	- Updated PropTypes for clarity regarding available options in the modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->