### PR TITLE
M1146 button to add classification attribute consistent with manual entry button

### DIFF
--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewRow.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewRow.js
@@ -204,7 +204,7 @@ const NewRow = ({
                 disabled={!selectedBenthicAttr}
                 onClick={handleAddNewRowClick}
               >
-                Add New Row
+                <IconPlus /> Add Row
               </ButtonPrimary>
             </NewRowFooterContainer>
           }


### PR DESCRIPTION
Changes: The image classification point popover New Attribute modal add button is now the same as the manual observation entry button

[Ticket](https://trello.com/c/sOkvxdyu/1146-make-add-row-button-consistent?filter=member:mnunes24)

Steps to test:
Look at the screenshots. They are the same buttons now as requested in the ticket!

OR:
- open the app and create a manual-entry BPQ record. Note the 'add row' button. 
- create a image-classification BPQ record. 
- upload an image
- click 'review'
- click on an point to open the point popover
- click 'select new attribute'. Note the button to confirm is the same as to add ab observation in manual mode

<img width="402" alt="Screenshot 2025-01-07 at 8 30 27 PM" src="https://github.com/user-attachments/assets/9c2f9635-ac90-4b8e-9e29-62006dfe4487" />
<img width="399" alt="Screenshot 2025-01-07 at 8 30 11 PM" src="https://github.com/user-attachments/assets/f6f0c5ea-08f0-4de1-a33b-ccf4f9b2fe60" />
