### PR TITLE
[M1155] Observation table deletion bug

### DIFF
--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationContainer.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationContainer.js
@@ -8,10 +8,15 @@ import { ButtonContainer, IconContainer } from './ImageClassificationObservation
 const ImageClassificationContainer = (props) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [uploadedFiles, setUploadedFiles] = useState([])
+  const [isUploading, setIsUploading] = useState(false)
 
   const handleFilesUpload = (files) => {
     setUploadedFiles([...uploadedFiles, ...files])
     setIsModalOpen(false)
+  }
+
+  const handleUploadingChange = (isUploading) => {
+    setIsUploading(isUploading)
   }
 
   return (
@@ -19,6 +24,7 @@ const ImageClassificationContainer = (props) => {
       <ImageClassificationObservationTable
         uploadedFiles={uploadedFiles}
         setUploadedFiles={setUploadedFiles}
+        isUploading={isUploading}
         {...props}
       />
       <ButtonContainer>
@@ -33,6 +39,7 @@ const ImageClassificationContainer = (props) => {
         <ImageUploadModal
           onClose={() => setIsModalOpen(false)}
           onFilesUpload={handleFilesUpload}
+          isUploading={handleUploadingChange}
           isOpen={isModalOpen}
           existingFiles={uploadedFiles}
         />

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -92,12 +92,11 @@ const statusLabels = {
 }
 
 const ImageClassificationObservationTable = ({
-  uploadedFiles,
-  setUploadedFiles,
   collectRecord = undefined,
   areValidationsShowing,
   ignoreObservationValidations,
   resetObservationValidations,
+  isUploading,
 }) => {
   const [imageId, setImageId] = useState()
   const [images, setImages] = useState([])
@@ -158,9 +157,6 @@ const ImageClassificationObservationTable = ({
       .then(() => {
         const updatedImages = images.filter((f) => f.id !== file.id)
         setImages(updatedImages)
-
-        const updatedUploadedFiles = uploadedFiles.filter((f) => f.id !== file.id)
-        setUploadedFiles(updatedUploadedFiles)
 
         toast.warn('File removed')
       })
@@ -318,7 +314,7 @@ const ImageClassificationObservationTable = ({
         setImages(response.results)
 
         const allProcessed = response.results.every((file) =>
-          isImageProcessed(file.classification_status.status),
+          isImageProcessed(file.classification_status?.status),
         )
 
         if (allProcessed) {
@@ -364,29 +360,10 @@ const ImageClassificationObservationTable = ({
   }, [benthicAttributes, growthForms, images, distillImagesData])
 
   const _startPollingOnUpload = useEffect(() => {
-    const hasNewImages = uploadedFiles.some((file) => !images.some((img) => img.id === file.id))
-
-    if (hasNewImages) {
-      setImages((prevImages) => {
-        const existingImagesMap = new Map(prevImages.map((img) => [img.id, img]))
-
-        // Merge existing images with newly uploaded ones
-        const mergedImages = [...prevImages]
-
-        uploadedFiles.forEach((file) => {
-          if (!existingImagesMap.has(file.id)) {
-            mergedImages.push(file)
-          }
-        })
-
-        return mergedImages
-      })
-
-      if (!polling) {
-        setPolling(true)
-      }
+    if (isUploading) {
+      setPolling(true)
     }
-  }, [uploadedFiles, polling, images])
+  }, [images, isUploading])
 
   let rowIndex = 1
 
@@ -435,7 +412,7 @@ const ImageClassificationObservationTable = ({
                         <TdWithHoverText
                           data-tooltip={file.original_image_name}
                           onClick={() => handleImageClick(file)}
-                          cursor={file.classification_status.status === 3 ? 'pointer' : 'default'}
+                          cursor={file.classification_status?.status === 3 ? 'pointer' : 'default'}
                         >
                           <ImageWrapper>
                             <Thumbnail imageUrl={file.thumbnail} />
@@ -443,15 +420,15 @@ const ImageClassificationObservationTable = ({
                         </TdWithHoverText>
                         <StyledTd
                           colSpan={8}
-                          textAlign={file.classification_status.status === 3 ? 'left' : 'center'}
+                          textAlign={file.classification_status?.status === 3 ? 'left' : 'center'}
                         >
-                          {!isImageProcessed(file.classification_status.status) ? (
+                          {!isImageProcessed(file.classification_status?.status) ? (
                             <>
                               <Spinner />
-                              {statusLabels[file.classification_status.status]}...
+                              {statusLabels[file.classification_status?.status]}...
                             </>
                           ) : (
-                            statusLabels[file.classification_status.status]
+                            statusLabels[file.classification_status?.status]
                           )}
                         </StyledTd>
                       </Tr>
@@ -546,7 +523,7 @@ const ImageClassificationObservationTable = ({
                                   <ButtonPrimary
                                     type="button"
                                     onClick={() => setImageId(file.id)}
-                                    disabled={!isImageProcessed(file.classification_status.status)}
+                                    disabled={!isImageProcessed(file.classification_status?.status)}
                                   >
                                     Review
                                   </ButtonPrimary>
@@ -556,7 +533,7 @@ const ImageClassificationObservationTable = ({
                                     type="button"
                                     onClick={() => handleRemoveImage(file)}
                                     disabled={
-                                      file.classification_status.status !== 3 ||
+                                      file.classification_status?.status !== 3 ||
                                       deletingImage === file.id
                                     }
                                   >
@@ -641,12 +618,12 @@ const ImageClassificationObservationTable = ({
 }
 
 ImageClassificationObservationTable.propTypes = {
-  uploadedFiles: PropTypes.arrayOf(PropTypes.object).isRequired,
   setUploadedFiles: PropTypes.func.isRequired,
   areValidationsShowing: PropTypes.bool.isRequired,
   collectRecord: benthicPhotoQuadratPropType,
   ignoreObservationValidations: PropTypes.func.isRequired,
   resetObservationValidations: PropTypes.func.isRequired,
+  isUploading: PropTypes.bool.isRequired,
 }
 
 export default ImageClassificationObservationTable

--- a/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
@@ -19,7 +19,7 @@ const renderUploadProgress = (processedCount, totalFiles, handleCancelUpload) =>
   </div>
 )
 
-const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => {
+const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles, isUploading }) => {
   const isCancelledRef = useRef(false)
   const fileInputRef = useRef(null)
   const { recordId, projectId } = useParams()
@@ -81,6 +81,7 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
 
   const validateAndUploadFiles = async (files) => {
     onClose()
+    isUploading(true)
 
     // Show the persistent uploading toast and store the toastId
     if (!toastId.current) {
@@ -94,6 +95,7 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
 
     for (const file of files) {
       if (isCancelledRef.current) {
+        isUploading(false)
         return
       }
 
@@ -134,6 +136,7 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
       }
 
       if (isCancelledRef.current) {
+        isUploading(false)
         return
       }
     }
@@ -152,6 +155,8 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles }) => 
       toast.dismiss(toastId.current)
       toastId.current = null
     }
+
+    isUploading(false)
   }
 
   const handleFileChange = (event) => {
@@ -221,6 +226,7 @@ ImageUploadModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   onFilesUpload: PropTypes.func.isRequired,
   existingFiles: PropTypes.array.isRequired,
+  isUploading: PropTypes.func.isRequired,
 }
 
 export default ImageUploadModal


### PR DESCRIPTION
[trello card](https://trello.com/c/yNKDEu2E/1155-ic-observation-table-glitches-when-deleting-an-image-while-others-are-processing-queued)

bug fix for deletion bug. Previously, if you tried to delete images while others were processing or queued, the table would sometimes start to glitch, and many network requests would be fired off. This was caused by `uploadedFiles` and `images ` becoming out of sync due to a race condition. To fix, I removed `uploadFiles` var in the image classification table and replaced with 'isUploading'. I also simplified the `_startPollingOnUpload useEffect` 

to test:
1. upload images
2. delete some images that are done processing while others are uploading or queued
3. ensure table doesn't start glitching, or files don't reappear as described in the linked ticket