### PR TITLE
[M585] add user roles info modal

### DIFF
--- a/src/components/UserRolesInfoModal/UserRolesInfoModal.js
+++ b/src/components/UserRolesInfoModal/UserRolesInfoModal.js
@@ -1,0 +1,270 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled, { css } from 'styled-components/macro'
+
+import { ButtonSecondary } from '../generic/buttons'
+import { IconCheck, IconClose } from '../icons'
+import { Table, Td, Tr, TableOverflowWrapper } from '../generic/Table/table'
+import language from '../../language'
+import theme from '../../theme'
+import Modal, { RightFooter } from '../generic/Modal/Modal'
+
+const Thead = styled.th`
+  text-align: center;
+  background-color: ${theme.color.primaryColor};
+  color: white;
+  padding: ${theme.spacing.small} ${theme.spacing.medium};
+  vertical-align: top;
+  span {
+    white-space: nowrap;
+  }
+  small {
+    display: block;
+  }
+`
+
+const Tcell = styled(Td)`
+  ${(props) =>
+    props.cellWithText
+      ? css`
+          text-align: left;
+        `
+      : css`
+          text-align: center;
+        `};
+`
+
+const TcellWithIconClose = styled(Tcell)`
+  color: ${theme.color.cautionColor};
+`
+const UserRolesInfoModal = ({ isOpen, onDismiss }) => {
+  const modalContent = (
+    <TableOverflowWrapper>
+      <Table>
+        <thead>
+          <Tr>
+            <Thead>Accessible Information</Thead>
+            <Thead>Admin</Thead>
+            <Thead>Collect</Thead>
+            <Thead>Read-Only</Thead>
+          </Tr>
+        </thead>
+        <tbody>
+          <Tr>
+            <Td colSpan="4">
+              <strong>Project management</strong>
+            </Td>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>Edit project info</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>Set up data sharing policy</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>Add or remove project members</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>View project member email</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>Delete a project</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+          </Tr>
+
+          <Tr>
+            <Td colSpan="4" cellWithText>
+              <strong>Data collection and management</strong>
+            </Td>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>Add/update site or management regimes</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>Delete a site or management regime</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>Download sites and management regimes</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>Create, validate, and submit sample units</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>Delete unsubmited sample units</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>Edit submitted sample units</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>Transfer unsubbmitted sample units</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>Download submitted sample units</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>View observers and transects overview</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+          </Tr>
+          <Tr>
+            <Tcell cellWithText>View management regimes overview</Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+          </Tr>
+        </tbody>
+      </Table>
+    </TableOverflowWrapper>
+  )
+  const footerContent = (
+    <RightFooter>
+      <ButtonSecondary onClick={onDismiss}>Close</ButtonSecondary>
+    </RightFooter>
+  )
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onDismiss={onDismiss}
+      title={language.pages.userTable.moreInfoTitle}
+      mainContent={modalContent}
+      footerContent={footerContent}
+    />
+  )
+}
+
+UserRolesInfoModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onDismiss: PropTypes.func.isRequired,
+}
+
+export default UserRolesInfoModal

--- a/src/components/UserRolesInfoModal/index.js
+++ b/src/components/UserRolesInfoModal/index.js
@@ -1,0 +1,3 @@
+import UserRolesInfoModal from './UserRolesInfoModal'
+
+export default UserRolesInfoModal

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -4,13 +4,12 @@ import { useParams } from 'react-router-dom'
 import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import styled, { css } from 'styled-components/macro'
 
-import { ButtonSecondary, ButtonCaution, IconButton } from '../../generic/buttons'
+import { ButtonSecondary, ButtonCaution, IconButton, ButtonPrimary } from '../../generic/buttons'
 import { ContentPageLayout } from '../../Layout'
 import { getProfileNameOrEmailForPendingUser } from '../../../library/getProfileNameOrEmailForPendingUser'
 import { getTableColumnHeaderProps } from '../../../library/getTableColumnHeaderProps'
 import { getTableFilteredRows } from '../../../library/getTableFilteredRows'
 import { getToastArguments } from '../../../library/getToastArguments'
-import { H2 } from '../../generic/text'
 import { hoverState, mediaQueryPhoneOnly } from '../../../library/styling/mediaQueries'
 import {
   IconAccount,
@@ -34,6 +33,7 @@ import {
   StickyTableOverflowWrapper,
   GenericStickyTable,
 } from '../../generic/Table/table'
+import { P, H3 } from '../../generic/text'
 import { useCurrentUser } from '../../../App/CurrentUserContext'
 import { useDatabaseSwitchboardInstance } from '../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 import { useOnlineStatus } from '../../../library/onlineStatusContext'
@@ -63,6 +63,7 @@ import { PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
 import { useHttpResponseErrorHandler } from '../../../App/HttpResponseErrorHandlerContext'
 import { LabelContainer } from '../../generic/form'
 import ColumnHeaderToolTip from '../../ColumnHeaderToolTip/ColumnHeaderToolTip'
+import UserRolesInfoModal from '../../UserRolesInfoModal/UserRolesInfoModal'
 
 const ToolbarRowWrapper = styled('div')`
   display: grid;
@@ -72,6 +73,10 @@ const ToolbarRowWrapper = styled('div')`
     grid-template-rows: 1fr 1fr;
     grid-template-columns: auto;
   `)}
+`
+
+const InfoParagraph = styled('div')`
+  margin-bottom: 1.5em;
 `
 
 const InlineStyle = styled('div')`
@@ -174,6 +179,10 @@ const Users = () => {
   useDocumentTitle(`${language.pages.userTable.title} - ${language.title.mermaid}`)
 
   const [toUserProfileId, setToUserProfileId] = useState(currentUser.id)
+
+  const [isUserRolesModalOpen, setIsUserRolesModalOpen] = useState(false)
+  const openUserRolesModal = () => setIsUserRolesModalOpen(true)
+  const closeUserRolesModal = () => setIsUserRolesModalOpen(false)
 
   const _getSupportingData = useEffect(() => {
     if (!isAppOnline) {
@@ -865,6 +874,7 @@ const Users = () => {
             })}
           </tbody>
         </GenericStickyTable>
+        <UserRolesInfoModal isOpen={isUserRolesModalOpen} onDismiss={closeUserRolesModal} />
       </StickyTableOverflowWrapper>
       <TableNavigation>
         <PageSizeSelector
@@ -921,7 +931,13 @@ const Users = () => {
   )
   const toolbar = (
     <>
-      <H2>{language.pages.userTable.title}</H2>
+      <H3>{language.pages.userTable.title}</H3>
+      <InfoParagraph>
+        <P>{language.pages.userTable.introductionParagraph}</P>
+        <ButtonPrimary type="button" onClick={openUserRolesModal}>
+          <IconInfo /> View User Roles...
+        </ButtonPrimary>
+      </InfoParagraph>
       {isAppOnline && (
         <>
           {isReadonlyUserWithActiveSampleUnits && isAdminUser && (

--- a/src/language.js
+++ b/src/language.js
@@ -592,6 +592,9 @@ const pages = {
   },
   userTable: {
     title: 'Users',
+    introductionParagraph:
+      'MERMAID gives you the ability to control who can see and access your data.',
+    moreInfoTitle: 'User Roles',
     filterToolbarTextForAdmin: 'Filter this table by name or email',
     filterToolbarTextForNonAdmin: 'Filter this table by name or role',
     searchEmailToolbarText: 'Enter email address of user to add',


### PR DESCRIPTION
[trello card](https://trello.com/c/7Jr71N9z/585-user-roles-table)

Add user roles info modal, which is similar to the data sharing info modal

to test:

1. click on a project page
2. go to sub nav menu
3. click on users
4. click on 'view user roles...' button 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a User Roles Information Modal to provide detailed insights into user permissions and access levels
  - Introduced a button to view user role details within the Users page

- **User Experience**
  - Enhanced user management interface with clear explanations about data access control
  - Improved transparency of user role capabilities through a dedicated modal

- **Documentation**
  - Added contextual information about user roles and their associated permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->