### PR TITLE
[M1148] fish belt edit display bug

### DIFF
--- a/src/components/pages/submittedRecordPages/SubmittedBenthicPhotoQuadrat/SubmittedBenthicPhotoQuadrat.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBenthicPhotoQuadrat/SubmittedBenthicPhotoQuadrat.js
@@ -194,7 +194,7 @@ const SubmittedBenthicPhotoQuadrat = () => {
                 </p>
                 <ButtonSecondary
                   onClick={handleMoveToCollect}
-                  disabled={isAdminUser ? isMoveToButtonDisabled : 'false'}
+                  disabled={!isAdminUser || isMoveToButtonDisabled}
                 >
                   <IconPen />
                   {language.pages.submittedForm.moveSampleUnitButton}

--- a/src/components/pages/submittedRecordPages/SubmittedBenthicPit/SubmittedBenthicPit.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBenthicPit/SubmittedBenthicPit.js
@@ -194,7 +194,7 @@ const SubmittedBenthicPit = () => {
                 </p>
                 <ButtonSecondary
                   onClick={handleMoveToCollect}
-                  disabled={isAdminUser ? isMoveToButtonDisabled : 'false'}
+                  disabled={!isAdminUser || isMoveToButtonDisabled}
                 >
                   <IconPen />
                   {language.pages.submittedForm.moveSampleUnitButton}

--- a/src/components/pages/submittedRecordPages/SubmittedBleaching/SubmittedBleaching.js
+++ b/src/components/pages/submittedRecordPages/SubmittedBleaching/SubmittedBleaching.js
@@ -197,7 +197,7 @@ const SubmittedBleaching = () => {
                 </p>
                 <ButtonSecondary
                   onClick={handleMoveToCollect}
-                  disabled={isAdminUser ? isMoveToButtonDisabled : 'false'}
+                  disabled={!isAdminUser || isMoveToButtonDisabled}
                 >
                   <IconPen />
                   {language.pages.submittedForm.moveSampleUnitButton}

--- a/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
+++ b/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
@@ -208,7 +208,7 @@ const SubmittedFishBelt = () => {
                 </p>
                 <ButtonSecondary
                   onClick={handleMoveToCollect}
-                  disabled={isAdminUser ? isMoveToButtonDisabled : `false`}
+                  disabled={!isAdminUser || isMoveToButtonDisabled}
                 >
                   <IconPen />
                   {language.pages.submittedForm.moveSampleUnitButton}

--- a/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
+++ b/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
@@ -27,6 +27,7 @@ import { getRecordSubNavNodeInfo } from '../../../../library/getRecordSubNavNode
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
 import { FormSubTitle } from '../SubmittedFormPage.styles'
 import { useHttpResponseErrorHandler } from '../../../../App/HttpResponseErrorHandlerContext'
+import { getIsUserAdminForProject } from '../../../../App/currentUserProfileHelpers'
 
 const SubmittedFishBelt = () => {
   const [choices, setChoices] = useState({})
@@ -48,8 +49,9 @@ const SubmittedFishBelt = () => {
   const isMounted = useIsMounted()
   const observers = submittedRecord?.observers ?? []
   const { currentUser } = useCurrentUser()
-  const [currentUserProfile, setCurrentUserProfile] = useState({})
+  // const [currentUserProfile, setCurrentUserProfile] = useState({})
   const handleHttpResponseError = useHttpResponseErrorHandler()
+  const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
 
   const _getSupportingData = useEffect(() => {
     if (isAppOnline && databaseSwitchboardInstance && projectId && !isSyncInProgress) {
@@ -99,17 +101,12 @@ const SubmittedFishBelt = () => {
                 'fishbelt',
               )
 
-              const filteredUserProfile = projectProfilesResponse.filter(
-                ({ profile }) => currentUser.id === profile,
-              )[0]
-
               setSites(sitesResponse)
               setManagementRegimes(managementRegimesResponse)
               setChoices(choicesResponse)
               setSubmittedRecord(submittedRecordResponse)
               setFishNameOptions(updateFishNameOptions)
               setFishNameConstants(updateFishNameConstants)
-              setCurrentUserProfile(filteredUserProfile)
               setSubNavNode(recordNameForSubNode)
               setIsLoading(false)
             }
@@ -208,13 +205,13 @@ const SubmittedFishBelt = () => {
             <RowSpaceBetween>
               <>
                 <p>
-                  {currentUserProfile.is_admin
+                  {isAdminUser
                     ? language.pages.submittedForm.sampleUnitsAreReadOnly
                     : language.pages.submittedForm.adminEditOnly}
                 </p>
                 <ButtonSecondary
                   onClick={handleMoveToCollect}
-                  disabled={currentUserProfile.is_admin ? false : isMoveToButtonDisabled}
+                  disabled={isAdminUser ? isMoveToButtonDisabled : 'false'}
                 >
                   <IconPen />
                   {language.pages.submittedForm.moveSampleUnitButton}

--- a/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
+++ b/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
@@ -80,7 +80,6 @@ const SubmittedFishBelt = () => {
             genera,
             families,
             submittedRecordResponse,
-            projectProfilesResponse,
           ]) => {
             if (isMounted.current) {
               const updateFishNameOptions = getFishNameOptions({

--- a/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
+++ b/src/components/pages/submittedRecordPages/SubmittedFishBelt/SubmittedFishBelt.js
@@ -49,7 +49,6 @@ const SubmittedFishBelt = () => {
   const isMounted = useIsMounted()
   const observers = submittedRecord?.observers ?? []
   const { currentUser } = useCurrentUser()
-  // const [currentUserProfile, setCurrentUserProfile] = useState({})
   const handleHttpResponseError = useHttpResponseErrorHandler()
   const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
 
@@ -67,7 +66,6 @@ const SubmittedFishBelt = () => {
           submittedRecordId,
           'beltfishtransectmethods',
         ),
-        databaseSwitchboardInstance.getProjectProfiles(projectId),
       ]
 
       Promise.all(promises)
@@ -210,7 +208,7 @@ const SubmittedFishBelt = () => {
                 </p>
                 <ButtonSecondary
                   onClick={handleMoveToCollect}
-                  disabled={isAdminUser ? isMoveToButtonDisabled : 'false'}
+                  disabled={isAdminUser ? isMoveToButtonDisabled : `false`}
                 >
                   <IconPen />
                   {language.pages.submittedForm.moveSampleUnitButton}

--- a/src/components/pages/submittedRecordPages/SubmittedHabitatComplexity/SubmittedHabitatComplexity.js
+++ b/src/components/pages/submittedRecordPages/SubmittedHabitatComplexity/SubmittedHabitatComplexity.js
@@ -194,7 +194,7 @@ const SubmittedHabitatComplexity = () => {
                 </p>
                 <ButtonSecondary
                   onClick={handleMoveToCollect}
-                  disabled={isAdminUser ? isMoveToButtonDisabled : 'false'}
+                  disabled={!isAdminUser || isMoveToButtonDisabled}
                 >
                   <IconPen />
                   {language.pages.submittedForm.moveSampleUnitButton}


### PR DESCRIPTION
[trello card](https://trello.com/c/XgDOU3qC/1148-edit-sample-unit-move-to-collecting-button-not-greyed-out-with-read-only-permissions)

to test:

1. go to submitted fish belt CR as read-only user
2. ensure edit button is disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a streamlined admin check for users, enhancing the display of admin-related content.
- **Bug Fixes**
	- Improved logic for button states to ensure correct enabling/disabling based on admin status, enhancing user interaction.
- **Chores**
	- Updated button properties across multiple components to align with the new admin check logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->