### PR TITLE
M1184 show loading indicator over IC image until its done loading

### DIFF
--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
@@ -3,6 +3,7 @@ import colorHelper from 'color'
 import theme from '../../../../theme'
 import { Table, Tr, Td } from '../../../generic/Table/table'
 import { IMAGE_CLASSIFICATION_COLORS as COLORS } from '../../../../library/constants/constants'
+import LoadingIndicator from '../../../LoadingIndicator/LoadingIndicator'
 
 const confirmed = colorHelper(COLORS.confirmed)
 const unconfirmed = colorHelper(COLORS.unconfirmed)
@@ -134,4 +135,9 @@ export const ButtonZoom = styled.button`
   & svg {
     opacity: ${({ $isSelected }) => ($isSelected ? 1 : 0)};
   }
+`
+
+export const LoadingIndicatorImageClassificationImage = styled(LoadingIndicator)`
+  width: 100%;
+  height: 100%;
 `

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
@@ -4,7 +4,11 @@ import maplibregl from 'maplibre-gl'
 import { IMAGE_CLASSIFICATION_COLORS as COLORS } from '../../../../library/constants/constants'
 import { imageClassificationResponsePropType } from '../../../../App/mermaidData/mermaidDataProptypes'
 import { IconReset } from '../../../icons'
-import { ImageAnnotationMapWrapper, MapResetButton } from './ImageAnnotationModal.styles'
+import {
+  ImageAnnotationMapWrapper,
+  LoadingIndicatorImageClassificationImage,
+  MapResetButton,
+} from './ImageAnnotationModal.styles'
 import ImageAnnotationPopup from './ImageAnnotationPopup/ImageAnnotationPopup'
 import EditPointPopupWrapper from './ImageAnnotationPopup/EditPointPopupWrapper'
 
@@ -311,6 +315,7 @@ const ImageAnnotationModalMap = ({
 
   return (
     <ImageAnnotationMapWrapper>
+      {!hasMapLoaded ? <LoadingIndicatorImageClassificationImage /> : null}
       <div
         ref={mapContainer}
         style={{
@@ -318,9 +323,12 @@ const ImageAnnotationModalMap = ({
           height: dataToReview.original_image_height * imageScale,
         }}
       />
-      <MapResetButton type="button" onClick={() => easeToDefaultView(map)}>
-        <IconReset />
-      </MapResetButton>
+      {hasMapLoaded ? (
+        <MapResetButton type="button" onClick={() => easeToDefaultView(map)}>
+          <IconReset />
+        </MapResetButton>
+      ) : null}
+
       {selectedPoint.id ? (
         <EditPointPopupWrapper map={map.current} lngLat={selectedPoint.lngLat}>
           <ImageAnnotationPopup


### PR DESCRIPTION
[Trello card](https://trello.com/c/mKivT6DK/1184-add-loading-indicator-to-the-image-in-the-annotation-modal)

Steps to test:
- go to a BPQ record with IC
- in dev tools throttle the internet connection
- click to review the IC image
- note the image-specific loading indicator

<img width="1013" alt="Screenshot 2025-01-10 at 12 41 16 PM" src="https://github.com/user-attachments/assets/504b2b1e-5064-48e1-90ba-1fa46b344dd8" />
