### PR TITLE
Image classification/m1222 zoom icon hover state

### DIFF
--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
@@ -59,7 +59,7 @@ export const ImageAnnotationPopupContainer = styled.div`
   right: 0;
 `
 
-export const TrWithBorderStyling = styled(Tr)`
+export const TrImageClassification = styled(Tr)`
   border: 1px solid transparent;
   border-top: ${({ $isSelected }) => $isSelected && `2px solid ${COLORS.selected}`};
   border-bottom: ${({ $isSelected }) => $isSelected && `2px solid ${COLORS.selected}`};
@@ -69,6 +69,10 @@ export const TrWithBorderStyling = styled(Tr)`
     svg {
       opacity: 1; // this make the zoom icon visible on hover
     }
+  }
+  &:nth-child(odd),
+  &:nth-child(even) {
+    background-color: ${theme.color.white}; // undo default table row striping
   }
 `
 
@@ -125,6 +129,9 @@ export const TdZoom = styled(Td)`
   padding: 0;
   height: 31px;
   width: 48px;
+  &:hover {
+    background-color: ${theme.color.secondaryHover};
+  }
 `
 export const ButtonZoom = styled.button`
   all: unset;

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalTable.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalTable.js
@@ -7,7 +7,7 @@ import {
   TdConfirmed,
   TdUnconfirmed,
   TdZoom,
-  TrWithBorderStyling,
+  TrImageClassification,
 } from './ImageAnnotationModal.styles'
 import { ButtonSecondary } from '../../../generic/buttons'
 import { Tr, Th, Td, TableOverflowWrapper } from '../../../generic/Table/table'
@@ -82,7 +82,7 @@ const ImageAnnotationModalTable = ({
               const unconfirmedCount = tableData[rowKey].length - confirmedCount
 
               return (
-                <TrWithBorderStyling
+                <TrImageClassification
                   key={rowKey}
                   onClick={() => handleRowSelect(rowKey)}
                   onMouseEnter={() => setHoveredAttributeId(rowKey)}
@@ -119,7 +119,7 @@ const ImageAnnotationModalTable = ({
                       </ButtonSecondary>
                     )}
                   </Td>
-                </TrWithBorderStyling>
+                </TrImageClassification>
               )
             })}
         </tbody>


### PR DESCRIPTION
[ticket](https://trello.com/c/OOA1abp2/1222-zoom-icon-hover-state)

Steps to test:
- view the IC review modal
- hover over a row and then zoom button, notice the hover colours are different for each. 
- also notice the row striping on the table has been removed


In image, imagine a cursor over the zoom button, causing it to be darker
<img width="1184" alt="Screenshot 2025-01-10 at 1 00 51 PM" src="https://github.com/user-attachments/assets/663b0188-d9b0-42d2-8086-e54d041e20b2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Based on the comprehensive summary of changes, here are the release notes:

- **New Features**
  - Added image classification functionality for benthic photo quadrat records
  - Introduced image upload and annotation capabilities
  - Implemented sample unit input selector for image classification

- **Improvements**
  - Enhanced modal components with more flexible configuration
  - Added new icons and styling for image classification interfaces
  - Improved table and thumbnail rendering for submitted records

- **Bug Fixes**
  - Updated validation logic for observations
  - Refined image scaling and point annotation processes

- **Chores**
  - Added new dependencies for geospatial operations
  - Updated language localization for new features
  - Expanded test utilities and mock data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->