### PR TITLE
M1145: add prompt when browser tab is being closed

### DIFF
--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
@@ -17,7 +17,6 @@ import {
 import { useDatabaseSwitchboardInstance } from '../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 import LoadingIndicator from '../../../LoadingIndicator/LoadingIndicator'
 import { ButtonPrimary, ButtonSecondary } from '../../../generic/buttons'
-import useBeforeUnloadPrompt from '../../../../library/useBeforeUnloadPrompt'
 import EnhancedPrompt from '../../../generic/EnhancedPrompt'
 
 const EXCLUDE_PARAMS =
@@ -45,8 +44,6 @@ const ImageAnnotationModal = ({
   const [hoveredAttributeId, setHoveredAttributeId] = useState('')
   const [isSaving, setIsSaving] = useState(false)
   const [isDataUpdatedSinceLastSave, setIsDataUpdatedSinceLastSave] = useState(false)
-
-  useBeforeUnloadPrompt({ shouldPromptTrigger: isDataUpdatedSinceLastSave })
 
   const getBenthicAttributeLabel = (benthicAttributeId) => {
     const matchingBenthicAttribute = benthicAttributes.find(({ id }) => id === benthicAttributeId)

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
@@ -18,6 +18,7 @@ import { useDatabaseSwitchboardInstance } from '../../../../App/mermaidData/data
 import LoadingIndicator from '../../../LoadingIndicator/LoadingIndicator'
 import { ButtonPrimary, ButtonSecondary } from '../../../generic/buttons'
 import useBeforeUnloadPrompt from '../../../../library/useBeforeUnloadPrompt'
+import EnhancedPrompt from '../../../generic/EnhancedPrompt'
 
 const EXCLUDE_PARAMS =
   'classification_status,collect_record_id,comments,created_by,created_on,data,id,location,name,num_confirmed,num_unclassified,num_unconfirmed,photo_timestamp,thumbnail,updated_by,updated_on'
@@ -115,65 +116,68 @@ const ImageAnnotationModal = ({
   }
 
   return (
-    <Modal
-      title={dataToReview?.original_image_name ?? ''}
-      isOpen
-      onDismiss={handleCloseModal}
-      contentOverflowIsVisible={true}
-      maxWidth="fit-content"
-      mainContent={
-        dataToReview && !isSaving ? (
-          <ImageAnnotationModalContainer>
-            <ImageAnnotationModalTable
-              points={dataToReview.points}
-              setDataToReview={setDataToReview}
-              selectedAttributeId={selectedAttributeId}
-              setSelectedAttributeId={setSelectedAttributeId}
-              setHoveredAttributeId={setHoveredAttributeId}
-              setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
-            />
-            <ImageAnnotationModalMap
-              dataToReview={dataToReview}
-              setDataToReview={setDataToReview}
-              selectedAttributeId={selectedAttributeId}
-              hoveredAttributeId={hoveredAttributeId}
-              databaseSwitchboardInstance={databaseSwitchboardInstance}
-              setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
-            />
-          </ImageAnnotationModalContainer>
-        ) : (
-          <LoadingContainer>
-            <LoadingIndicator />
-          </LoadingContainer>
-        )
-      }
-      footerContent={
-        <Footer>
-          <Legend>
-            <LegendItem>
-              <LegendSquare color={COLORS.unconfirmed} />
-              Unconfirmed
-            </LegendItem>
-            <LegendItem>
-              <LegendSquare color={COLORS.confirmed} />
-              Confirmed
-            </LegendItem>
-            <LegendItem>
-              <LegendSquare color={COLORS.unclassified} />
-              Unclassified
-            </LegendItem>
-          </Legend>
-          <div>
-            <ButtonSecondary type="button" onClick={handleCloseModal} disabled={isSaving}>
-              Cancel
-            </ButtonSecondary>
-            <ButtonPrimary type="button" onClick={handleSaveChanges} disabled={isSaving}>
-              Save Changes
-            </ButtonPrimary>
-          </div>
-        </Footer>
-      }
-    />
+    <>
+      <EnhancedPrompt shouldPromptTrigger={isDataUpdatedSinceLastSave} />
+      <Modal
+        title={dataToReview?.original_image_name ?? ''}
+        isOpen
+        onDismiss={handleCloseModal}
+        contentOverflowIsVisible={true}
+        maxWidth="fit-content"
+        mainContent={
+          dataToReview && !isSaving ? (
+            <ImageAnnotationModalContainer>
+              <ImageAnnotationModalTable
+                points={dataToReview.points}
+                setDataToReview={setDataToReview}
+                selectedAttributeId={selectedAttributeId}
+                setSelectedAttributeId={setSelectedAttributeId}
+                setHoveredAttributeId={setHoveredAttributeId}
+                setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
+              />
+              <ImageAnnotationModalMap
+                dataToReview={dataToReview}
+                setDataToReview={setDataToReview}
+                selectedAttributeId={selectedAttributeId}
+                hoveredAttributeId={hoveredAttributeId}
+                databaseSwitchboardInstance={databaseSwitchboardInstance}
+                setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
+              />
+            </ImageAnnotationModalContainer>
+          ) : (
+            <LoadingContainer>
+              <LoadingIndicator />
+            </LoadingContainer>
+          )
+        }
+        footerContent={
+          <Footer>
+            <Legend>
+              <LegendItem>
+                <LegendSquare color={COLORS.unconfirmed} />
+                Unconfirmed
+              </LegendItem>
+              <LegendItem>
+                <LegendSquare color={COLORS.confirmed} />
+                Confirmed
+              </LegendItem>
+              <LegendItem>
+                <LegendSquare color={COLORS.unclassified} />
+                Unclassified
+              </LegendItem>
+            </Legend>
+            <div>
+              <ButtonSecondary type="button" onClick={handleCloseModal} disabled={isSaving}>
+                Cancel
+              </ButtonSecondary>
+              <ButtonPrimary type="button" onClick={handleSaveChanges} disabled={isSaving}>
+                Save Changes
+              </ButtonPrimary>
+            </div>
+          </Footer>
+        }
+      />
+    </>
   )
 }
 

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
@@ -17,6 +17,7 @@ import {
 import { useDatabaseSwitchboardInstance } from '../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 import LoadingIndicator from '../../../LoadingIndicator/LoadingIndicator'
 import { ButtonPrimary, ButtonSecondary } from '../../../generic/buttons'
+import useBeforeUnloadPrompt from '../../../../library/useBeforeUnloadPrompt'
 
 const EXCLUDE_PARAMS =
   'classification_status,collect_record_id,comments,created_by,created_on,data,id,location,name,num_confirmed,num_unclassified,num_unconfirmed,photo_timestamp,thumbnail,updated_by,updated_on'
@@ -43,6 +44,9 @@ const ImageAnnotationModal = ({
   const [hoveredAttributeId, setHoveredAttributeId] = useState('')
   const [isSaving, setIsSaving] = useState(false)
   const [isDataUpdatedSinceLastSave, setIsDataUpdatedSinceLastSave] = useState(false)
+
+  // Use the custom hook to show the browser prompt when there are unsaved changes
+  useBeforeUnloadPrompt({ shouldPromptTrigger: isDataUpdatedSinceLastSave })
 
   const getBenthicAttributeLabel = (benthicAttributeId) => {
     const matchingBenthicAttribute = benthicAttributes.find(({ id }) => id === benthicAttributeId)

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
@@ -45,7 +45,6 @@ const ImageAnnotationModal = ({
   const [isSaving, setIsSaving] = useState(false)
   const [isDataUpdatedSinceLastSave, setIsDataUpdatedSinceLastSave] = useState(false)
 
-  // Use the custom hook to show the browser prompt when there are unsaved changes
   useBeforeUnloadPrompt({ shouldPromptTrigger: isDataUpdatedSinceLastSave })
 
   const getBenthicAttributeLabel = (benthicAttributeId) => {


### PR DESCRIPTION
[trello card](https://trello.com/c/d8qkSuPN/1145-add-a-save-confirmation-when-closing-the-image-annotation-modal)


to test:
1. go to IC
2. upload images
3. open annotation modal
4. make changes
5. close browser tab
6. view prompt