### PR TITLE
M1093: Meta data for a CR is not preserved when moving back to collect

### DIFF
--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
@@ -113,7 +113,7 @@ const CollectRecordFormPage = ({
   observationsTable2Reducer = [],
   ObservationTable1,
   ObservationTable2 = undefined,
-  isImageClassification,
+  isImageClassification = null,
   sampleUnitFormatSaveFunction,
   sampleUnitName,
   SampleUnitTransectInputs,


### PR DESCRIPTION
[Trello Card
](https://trello.com/c/V734JOya/1093-meta-data-for-a-cr-is-not-preserved-when-moving-back-to-collect)

**Changes**
- assigned a default value of `null` to `IsImageClassification` so that the `_handleSaveObservationTableType` effect doesn' get triggered unneedlessly. 

**To Test**
- Open any collect record.
- Ensure that it's contents are not removed when loading.
- Should also test moving a submitted record back to collect, and seeing that the contents are preserved. 