### PR TITLE
M1122 redo hover state for IC with clarified requirements

### DIFF
--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
@@ -60,13 +60,24 @@ export const ImageAnnotationPopupContainer = styled.div`
   right: 0;
 `
 
+export const TdZoom = styled(Td)`
+  padding: 0;
+  height: 31px;
+  width: 48px;
+  background-color: ${theme.color.white}; // stop the row hover colour from showing
+  &:hover {
+    background-color: ${theme.color.tableRowHover};
+  }
+`
+
 export const TrImageClassification = styled(Tr)`
   border: 1px solid transparent;
   border-top: ${({ $isSelected }) => $isSelected && `2px solid ${COLORS.selected}`};
   border-bottom: ${({ $isSelected }) => $isSelected && `2px solid ${COLORS.selected}`};
   cursor: pointer;
   &:hover {
-    outline: ${({ $isSelected }) => !$isSelected && `2px solid ${COLORS.hover}`};
+    border-top: ${({ $isSelected }) => !$isSelected && `2px solid ${COLORS.hover}`};
+    border-bottom: ${({ $isSelected }) => !$isSelected && `2px solid ${COLORS.hover}`};
     svg {
       opacity: 1; // this make the zoom icon visible on hover
     }
@@ -74,6 +85,9 @@ export const TrImageClassification = styled(Tr)`
   &:nth-child(odd),
   &:nth-child(even) {
     background-color: ${theme.color.white}; // undo default table row striping
+  }
+  &:has(${TdZoom}:hover) {
+    background-color: ${theme.color.white};
   }
 `
 
@@ -126,14 +140,6 @@ export const MapResetButton = styled.button`
   box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1); // copy maplibre button shadow
 `
 
-export const TdZoom = styled(Td)`
-  padding: 0;
-  height: 31px;
-  width: 48px;
-  &:hover {
-    background-color: ${theme.color.secondaryHover};
-  }
-`
 export const ButtonZoom = styled.button`
   all: unset;
   height: 100%;


### PR DESCRIPTION
[Trello ticket ](https://trello.com/c/OOA1abp2/1222-zoom-icon-hover-state)(see comment with clarified requirements)

Steps to test:
- open image classification review
- hover over a row note that either the zoom cell has a hovor colour or the rest of the row. Not both at the same time. 
- select a row and note similar hover colours between the zoom cell and the rest of the row

![Screen Recording 2025-01-10 at 3 54 29 PM](https://github.com/user-attachments/assets/817eeacb-6336-4788-aa4a-365f08d8578f)