### PR TITLE
display thumbnail for submitted bpq record.

### DIFF
--- a/src/components/pages/submittedRecordPages/SubmittedBenthicPhotoQuadrat/SubmittedBenthicPhotoQuadratObservationTable.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBenthicPhotoQuadrat/SubmittedBenthicPhotoQuadratObservationTable.js
@@ -83,20 +83,16 @@ const SubmittedBenthicPhotoQuadratObservationTable = ({
 
     const image = images.find((img) => img.id === observation.image)
 
-    return (
-      <>
-        {isFirstRowOfQuadrat && (
-          <TdWithHoverText
-            data-tooltip={image?.original_image_name}
-            rowSpan={quadratLengths[observation.quadrat_number]}
-          >
-            <ImageWrapper>
-              <Thumbnail imageUrl={image?.thumbnail} />
-            </ImageWrapper>
-          </TdWithHoverText>
-        )}
-      </>
-    )
+    return isFirstRowOfQuadrat ? (
+      <TdWithHoverText
+        data-tooltip={image?.original_image_name}
+        rowSpan={quadratLengths[observation.quadrat_number]}
+      >
+        <ImageWrapper>
+          <Thumbnail imageUrl={image?.thumbnail} />
+        </ImageWrapper>
+      </TdWithHoverText>
+    ) : null
   }
 
   const observationBeltFish = obs_benthic_photo_quadrats.map((observation, index) => {


### PR DESCRIPTION
[Trello Card](https://trello.com/c/es7M7hSM/1109-thumbnails-for-bpq-submitted-observation-table?filter=label:UX,label:classification,member:parmvirthind1)

**Changes**
- Added thumbnails to BPQ records that used image classification

**To test**
1. Open a submitted BPQ record that used image classification
  - Ensure that thumbnails appear ONCE per quadrat (note: API is acting weird here, might see +1 quadrat than you submitted)
  - Ensure that hovering over the thumbnail displays some style and image name
2. Open a submitted BPQ record that **did not use** image classification
  - Ensure that thumbnails are not displayed
  - Ensure that the table looks normal and that there are no errors/warnings in the console.

**Screenshot:**
<img width="1512" alt="Screenshot 2024-11-14 at 3 22 08 PM" src="https://github.com/user-attachments/assets/d8536083-41cf-4017-9b2c-0374440d5609">
