### PR TITLE
[M1145] Add a save confirmation when closing the image annotation modal.

### DIFF
--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
@@ -42,6 +42,7 @@ const ImageAnnotationModal = ({
   const [selectedAttributeId, setSelectedAttributeId] = useState('')
   const [hoveredAttributeId, setHoveredAttributeId] = useState('')
   const [isSaving, setIsSaving] = useState(false)
+  const [isDataUpdatedSinceLastSave, setIsDataUpdatedSinceLastSave] = useState(false)
 
   const getBenthicAttributeLabel = (benthicAttributeId) => {
     const matchingBenthicAttribute = benthicAttributes.find(({ id }) => id === benthicAttributeId)
@@ -83,7 +84,18 @@ const ImageAnnotationModal = ({
     // eslint-disable-next-line
   }, [])
 
-  const handleCloseModal = () => setImageId()
+  const handleCloseModal = () => {
+    if (isDataUpdatedSinceLastSave) {
+      const userConfirmed = window.confirm(
+        'Are you sure you want to discard the change to this image?',
+      )
+      if (userConfirmed) {
+        setImageId()
+      }
+    } else {
+      setImageId()
+    }
+  }
 
   const handleSaveChanges = () => {
     setIsSaving(true)
@@ -119,6 +131,7 @@ const ImageAnnotationModal = ({
               selectedAttributeId={selectedAttributeId}
               setSelectedAttributeId={setSelectedAttributeId}
               setHoveredAttributeId={setHoveredAttributeId}
+              setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
             />
             <ImageAnnotationModalMap
               dataToReview={dataToReview}
@@ -126,6 +139,7 @@ const ImageAnnotationModal = ({
               selectedAttributeId={selectedAttributeId}
               hoveredAttributeId={hoveredAttributeId}
               databaseSwitchboardInstance={databaseSwitchboardInstance}
+              setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
             />
           </ImageAnnotationModalContainer>
         ) : (

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
@@ -85,14 +85,10 @@ const ImageAnnotationModal = ({
   }, [])
 
   const handleCloseModal = () => {
-    if (isDataUpdatedSinceLastSave) {
-      const userConfirmed = window.confirm(
-        'Are you sure you want to discard the change to this image?',
-      )
-      if (userConfirmed) {
-        setImageId()
-      }
-    } else {
+    if (
+      !isDataUpdatedSinceLastSave ||
+      window.confirm('Are you sure you want to discard the change to this image?')
+    ) {
       setImageId()
     }
   }

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
@@ -72,6 +72,7 @@ const ImageAnnotationModalMap = ({
   selectedAttributeId,
   hoveredAttributeId,
   databaseSwitchboardInstance,
+  setIsDataUpdatedSinceLastSave,
 }) => {
   const mapContainer = useRef(null)
   const map = useRef(null)
@@ -408,6 +409,7 @@ const ImageAnnotationModalMap = ({
             setDataToReview={setDataToReview}
             pointId={selectedPoint.id}
             databaseSwitchboardInstance={databaseSwitchboardInstance}
+            setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
           />
         </EditPointPopupWrapper>
       ) : null}
@@ -421,6 +423,7 @@ ImageAnnotationModalMap.propTypes = {
   selectedAttributeId: PropTypes.string.isRequired,
   hoveredAttributeId: PropTypes.string.isRequired,
   databaseSwitchboardInstance: PropTypes.object.isRequired,
+  setIsDataUpdatedSinceLastSave: PropTypes.func.isRequired,
 }
 
 export default ImageAnnotationModalMap

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalTable.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalTable.js
@@ -16,6 +16,7 @@ const ImageAnnotationModalTable = ({
   selectedAttributeId,
   setSelectedAttributeId,
   setHoveredAttributeId,
+  setIsDataUpdatedSinceLastSave,
 }) => {
   const classifiedPoints = points.filter(({ annotations }) => annotations.length > 0)
   const tableData = Object.groupBy(classifiedPoints, ({ annotations }) => annotations[0].ba_gr)
@@ -47,6 +48,7 @@ const ImageAnnotationModalTable = ({
     })
 
     setDataToReview((prevState) => ({ ...prevState, points: updatedPoints }))
+    setIsDataUpdatedSinceLastSave(true)
   }
 
   return (
@@ -109,6 +111,7 @@ ImageAnnotationModalTable.propTypes = {
   setHoveredAttributeId: PropTypes.func.isRequired,
   setDataToReview: PropTypes.func.isRequired,
   points: PropTypes.arrayOf(imageClassificationPointPropType).isRequired,
+  setIsDataUpdatedSinceLastSave: PropTypes.func.isRequired,
 }
 
 export default ImageAnnotationModalTable

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ClassifierGuesses.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ClassifierGuesses.js
@@ -17,7 +17,12 @@ const confirmFirstAnnotationAndUnconfirmRest = (annotation, i) => {
   annotation.is_confirmed = i === 0
 }
 
-const ClassifierGuesses = ({ selectedPoint, dataToReview, setDataToReview }) => {
+const ClassifierGuesses = ({
+  selectedPoint,
+  dataToReview,
+  setDataToReview,
+  setIsDataUpdatedSinceLastSave,
+}) => {
   const classifierGuesses = selectedPoint.annotations.filter(
     (annotation) => annotation.is_machine_created,
   )
@@ -36,6 +41,7 @@ const ClassifierGuesses = ({ selectedPoint, dataToReview, setDataToReview }) => 
       point.id === selectedPoint.id ? { ...point, annotations: updatedAnnotations } : point,
     )
     setDataToReview({ ...dataToReview, points: updatedPoints })
+    setIsDataUpdatedSinceLastSave(true)
   }
 
   return classifierGuessesSortedByScore.map((annotation) => (
@@ -59,6 +65,7 @@ ClassifierGuesses.propTypes = {
   selectedPoint: imageClassificationPointPropType.isRequired,
   dataToReview: imageClassificationResponsePropType.isRequired,
   setDataToReview: PropTypes.func.isRequired,
+  setIsDataUpdatedSinceLastSave: PropTypes.func.isRequired,
 }
 
 export default ClassifierGuesses

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ExistingRows.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ExistingRows.js
@@ -15,7 +15,12 @@ const isAClassifierGuessOfSelectedPoint = (annotations, ba_gr) =>
 
 const isOptionAlreadyAdded = (acc, value) => acc.some((option) => option.value === value)
 
-const ExistingRows = ({ selectedPoint, dataToReview, setDataToReview }) => {
+const ExistingRows = ({
+  selectedPoint,
+  dataToReview,
+  setDataToReview,
+  setIsDataUpdatedSinceLastSave,
+}) => {
   const [selectedExistingRow, setSelectedExistingRow] = useState('')
 
   const existingRowDropdownOptions = dataToReview.points
@@ -72,6 +77,7 @@ const ExistingRows = ({ selectedPoint, dataToReview, setDataToReview }) => {
       point.id === selectedPoint.id ? { ...point, annotations: updatedAnnotations } : point,
     )
     setDataToReview({ ...dataToReview, points: updatedPoints })
+    setIsDataUpdatedSinceLastSave(true)
   }
 
   return (
@@ -116,6 +122,7 @@ ExistingRows.propTypes = {
   selectedPoint: imageClassificationPointPropType.isRequired,
   dataToReview: imageClassificationResponsePropType.isRequired,
   setDataToReview: PropTypes.func.isRequired,
+  setIsDataUpdatedSinceLastSave: PropTypes.func.isRequired,
 }
 
 export default ExistingRows

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
@@ -14,6 +14,7 @@ const ImageAnnotationPopup = ({
   setDataToReview,
   pointId,
   databaseSwitchboardInstance,
+  setIsDataUpdatedSinceLastSave,
 }) => {
   const selectedPoint = dataToReview.points.find((point) => point.id === pointId)
 
@@ -30,17 +31,20 @@ const ImageAnnotationPopup = ({
           selectedPoint={selectedPoint}
           dataToReview={dataToReview}
           setDataToReview={setDataToReview}
+          setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
         />
         <ExistingRows
           selectedPoint={selectedPoint}
           dataToReview={dataToReview}
           setDataToReview={setDataToReview}
+          setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
         />
         <NewRow
           selectedPoint={selectedPoint}
           dataToReview={dataToReview}
           setDataToReview={setDataToReview}
           databaseSwitchboardInstance={databaseSwitchboardInstance}
+          setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
         />
       </tbody>
     </EditPointPopupTable>
@@ -52,6 +56,7 @@ ImageAnnotationPopup.propTypes = {
   setDataToReview: PropTypes.func.isRequired,
   pointId: PropTypes.string.isRequired,
   databaseSwitchboardInstance: databaseSwitchboardPropTypes,
+  setIsDataUpdatedSinceLastSave: PropTypes.func.isRequired,
 }
 
 export default ImageAnnotationPopup

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewRow.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewRow.js
@@ -25,7 +25,13 @@ import { createPortal } from 'react-dom'
 const isAClassifierGuessOfSelectedPoint = (annotations, ba_gr) =>
   annotations.some((annotation) => annotation.is_machine_created && annotation.ba_gr === ba_gr)
 
-const NewRow = ({ selectedPoint, dataToReview, setDataToReview, databaseSwitchboardInstance }) => {
+const NewRow = ({
+  selectedPoint,
+  dataToReview,
+  setDataToReview,
+  databaseSwitchboardInstance,
+  setIsDataUpdatedSinceLastSave,
+}) => {
   const [shouldDisplayModal, setShouldDisplayModal] = useState(false)
   const [benthicAttributeSelectOptions, setBenthicAttributeSelectOptions] = useState([])
   const [growthFormSelectOptions, setGrowthFormSelectOptions] = useState([])
@@ -79,6 +85,7 @@ const NewRow = ({ selectedPoint, dataToReview, setDataToReview, databaseSwitchbo
     )
 
     setDataToReview({ ...dataToReview, points: updatedPoints })
+    setIsDataUpdatedSinceLastSave(true)
     handleCloseModal()
   }
 
@@ -117,6 +124,7 @@ const NewRow = ({ selectedPoint, dataToReview, setDataToReview, databaseSwitchbo
     )
 
     setDataToReview({ ...dataToReview, points: updatedPoints })
+    setIsDataUpdatedSinceLastSave(true)
     handleCloseModal()
   }
 
@@ -212,6 +220,7 @@ NewRow.propTypes = {
   dataToReview: imageClassificationResponsePropType.isRequired,
   setDataToReview: PropTypes.func.isRequired,
   databaseSwitchboardInstance: PropTypes.object.isRequired,
+  setIsDataUpdatedSinceLastSave: PropTypes.func.isRequired,
 }
 
 export default NewRow

--- a/src/components/pages/ImageClassification/SampleUnitInputSelector/SampleUnitInputSelector.js
+++ b/src/components/pages/ImageClassification/SampleUnitInputSelector/SampleUnitInputSelector.js
@@ -27,11 +27,15 @@ const SampleUnitInputSelector = ({ setIsImageClassification, isAppOnline }) => {
       </TextContainer>
       <ButtonContainer>
         <div>
-        {!isAppOnline ? <OfflineText>Unavailable offline.</OfflineText> : null}
-        <ButtonPrimary type="button" onClick={handleSampleUnitChange(true)} disabled={!isAppOnline}>
-          <IconSparkles />
-          <ButtonText>{language.imageClassification.sampleUnitInputSelector.button1}</ButtonText>
-        </ButtonPrimary>
+          {!isAppOnline ? <OfflineText>Unavailable offline.</OfflineText> : null}
+          <ButtonPrimary
+            type="button"
+            onClick={handleSampleUnitChange(true)}
+            disabled={!isAppOnline}
+          >
+            <IconSparkles />
+            <ButtonText>{language.imageClassification.sampleUnitInputSelector.button1}</ButtonText>
+          </ButtonPrimary>
         </div>
         <ButtonSecondary type="button" onClick={handleSampleUnitChange(false)}>
           <IconPen />


### PR DESCRIPTION
[trello card](https://trello.com/c/d8qkSuPN/1145-add-a-save-confirmation-when-closing-the-image-annotation-modal)

to test:

1. upload images in BPQ record
2. open image annotation modal
3. make changes (confirm, add new attribute in modal map, change classifier guess etc)
4. click 'x' or cancel (don't save changes)
5. ensure js alert pops up to show that you have unsaved changes