### PR TITLE
M1220 remove auto IC confirmation when selecting attributes. Implement explicit confirm button.

### DIFF
--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
@@ -4,6 +4,8 @@ import theme from '../../../../theme'
 import { Table, Tr, Td } from '../../../generic/Table/table'
 import { IMAGE_CLASSIFICATION_COLORS as COLORS } from '../../../../library/constants/constants'
 import LoadingIndicator from '../../../LoadingIndicator/LoadingIndicator'
+import { RowSpaceBetween } from '../../../generic/positioning'
+import { ButtonPrimary } from '../../../generic/buttons'
 
 const confirmed = colorHelper(COLORS.confirmed)
 const unconfirmed = colorHelper(COLORS.unconfirmed)
@@ -153,4 +155,11 @@ export const ButtonZoom = styled.button`
 export const LoadingIndicatorImageClassificationImage = styled(LoadingIndicator)`
   width: 100%;
   height: 100%;
+`
+export const PopupBottomRow = styled(RowSpaceBetween)`
+  padding: 1rem;
+`
+
+export const PopupConfirmButton = styled(ButtonPrimary)`
+  width: 100%;
 `

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalTable.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalTable.js
@@ -27,7 +27,7 @@ const ImageAnnotationModalTable = ({
   const tableData = Object.groupBy(classifiedPoints, ({ annotations }) => annotations[0].ba_gr)
 
   const sortAlphabeticallyByAttributeLabel = (a, b) =>
-    tableData[a][0].annotations[0].ba_gr_label.localeCompare(
+    tableData[a][0].annotations[0].ba_gr_label?.localeCompare(
       tableData[b][0].annotations[0].ba_gr_label,
     )
 

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ClassifierGuesses.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ClassifierGuesses.js
@@ -13,10 +13,6 @@ const moveAnnotationToFront = (array, index) => {
   return [movedAnnotation, ...newArray]
 }
 
-const confirmFirstAnnotationAndUnconfirmRest = (annotation, i) => {
-  annotation.is_confirmed = i === 0
-}
-
 const ClassifierGuesses = ({
   selectedPoint,
   dataToReview,
@@ -36,9 +32,15 @@ const ClassifierGuesses = ({
       classifierGuessesSortedByScore,
       classifierGuessIndex,
     )
-    updatedAnnotations.forEach(confirmFirstAnnotationAndUnconfirmRest)
+
+    const updatedAnnotationsWithResetConfirmation = updatedAnnotations.map((annotation) => ({
+      ...annotation,
+      is_confirmed: false,
+    }))
     const updatedPoints = dataToReview.points.map((point) =>
-      point.id === selectedPoint.id ? { ...point, annotations: updatedAnnotations } : point,
+      point.id === selectedPoint.id
+        ? { ...point, annotations: updatedAnnotationsWithResetConfirmation }
+        : point,
     )
     setDataToReview({ ...dataToReview, points: updatedPoints })
     setIsDataUpdatedSinceLastSave(true)

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/EditPointPopupWrapper.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/EditPointPopupWrapper.js
@@ -1,12 +1,10 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect } from 'react'
 import maplibregl from 'maplibre-gl'
 import PropTypes from 'prop-types'
 
 // This component allows our popup to work with React State
 // Solution based off here: https://sparkgeo.com/blog/create-a-working-react-mapbox-popup/
-const EditPointPopupWrapper = ({ children, map, lngLat, anchor }) => {
-  const popupRef = useRef()
-
+const EditPointPopupWrapper = ({ children, map, lngLat, anchor, popupRef }) => {
   useEffect(() => {
     new maplibregl.Popup({
       anchor,
@@ -17,7 +15,7 @@ const EditPointPopupWrapper = ({ children, map, lngLat, anchor }) => {
       .setLngLat(lngLat)
       .setDOMContent(popupRef.current)
       .addTo(map)
-  }, [anchor, children, lngLat, map])
+  }, [anchor, children, lngLat, map, popupRef])
 
   return (
     <div style={{ display: 'none' }}>
@@ -31,6 +29,7 @@ EditPointPopupWrapper.propTypes = {
   map: PropTypes.object.isRequired,
   lngLat: PropTypes.arrayOf(PropTypes.number).isRequired,
   anchor: PropTypes.oneOf(['top-left', 'top-right', 'bottom-left', 'bottom-right']),
+  popupRef: PropTypes.object.isRequired,
 }
 
 export default EditPointPopupWrapper

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
@@ -1,11 +1,15 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { Tr, Th } from '../../../../generic/Table/table'
 import { imageClassificationResponsePropType } from '../../../../../App/mermaidData/mermaidDataProptypes'
 import { databaseSwitchboardPropTypes } from '../../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboard'
 import SelectAttributeFromClassifierGuesses from './SelectAttributeFromClassifierGuesses'
 import ClassifierGuesses from './ClassifierGuesses'
-import { EditPointPopupTable } from '../ImageAnnotationModal.styles'
+import {
+  EditPointPopupTable,
+  PopupBottomRow,
+  PopupConfirmButton,
+} from '../ImageAnnotationModal.styles'
 import './ImageAnnotationPopup.css'
 
 const ImageAnnotationPopup = ({
@@ -14,33 +18,71 @@ const ImageAnnotationPopup = ({
   pointId,
   databaseSwitchboardInstance,
   setIsDataUpdatedSinceLastSave,
+  closePopup,
 }) => {
   const selectedPoint = dataToReview.points.find((point) => point.id === pointId)
+  const isSelectedPointConfirmed = selectedPoint.annotations[0]?.is_confirmed
+  const isSelectedPointUnclassified = selectedPoint.annotations.length === 0
+
+  const confirmPoint = useCallback(
+    (pointId) => {
+      const updatedPoints = dataToReview.points.map((point) => {
+        if (point.id !== pointId) {
+          return point
+        }
+
+        const updatedAnnotations = point.annotations.map((annotation, index) => {
+          return { ...annotation, is_confirmed: index === 0 } // we want only one annotation at a time to be confirmed.
+        })
+
+        return {
+          ...point,
+          annotations: updatedAnnotations,
+        }
+      })
+
+      setDataToReview((previousState) => ({ ...previousState, points: updatedPoints }))
+      setIsDataUpdatedSinceLastSave(true)
+      closePopup()
+    },
+    [closePopup, dataToReview.points, setDataToReview, setIsDataUpdatedSinceLastSave],
+  )
 
   return (
-    <EditPointPopupTable aria-labelledby="table-label">
-      <thead>
-        <Tr>
-          <Th colSpan={2}>Classifier Guesses</Th>
-          <Th align="right">Confidence</Th>
-        </Tr>
-      </thead>
-      <tbody>
-        <ClassifierGuesses
-          selectedPoint={selectedPoint}
-          dataToReview={dataToReview}
-          setDataToReview={setDataToReview}
-          setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
-        />
-        <SelectAttributeFromClassifierGuesses
-          selectedPoint={selectedPoint}
-          dataToReview={dataToReview}
-          setDataToReview={setDataToReview}
-          setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
-          databaseSwitchboardInstance={databaseSwitchboardInstance}
-        />
-      </tbody>
-    </EditPointPopupTable>
+    <>
+      <EditPointPopupTable aria-labelledby="table-label">
+        <thead>
+          <Tr>
+            <Th colSpan={2}>Classifier Guesses</Th>
+            <Th align="right">Confidence</Th>
+          </Tr>
+        </thead>
+        <tbody>
+          <ClassifierGuesses
+            selectedPoint={selectedPoint}
+            dataToReview={dataToReview}
+            setDataToReview={setDataToReview}
+            setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
+          />
+          <SelectAttributeFromClassifierGuesses
+            selectedPoint={selectedPoint}
+            dataToReview={dataToReview}
+            setDataToReview={setDataToReview}
+            setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
+            databaseSwitchboardInstance={databaseSwitchboardInstance}
+          />
+        </tbody>
+      </EditPointPopupTable>
+      <PopupBottomRow>
+        <PopupConfirmButton
+          type="button"
+          onClick={() => confirmPoint(selectedPoint.id)}
+          disabled={isSelectedPointConfirmed || isSelectedPointUnclassified}
+        >
+          Confirm
+        </PopupConfirmButton>
+      </PopupBottomRow>
+    </>
   )
 }
 
@@ -50,6 +92,7 @@ ImageAnnotationPopup.propTypes = {
   pointId: PropTypes.string.isRequired,
   databaseSwitchboardInstance: databaseSwitchboardPropTypes,
   setIsDataUpdatedSinceLastSave: PropTypes.func.isRequired,
+  closePopup: PropTypes.func.isRequired,
 }
 
 export default ImageAnnotationPopup

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/SelectAttributeFromClassifierGuesses.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/SelectAttributeFromClassifierGuesses.js
@@ -36,11 +36,15 @@ const SelectAttributeFromClassifierGuesses = ({
   setIsDataUpdatedSinceLastSave,
   databaseSwitchboardInstance,
 }) => {
-  const rowKeyForPoint = selectedPoint.annotations[0].ba_gr
+  const rowKeyForPoint = selectedPoint.annotations[0]?.ba_gr
 
   const existingRowDropdownOptions = dataToReview.points
     .reduce((acc, currentPoint) => {
-      const { ba_gr, ba_gr_label } = currentPoint.annotations[0]
+      const annotations = currentPoint.annotations[0]
+      if (!annotations) {
+        return acc
+      }
+      const { ba_gr, ba_gr_label } = annotations
 
       if (
         isClassified(currentPoint) &&
@@ -108,7 +112,7 @@ const SelectAttributeFromClassifierGuesses = ({
       ba_gr_label: labelForExistingAnnotation,
       benthic_attribute,
       growth_form: growth_form === 'null' ? null : growth_form,
-      is_confirmed: true,
+      is_confirmed: false,
       is_machine_created: false,
     }
 
@@ -134,7 +138,7 @@ const SelectAttributeFromClassifierGuesses = ({
             name="existing-row-point-selection"
             value="existing-row"
             disabled={!selectedExistingRow}
-            checked={selectedPoint.annotations[0].ba_gr === selectedExistingRow}
+            checked={selectedPoint.annotations[0]?.ba_gr === selectedExistingRow}
             onChange={() => addExistingAnnotation(selectedExistingRow)}
           />
         </PopupTdForRadio>


### PR DESCRIPTION
[Ticket](https://trello.com/c/WzRjXZht/1220-image-classification-point-popover-confirm-button)

Description of change:
- remove classification being autoconfirmed when user selects new classifications via any method (guesses radios, dropdown, or making a new attribute)
- ensure clicking on an unclasified point doesnt crash app (by adding optional chaining mostly)
- implement confirm button
- disable confirm button if point classification is confirmed (unless the user changes the confirmed classification to something else)
- when clicking confirm, the popover closes and the points classification is confirmed

Steps to test:
- To ensure 'unclassified' points are returned, set your API to have `CLASSIFIED_THRESHOLD = 0.5` in `src/app/settings.py` and run `make install` then start your API and image worker as usual. 
- open BPQ record,
- review image classification
- click on a unclassified point. The confirm button should be disabled until a classification is selected.
- click unconfirmed point to open popup. Button should be enabled. 
- click confirm => popover closes, point should not have confirmed colouring
- click same point again => confirm button should be disabled
- For confirmed points, using each of the three methods (guess radios, drop down, select new attribute), change the value of the classification => the confirm button should be enabled after the value change of each method

<img width="386" alt="Screenshot 2025-01-16 at 10 53 44 AM" src="https://github.com/user-attachments/assets/dd7ecacf-d11d-4989-9d1e-b211115edca9" />
