### PR TITLE
M760: add Average colonies bleached row to data sharing info page

### DIFF
--- a/src/components/DataSharingInfoModal/DataSharingInfoModal.js
+++ b/src/components/DataSharingInfoModal/DataSharingInfoModal.js
@@ -132,6 +132,18 @@ const DataSharingInfoModal = ({ isOpen, onDismiss }) => {
             </Tcell>
           </Tr>
           <Tr>
+            <Tcell cellWithText>Average colonies bleached (%)</Tcell>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+          </Tr>
+          <Tr>
             <Td colSpan="4" cellWithText>
               <strong>Transect-level observations</strong>
             </Td>

--- a/src/components/pages/DataSharing/DataSharing.js
+++ b/src/components/pages/DataSharing/DataSharing.js
@@ -92,7 +92,7 @@ const DataSharing = () => {
 
   useDocumentTitle(`${language.pages.dataSharing.title} - ${language.title.mermaid}`)
 
-  const [issDataSharingInfoModalOpen, setIsDataSharingInfoModalOpen] = useState(false)
+  const [isDataSharingInfoModalOpen, setIsDataSharingInfoModalOpen] = useState(false)
   const openDataSharingInfoModal = () => setIsDataSharingInfoModalOpen(true)
   const closeDataSharingInfoModal = () => setIsDataSharingInfoModalOpen(false)
 
@@ -328,7 +328,7 @@ const DataSharing = () => {
       ) : null}
       {!isAdminUser && isTestProject ? <p>{language.pages.dataSharing.isTestProject}</p> : null}
       <DataSharingInfoModal
-        isOpen={issDataSharingInfoModalOpen}
+        isOpen={isDataSharingInfoModalOpen}
         onDismiss={closeDataSharingInfoModal}
       />
     </MaxWidthInputWrapper>


### PR DESCRIPTION
[trello card](https://trello.com/c/PbuVG0v0/760-add-ave-bleached-colonies-to-data-sharing-chart)

Add row under Site-level averages with the same check/x columns with the label Average colonies bleached (%).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the modal visibility state variable name in the Data Sharing page
- **New Features**
  - Added a new row to the Data Sharing Information Modal displaying "Average colonies bleached (%)" with associated icons

<!-- end of auto-generated comment: release notes by coderabbit.ai -->