### PR TITLE
[M1149] Ensure consistent React Node wrapping for table data to resolve sorti…

### DIFF
--- a/src/components/pages/gfcrPages/Gfcr/Gfcr.js
+++ b/src/components/pages/gfcrPages/Gfcr/Gfcr.js
@@ -127,9 +127,13 @@ const Gfcr = () => {
       const localizedDate = new Date(report_date).toLocaleDateString(currentLocale, dateOptions)
 
       return {
-        title: isAdminUser ? <Link to={`${currentProjectPath}/gfcr/${id}`}>{title}</Link> : title,
-        indicator_set_type: indicator_set_type === 'report' ? 'Report' : 'Target',
-        report_date: localizedDate,
+        title: isAdminUser ? (
+          <Link to={`${currentProjectPath}/gfcr/${id}`}>{title}</Link>
+        ) : (
+          <span>{title || 'Untitled'}</span>
+        ),
+        indicator_set_type: <span>{indicator_set_type === 'report' ? 'Report' : 'Target'}</span>,
+        report_date: <span>{localizedDate}</span>,
       }
     })
   }, [gfcrIndicatorSets, isAdminUser, currentProjectPath])


### PR DESCRIPTION
[trello card
](https://trello.com/c/AAT4NZwC/1149-gfcr-page-not-loading-for-read-only-and-collector-users)

- Updated `tableCellData` to wrap `indicator_set_type` and `report_date` in `<span>` tags.
- Ensured `title` is consistently wrapped in either a `<Link>` (for admin users) or `<span>` (for non-admin users).
- Resolved sorting issues caused by inconsistent data types in the `'Type'` column when `indicator_set_type` was set to `'Target'`.

to test:
1. in a test project, enable GFCR as an admin.
2. add an indicator set, with type ‘target'.
3. in another browser, log into the app where i am a read only user in the same project (used another email to add myself)
4. click on gfcr
5. ensure no errors appear
