### PR TITLE
Image classification/m12237 omit popover table for unclassified

### DIFF
--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
@@ -50,29 +50,31 @@ const ImageAnnotationPopup = ({
 
   return (
     <>
-      <EditPointPopupTable aria-labelledby="table-label">
-        <thead>
-          <Tr>
-            <Th colSpan={2}>Classifier Guesses</Th>
-            <Th align="right">Confidence</Th>
-          </Tr>
-        </thead>
-        <tbody>
-          <ClassifierGuesses
-            selectedPoint={selectedPoint}
-            dataToReview={dataToReview}
-            setDataToReview={setDataToReview}
-            setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
-          />
-          <SelectAttributeFromClassifierGuesses
-            selectedPoint={selectedPoint}
-            dataToReview={dataToReview}
-            setDataToReview={setDataToReview}
-            setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
-            databaseSwitchboardInstance={databaseSwitchboardInstance}
-          />
-        </tbody>
-      </EditPointPopupTable>
+      {isSelectedPointUnclassified ? null : (
+        <EditPointPopupTable aria-labelledby="table-label">
+          <thead>
+            <Tr>
+              <Th colSpan={2}>Classifier Guesses</Th>
+              <Th align="right">Confidence</Th>
+            </Tr>
+          </thead>
+          <tbody>
+            <ClassifierGuesses
+              selectedPoint={selectedPoint}
+              dataToReview={dataToReview}
+              setDataToReview={setDataToReview}
+              setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
+            />
+          </tbody>
+        </EditPointPopupTable>
+      )}
+      <SelectAttributeFromClassifierGuesses
+        selectedPoint={selectedPoint}
+        dataToReview={dataToReview}
+        setDataToReview={setDataToReview}
+        setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
+        databaseSwitchboardInstance={databaseSwitchboardInstance}
+      />
       <PopupBottomRow>
         <PopupConfirmButton
           type="button"


### PR DESCRIPTION
[Ticket](https://trello.com/c/8Pc0p1ib/1237-omit-popover-guesses-table-if-unclassified-point-is-clicked)

Hide IC guess table if point is unclassified

Steps to test:
- open BPQ record IC review
- click on unclassified point => guess table should be absent
- click on classified (confirmed or unconfirmed) point => guess table should be visible.