### PR TITLE
M1119: add currency formatting to GFCR tables

### DIFF
--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/Investments.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/Investments.js
@@ -96,6 +96,11 @@ const Investments = ({
         (investmentTypeChoice) => investmentTypeChoice.id === investment_type,
       )?.name
 
+      const formattedInvestmentAmount = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+      }).format(investment_amount)
+
       return {
         finance_solution: (
           <StyledTableAnchor id={id} onClick={(event) => handleEditInvestment(event)}>
@@ -104,7 +109,7 @@ const Investments = ({
         ),
         investment_source: investmentSourceName,
         investment_type: investmentTypeName,
-        investment_amount: `$${investment_amount}`,
+        investment_amount: `${formattedInvestmentAmount}`,
       }
     })
   }, [choices, handleEditInvestment, indicatorSet, investments])

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/Investments.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/Investments.js
@@ -22,6 +22,7 @@ import { StyledTableAnchor } from './subPages.styles'
 import { choicesPropType } from '../../../../../App/mermaidData/mermaidDataProptypes'
 import GfcrGenericTable from '../../GfcrGenericTable'
 import InvestmentModal from '../modals/InvestmentModal'
+import formattedCurrencyAmount from '../../../../../library/formatCurrencyAmount'
 
 const tableLanguage = language.pages.gfcrInvestmentsTable
 
@@ -96,10 +97,7 @@ const Investments = ({
         (investmentTypeChoice) => investmentTypeChoice.id === investment_type,
       )?.name
 
-      const formattedInvestmentAmount = new Intl.NumberFormat('en-US', {
-        style: 'currency',
-        currency: 'USD',
-      }).format(investment_amount)
+      const formattedInvestmentAmount = formattedCurrencyAmount(investment_amount)
 
       return {
         finance_solution: (

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/Revenues.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/Revenues.js
@@ -88,6 +88,11 @@ const Revenues = ({ indicatorSet, setIndicatorSet, choices, setSelectedNavItem, 
         (revenueTypeChoice) => revenueTypeChoice.id === revenue_type,
       ).name
 
+      const formattedRevenueAmount = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+      }).format(revenue_amount)
+
       return {
         finance_solution: (
           <StyledTableAnchor id={id} onClick={(event) => handleEditRevenue(event)}>
@@ -96,7 +101,7 @@ const Revenues = ({ indicatorSet, setIndicatorSet, choices, setSelectedNavItem, 
         ),
         revenue_type: revenueTypeName,
         sustainable_revenue_stream: <IconCheckLabel isCheck={!!sustainable_revenue_stream} />,
-        revenue_amount: `$${revenue_amount}`,
+        revenue_amount: `${formattedRevenueAmount}`,
       }
     })
   }, [choices, handleEditRevenue, indicatorSet.finance_solutions, revenues])

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/Revenues.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/Revenues.js
@@ -23,6 +23,7 @@ import { choicesPropType } from '../../../../../App/mermaidData/mermaidDataPropt
 import GfcrGenericTable from '../../GfcrGenericTable'
 import IconCheckLabel from './IconCheckLabel'
 import RevenueModal from '../modals/RevenueModal'
+import formattedCurrencyAmount from '../../../../../library/formatCurrencyAmount'
 
 const tableLanguage = language.pages.gfcrRevenuesTable
 
@@ -88,10 +89,7 @@ const Revenues = ({ indicatorSet, setIndicatorSet, choices, setSelectedNavItem, 
         (revenueTypeChoice) => revenueTypeChoice.id === revenue_type,
       ).name
 
-      const formattedRevenueAmount = new Intl.NumberFormat('en-US', {
-        style: 'currency',
-        currency: 'USD',
-      }).format(revenue_amount)
+      const formattedRevenueAmount = formattedCurrencyAmount(revenue_amount)
 
       return {
         finance_solution: (

--- a/src/library/formatCurrencyAmount.js
+++ b/src/library/formatCurrencyAmount.js
@@ -1,0 +1,20 @@
+/**
+ * Formats a given number as a USD currency string.
+ *
+ * @param {number|string} amount - The number to format. Can be a number or a numeric string.
+ * @returns {string} - The formatted currency string (e.g., "$1,234.56").
+ */
+const formatCurrencyAmount = (amount) => {
+  if (isNaN(amount) || amount === null || amount === undefined) {
+    return ''
+  }
+
+  const numericValue = typeof amount === 'string' ? parseFloat(amount) : amount
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(numericValue)
+}
+
+export default formatCurrencyAmount


### PR DESCRIPTION
[trello card](https://trello.com/c/8XJTKhMR/1119-make-gfcr-currency-numbers-locale-formatted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced display of investment and revenue amounts with proper currency formatting.

- **Bug Fixes**
	- Improved presentation of financial figures by replacing string interpolation with formatted currency strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->