### PR TITLE
[ M967] Disable num points per quadrat when IC is selected

### DIFF
--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratTransectInputs.js
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratTransectInputs.js
@@ -38,6 +38,7 @@ const BenthicPhotoQuadratTransectInputs = ({
   resetNonObservationFieldValidations,
   validationsApiData,
   validationPropertiesWithDirtyResetOnInputChange,
+  isImageClassification,
 }) => {
   const { currents, relativedepths, tides, visibilities } = choices
 
@@ -394,6 +395,7 @@ const BenthicPhotoQuadratTransectInputs = ({
           value={formik.values.num_points_per_quadrat}
           onChange={handleNumberOfPointsPerQuadratChange}
           helperText={language.helperText.numberOfPointsPerQuadrat}
+          disabled={isImageClassification}
         />
         <InputSelectWithLabelAndValidation
           label="Visibility"
@@ -510,6 +512,7 @@ BenthicPhotoQuadratTransectInputs.propTypes = {
   validationsApiData: PropTypes.shape({ quadrat_transect: benthicpqtValidationPropType })
     .isRequired,
   validationPropertiesWithDirtyResetOnInputChange: PropTypes.func.isRequired,
+  isImageClassification: PropTypes.bool.isRequired,
 }
 
 export default BenthicPhotoQuadratTransectInputs

--- a/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
+++ b/src/components/pages/collectRecordFormPages/CollectRecordFormPage/CollectRecordFormPage.js
@@ -539,6 +539,7 @@ const CollectRecordFormPage = ({
           validationPropertiesWithDirtyResetOnInputChange={
             validationPropertiesWithDirtyResetOnInputChange
           }
+          isImageClassification={collectRecordBeingEdited?.data?.image_classification}
         />
 
         <ObserversInput


### PR DESCRIPTION
[trello card](https://trello.com/c/935CbVef/967-disable-number-of-points-per-quadrat-when-the-user-selects-image-classification)

to test:
1. select image classification in BPQ record.
2. ensure Number of Points per Quadrat transect input is disabled



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced image classification functionality, including a new modal for managing image annotations.
  - Added components for image upload, display, and annotation management.
  - Enhanced the `DatabaseSwitchboard` to support image annotation features.

- **Improvements**
  - Updated the `Modal` component for better configurability.
  - Enhanced user feedback through notifications for file uploads and errors.

- **Bug Fixes**
  - Improved error handling for image uploads and annotations.

- **Documentation**
  - Added comprehensive API endpoint documentation for image classification workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->