### PR TITLE
[M1152] blank users bug

### DIFF
--- a/src/App/mermaidData/databaseSwitchboard/ProjectsMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/ProjectsMixin.js
@@ -90,28 +90,35 @@ const ProjectsMixin = (Base) =>
         return Promise.reject(this._notAuthenticatedAndReadyError)
       }
 
-      return this._dexiePerUserDataInstance.project_profiles.toArray().then((projectProfiles) => {
-        if (projectProfiles.length > 0) {
-          const usersInCurrentProject = projectProfiles.filter(
-            ({ project }) => project === projectId,
-          )
+      return this._dexiePerUserDataInstance.project_profiles
+        .toArray()
+        .then((projectProfiles) => {
+          if (projectProfiles.length > 0) {
+            const usersInCurrentProject = projectProfiles.filter(
+              ({ project }) => project === projectId,
+            )
 
-          if (usersInCurrentProject.length > 0) {
-            return usersInCurrentProject
+            if (usersInCurrentProject.length > 0) {
+              return usersInCurrentProject
+            }
           }
-        }
 
-        // If IndexedDB returns no profiles or none match the projectId, fallback to API pull
-        return this._apiSyncInstance.pullAllProjectDataExceptChoices(projectId).then((pullData) => {
-          const projectProfiles = pullData.data.project_profiles.updates
+          // If IndexedDB returns no profiles or none match the projectId, fallback to API pull
+          return this._apiSyncInstance
+            .pullAllProjectDataExceptChoices(projectId)
+            .then((pullData) => {
+              const projectProfiles = pullData.data.project_profiles.updates
 
-          const usersInCurrentProject = projectProfiles.filter(
-            ({ project }) => project === projectId,
-          )
+              const usersInCurrentProject = projectProfiles.filter(
+                ({ project }) => project === projectId,
+              )
 
-          return usersInCurrentProject
+              return usersInCurrentProject
+            })
         })
-      })
+        .catch((error) => {
+          return Promise.reject(error)
+        })
     }
 
     editProjectProfileRole = async function editProjectProfileRole({

--- a/src/App/mermaidData/databaseSwitchboard/ProjectsMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/ProjectsMixin.js
@@ -86,13 +86,17 @@ const ProjectsMixin = (Base) =>
         Promise.reject(this._operationMissingParameterError)
       }
 
-      return this._isAuthenticatedAndReady
-        ? this._dexiePerUserDataInstance.project_profiles
-            .toArray()
-            .then((projectProfiles) =>
-              projectProfiles.filter((projectProfile) => projectProfile.project === projectId),
-            )
-        : Promise.reject(this._notAuthenticatedAndReadyError)
+      if (!this._isAuthenticatedAndReady) {
+        return Promise.reject(this._notAuthenticatedAndReadyError)
+      }
+
+      return this._apiSyncInstance
+        .pullAllProjectDataExceptChoices(projectId)
+        .then(async (pullData) => {
+          const projectProfiles = pullData.data.project_profiles.updates
+
+          return projectProfiles.filter((projectProfile) => projectProfile.project === projectId)
+        })
     }
 
     editProjectProfileRole = async function editProjectProfileRole({

--- a/src/components/FilterSearchToolbar/FilterSearchToolbar.js
+++ b/src/components/FilterSearchToolbar/FilterSearchToolbar.js
@@ -22,7 +22,7 @@ const FilterSearchToolbar = ({
   id = 'filter-search',
   name,
   disabled = false,
-  globalSearchText,
+  globalSearchText = '',
   handleGlobalFilterChange,
   type = 'page',
 }) => {

--- a/src/components/FilterSearchToolbar/FilterSearchToolbar.js
+++ b/src/components/FilterSearchToolbar/FilterSearchToolbar.js
@@ -126,7 +126,7 @@ FilterSearchToolbar.propTypes = {
   id: PropTypes.string,
   name: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
-  globalSearchText: PropTypes.string.isRequired,
+  globalSearchText: PropTypes.string,
   handleGlobalFilterChange: PropTypes.func.isRequired,
   type: PropTypes.string,
 }

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -850,9 +850,9 @@ const Users = () => {
           <tbody {...getTableBodyProps()}>
             {page.map((row) => {
               prepareRow(row)
-              const { key, ...restRowProps } = row.getRowProps()
+              const { key: rowKey, ...restRowProps } = row.getRowProps()
               return (
-                <Tr key={key} {...restRowProps}>
+                <Tr key={rowKey} {...restRowProps}>
                   {row.cells.map((cell) => {
                     const { key: cellKey, ...restCellProps } = cell.getCellProps()
                     return (

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -815,41 +815,48 @@ const Users = () => {
       <StickyTableOverflowWrapper>
         <GenericStickyTable {...getTableProps()} cursor={isTableUpdating ? 'wait' : 'pointer'}>
           <thead>
-            {headerGroups.map((headerGroup) => (
-              <Tr key={headerGroup.id} {...headerGroup.getHeaderGroupProps()}>
-                {headerGroup.headers.map((column) => {
-                  const isMultiSortColumn = headerGroup.headers.some(
-                    (header) => header.sortedIndex > 0,
-                  )
+            {headerGroups.map((headerGroup) => {
+              const { key, ...restHeaderGroupProps } = headerGroup.getHeaderGroupProps()
 
-                  return (
-                    <Th
-                      {...column.getHeaderProps(getTableColumnHeaderProps(column))}
-                      key={column.id}
-                      isSortedDescending={column.isSortedDesc}
-                      sortedIndex={column.sortedIndex}
-                      isMultiSortColumn={isMultiSortColumn}
-                      isSortingEnabled={!column.disableSortBy}
-                      disabledHover={column.disableSortBy}
-                    >
-                      <span id="header-span">{column.render('Header')}</span>
-                    </Th>
-                  )
-                })}
-              </Tr>
-            ))}
+              return (
+                <Tr key={key} {...restHeaderGroupProps}>
+                  {headerGroup.headers.map((column) => {
+                    const isMultiSortColumn = headerGroup.headers.some(
+                      (header) => header.sortedIndex > 0,
+                    )
+
+                    const { key: columnKey, ...restColumnProps } = column.getHeaderProps(
+                      getTableColumnHeaderProps(column),
+                    )
+
+                    return (
+                      <Th
+                        key={columnKey}
+                        {...restColumnProps}
+                        isSortedDescending={column.isSortedDesc}
+                        sortedIndex={column.sortedIndex}
+                        isMultiSortColumn={isMultiSortColumn}
+                        isSortingEnabled={!column.disableSortBy}
+                        disabledHover={column.disableSortBy}
+                      >
+                        <span id="header-span">{column.render('Header')}</span>
+                      </Th>
+                    )
+                  })}
+                </Tr>
+              )
+            })}
           </thead>
           <tbody {...getTableBodyProps()}>
             {page.map((row) => {
               prepareRow(row)
-              const { key: _, ...restRowProps } = row.getRowProps()
+              const { key, ...restRowProps } = row.getRowProps()
               return (
-                <Tr key={row.id} {...restRowProps}>
+                <Tr key={key} {...restRowProps}>
                   {row.cells.map((cell) => {
-                    const { key: _, ...restCellProps } = cell.getCellProps()
-                    const uniqueKey = `${row.id}-${cell.column.id}`
+                    const { key: cellKey, ...restCellProps } = cell.getCellProps()
                     return (
-                      <UserTableTd key={uniqueKey} {...restCellProps} align={cell.column.align}>
+                      <UserTableTd key={cellKey} {...restCellProps} align={cell.column.align}>
                         {cell.render('Cell')}
                       </UserTableTd>
                     )


### PR DESCRIPTION
[trello card](https://trello.com/c/hxQMN1PG/1152-blank-users-list-after-switching-projects)

Summary:

- the issue was caused by indexdb instance becoming out of sync with whats in the api on the initial load of a project users page. To fix this, I updated `getProjectProfiles` to try and get project profile data from the index db instance first, and if that failed, use an api pull/sync.  This approach prioritizes using locally cached data to minimize API calls and only pulls from the API if needed (if users returns an empty array).

- also fixed warning on users list page to ensure key prop is not being spread into JSX. 

To test:

1. open incognito to ensure empty cache

2. log into app

3. go to a project, click on ‘users' directly from the summary card not from the submenu within a project

4. view users table

5. upon refresh, users are there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Improved code readability and maintainability in the Users component by optimizing the rendering of table headers and rows.
	- Enhanced handling of key properties for better performance without changing the underlying functionality.

- **Bug Fixes**
	- Ensured unique keys are correctly assigned to each element in the table, maintaining the integrity of the rendering process.
	- Improved error handling across various methods in the ProjectsMixin class to ensure consistent promise rejections.

- **New Features**
	- Updated `globalSearchText` prop in the FilterSearchToolbar component to be optional, providing more flexibility in usage.
	- Enhanced project profile retrieval logic to include a fallback to an external API, ensuring better data freshness and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->