### PR TITLE
M1156 ensure image classification image popup doesnt overflow outside of image

### DIFF
--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/EditPointPopupWrapper.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/EditPointPopupWrapper.js
@@ -4,12 +4,12 @@ import PropTypes from 'prop-types'
 
 // This component allows our popup to work with React State
 // Solution based off here: https://sparkgeo.com/blog/create-a-working-react-mapbox-popup/
-const EditPointPopupWrapper = ({ children, map, lngLat }) => {
+const EditPointPopupWrapper = ({ children, map, lngLat, anchor }) => {
   const popupRef = useRef()
 
   useEffect(() => {
     new maplibregl.Popup({
-      anchor: 'top-left',
+      anchor,
       closeButton: false,
       maxWidth: 'none',
       className: 'edit-point-popup',
@@ -17,7 +17,7 @@ const EditPointPopupWrapper = ({ children, map, lngLat }) => {
       .setLngLat(lngLat)
       .setDOMContent(popupRef.current)
       .addTo(map)
-  }, [children, lngLat, map])
+  }, [anchor, children, lngLat, map])
 
   return (
     <div style={{ display: 'none' }}>
@@ -30,6 +30,7 @@ EditPointPopupWrapper.propTypes = {
   children: PropTypes.node.isRequired,
   map: PropTypes.object.isRequired,
   lngLat: PropTypes.arrayOf(PropTypes.number).isRequired,
+  anchor: PropTypes.oneOf(['top-left', 'top-right', 'bottom-left', 'bottom-right']),
 }
 
 export default EditPointPopupWrapper

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/usePointsGeoJson.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/usePointsGeoJson.js
@@ -23,6 +23,9 @@ export const usePointsGeoJson = ({ dataToReview, map, imageScale }) => {
         (point.column + halfPatchSize) * imageScale,
         (point.row - halfPatchSize) * imageScale,
       ])
+      const isPointInLeftHalfOfImage = point.column < dataToReview.original_image_width / 2
+      const isPointInTopHalfOfImage = point.row < dataToReview.original_image_height / 2
+
       return {
         type: 'Feature',
         properties: {
@@ -31,6 +34,8 @@ export const usePointsGeoJson = ({ dataToReview, map, imageScale }) => {
           ba_gr_label: point.annotations[0]?.ba_gr_label,
           isUnclassified: !point.annotations.length,
           isConfirmed: !!point.annotations[0]?.is_confirmed,
+          isPointInLeftHalfOfImage,
+          isPointInTopHalfOfImage,
         },
         geometry: {
           type: 'Polygon',


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/ivZFAs8Z/1156-point-pop-over-is-sometimes-cut-off-by-the-modal)

Steps to test:
- load up BPQ image review
- click on points in image making sure to zoom in and click on a sample of points on the top, right, left, and bottom. 
- notice that the popup no longer overflows outside of the image