### PR TITLE
[M1148] SU bug: button should be disabled when read-only

### DIFF
--- a/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
+++ b/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
@@ -160,8 +160,6 @@ const SubmittedFishBelt = () => {
       })
   }
 
-  console.log({ isMoveToButtonDisabled })
-
   return idsNotAssociatedWithData.length ? (
     <ContentPageLayout
       isPageContentLoading={isLoading}


### PR DESCRIPTION
[trello card](https://trello.com/c/XgDOU3qC/1148-edit-sample-unit-move-to-collecting-button-not-greyed-out-with-read-only-permissions)

to test:

1. go to submitted fish belt SU
2. edit button should be disabled as read-only user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced interactivity of the "Move to Collect" button for admin users, allowing it to be enabled regardless of other conditions.

- **Bug Fixes**
	- Improved user permissions handling related to button functionality. 

- **Documentation**
	- Clarified the conditions under which the "Move to Collect" button is enabled for better user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->