### PR TITLE
M12235 IC reset zoom button and zoom-to-point button

### DIFF
--- a/src/components/generic/Table/table.js
+++ b/src/components/generic/Table/table.js
@@ -79,23 +79,23 @@ const getHeaderSortAfter = (
     }
   `
 }
+export const thStyles = (props) => css`
+  text-align: ${props.align || 'left'};
+  padding: ${theme.spacing.medium};
+  background: ${theme.color.white};
+  vertical-align: top;
+  &::after {
+    content: ${props.isSortingEnabled ? ' \u25b2' : ''};
+    font-size: small;
+    white-space: nowrap;
+  }
+  > span {
+    ${getHeaderSortAfter(props.isMultiSortColumn, props.sortedIndex, props.isSortedDescending)}
+  }
+  font-weight: 700;
+`
 
-export const Th = styled.th(
-  (props) => css`
-    text-align: ${props.align || 'left'};
-    padding: ${theme.spacing.medium};
-    background: ${theme.color.white};
-    vertical-align: top;
-    &::after {
-      content: ${props.isSortingEnabled ? ' \u25b2' : ''};
-      font-size: small;
-      white-space: nowrap;
-    }
-    > span {
-      ${getHeaderSortAfter(props.isMultiSortColumn, props.sortedIndex, props.isSortedDescending)}
-    }
-  `,
-)
+export const Th = styled.th((props) => thStyles(props))
 
 export const Td = styled.td(
   (props) => css`

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -58,6 +58,7 @@ import upload from '@iconify-icons/mdi/upload'
 import user from '@iconify-icons/mdi/user'
 import usersAndTransects from '@iconify-icons/mdi/account-box-multiple-outline'
 import zoomIn from '@iconify-icons/mdi/zoom-in'
+import zoomOut from '@iconify-icons/mdi/zoom-out'
 
 const WarningIcon = styled(InlineIcon)`
   color: ${theme.color.warningColor};
@@ -126,3 +127,4 @@ export const IconUser = (props) => <InlineIcon icon={user} {...props} />
 export const IconUsers = (props) => <InlineIcon icon={accountGroup} {...props} />
 export const IconUsersAndTransects = (props) => <InlineIcon icon={usersAndTransects} {...props} />
 export const IconZoomIn = (props) => <InlineIcon icon={zoomIn} {...props} />
+export const IconZoomOut = (props) => <InlineIcon icon={zoomOut} {...props} />

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
@@ -1,11 +1,11 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import colorHelper from 'color'
 import theme from '../../../../theme'
-import { Table, Tr, Td } from '../../../generic/Table/table'
+import { Table, Tr, Td, thStyles } from '../../../generic/Table/table'
 import { IMAGE_CLASSIFICATION_COLORS as COLORS } from '../../../../library/constants/constants'
 import LoadingIndicator from '../../../LoadingIndicator/LoadingIndicator'
 import { RowSpaceBetween } from '../../../generic/positioning'
-import { ButtonPrimary } from '../../../generic/buttons'
+import { ButtonPrimary, IconButton } from '../../../generic/buttons'
 
 const confirmed = colorHelper(COLORS.confirmed)
 const unconfirmed = colorHelper(COLORS.unconfirmed)
@@ -157,9 +157,33 @@ export const LoadingIndicatorImageClassificationImage = styled(LoadingIndicator)
   height: 100%;
 `
 export const PopupBottomRow = styled(RowSpaceBetween)`
+  align-items: stretch;
   padding: 1rem;
 `
 
 export const PopupConfirmButton = styled(ButtonPrimary)`
   width: 100%;
+`
+export const PopupIconButton = styled(IconButton)`
+  border: solid thin ${theme.color.border};
+  margin: 0;
+  padding: ${theme.spacing.buttonPadding};
+
+  &:nth-child(2) {
+    border-left: none;
+  }
+`
+export const PopupZoomButtonContainer = styled.div`
+  display: flex;
+`
+export const LabelThatLooksLikeATh = styled.div(
+  (props) => css`
+    ${thStyles(props)}
+  `,
+)
+export const RowThatLooksLikeAnEvenTr = styled.div`
+  display: flex;
+  padding: 10px;
+  gap: 20px;
+  background-color: ${theme.color.tableRowEven};
 `

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
@@ -9,8 +9,11 @@ import {
   EditPointPopupTable,
   PopupBottomRow,
   PopupConfirmButton,
+  PopupIconButton,
+  PopupZoomButtonContainer,
 } from '../ImageAnnotationModal.styles'
 import './ImageAnnotationPopup.css'
+import { IconZoomIn, IconZoomOut } from '../../../../icons'
 
 const ImageAnnotationPopup = ({
   dataToReview,
@@ -19,6 +22,8 @@ const ImageAnnotationPopup = ({
   databaseSwitchboardInstance,
   setIsDataUpdatedSinceLastSave,
   closePopup,
+  resetZoom,
+  zoomToSelectedPoint,
 }) => {
   const selectedPoint = dataToReview.points.find((point) => point.id === pointId)
   const isSelectedPointConfirmed = selectedPoint.annotations[0]?.is_confirmed
@@ -76,12 +81,21 @@ const ImageAnnotationPopup = ({
         databaseSwitchboardInstance={databaseSwitchboardInstance}
       />
       <PopupBottomRow>
+        <PopupZoomButtonContainer>
+          <PopupIconButton type="button" onClick={resetZoom}>
+            <IconZoomOut />
+          </PopupIconButton>
+          <PopupIconButton type="button" onClick={zoomToSelectedPoint}>
+            <IconZoomIn />
+          </PopupIconButton>
+        </PopupZoomButtonContainer>
+
         <PopupConfirmButton
           type="button"
           onClick={() => confirmPoint(selectedPoint.id)}
           disabled={isSelectedPointConfirmed || isSelectedPointUnclassified}
         >
-          Confirm
+          {isSelectedPointConfirmed ? 'Confirmed' : 'Confirm'}
         </PopupConfirmButton>
       </PopupBottomRow>
     </>
@@ -95,6 +109,8 @@ ImageAnnotationPopup.propTypes = {
   databaseSwitchboardInstance: databaseSwitchboardPropTypes,
   setIsDataUpdatedSinceLastSave: PropTypes.func.isRequired,
   closePopup: PropTypes.func.isRequired,
+  resetZoom: PropTypes.func.isRequired,
+  zoomToSelectedPoint: PropTypes.func.isRequired,
 }
 
 export default ImageAnnotationPopup

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/SelectAttributeFromClassifierGuesses.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/SelectAttributeFromClassifierGuesses.js
@@ -10,13 +10,13 @@ import { createPortal } from 'react-dom'
 import { databaseSwitchboardPropTypes } from '../../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboard'
 import { IconPlus } from '../../../../icons'
 import {
+  LabelThatLooksLikeATh,
   NewAttributeModalContentContainer,
   NewAttributeModalFooterContainer,
   NewAttributeModalLabel,
+  RowThatLooksLikeAnEvenTr,
 } from '../ImageAnnotationModal.styles'
-import { PopupTd, PopupTdForRadio } from '../ImageAnnotationModal.styles'
 import { Select } from '../../../../generic/form'
-import { Th, Tr } from '../../../../generic/Table/table'
 import { useSelectNewAttribute } from '../../useSelectNewAttribute'
 import InputAutocomplete from '../../../../generic/InputAutocomplete'
 import language from '../../../../../language'
@@ -127,40 +127,35 @@ const SelectAttributeFromClassifierGuesses = ({
 
   return (
     <>
-      <Tr>
-        <Th colSpan={4}>Attribute growth form</Th>
-      </Tr>
-      <Tr>
-        <PopupTdForRadio>
-          <input
-            type="radio"
-            id="existing-row-point-selection"
-            name="existing-row-point-selection"
-            value="existing-row"
-            disabled={!selectedExistingRow}
-            checked={selectedPoint.annotations[0]?.ba_gr === selectedExistingRow}
-            onChange={() => addExistingAnnotation(selectedExistingRow)}
-          />
-        </PopupTdForRadio>
-        <PopupTd colSpan={3}>
-          <Select
-            label="Add to existing row"
-            value={selectedExistingRow}
-            onChange={handleSelectOnChange}
-          >
-            <option value="" disabled>
-              Choose...
+      <LabelThatLooksLikeATh>Attribute growth form</LabelThatLooksLikeATh>
+      <RowThatLooksLikeAnEvenTr>
+        <input
+          type="radio"
+          id="existing-row-point-selection"
+          name="existing-row-point-selection"
+          value="existing-row"
+          disabled={!selectedExistingRow}
+          checked={selectedPoint.annotations[0]?.ba_gr === selectedExistingRow}
+          onChange={() => addExistingAnnotation(selectedExistingRow)}
+        />
+
+        <Select
+          label="Add to existing row"
+          value={selectedExistingRow}
+          onChange={handleSelectOnChange}
+        >
+          <option value="" disabled>
+            Choose...
+          </option>
+          {existingRowDropdownOptions?.map((row) => (
+            <option key={row.value} value={row.value}>
+              {row.label}
             </option>
-            {existingRowDropdownOptions?.map((row) => (
-              <option key={row.value} value={row.value}>
-                {row.label}
-              </option>
-            ))}
-            <option disabled>──────────</option>
-            <option value="selectNewAttribute">Select new attribute...</option>
-          </Select>
-        </PopupTd>
-      </Tr>
+          ))}
+          <option disabled>──────────</option>
+          <option value="selectNewAttribute">Select new attribute...</option>
+        </Select>
+      </RowThatLooksLikeAnEvenTr>
       {createPortal(
         <Modal
           title="Select New Attribute"

--- a/src/components/pages/ImageClassification/useSelectNewAttribute.js
+++ b/src/components/pages/ImageClassification/useSelectNewAttribute.js
@@ -75,7 +75,7 @@ export const useSelectNewAttribute = ({
   }
 
   const addNewAnnotation = () => {
-    const classifierGuessesWithConfrimationReset = selectedPoint.annotations
+    const classifierGuessesWithConfirmationReset = selectedPoint.annotations
       .filter((annotation) => annotation.is_machine_created)
       .map((annotation) => ({ ...annotation, is_confirmed: false }))
 
@@ -97,7 +97,7 @@ export const useSelectNewAttribute = ({
       is_machine_created: false,
     }
 
-    const updatedAnnotations = [annotationToAdd, ...classifierGuessesWithConfrimationReset]
+    const updatedAnnotations = [annotationToAdd, ...classifierGuessesWithConfirmationReset]
 
     const updatedPoints = dataToReview.points.map((point) =>
       point.id === selectedPoint.id ? { ...point, annotations: updatedAnnotations } : point,


### PR DESCRIPTION
[Ticket](https://trello.com/c/qm74tcRG/1225-image-classification-add-zoom-in-and-out-buttons-to-point-popover)
Description:
- added zoom in and out buttons
- removed semantic error in that table elements must be within a table (I had moved the select out of of the table since only the guesses can pass as appropriate to be placed in a table



Steps to test:
- open a BPQ record with image classification
- click the IC review button
- click a point in the image
- click the zoom out button => it should zoom out to the initial extent (same as reset button)
- click the zoom in button => it should zoom to the point similar to when a user clicks the point

<img width="274" alt="Screenshot 2025-01-16 at 6 24 25 PM" src="https://github.com/user-attachments/assets/a0d43881-3d1f-4d91-b43f-299c6c2ef61c" />
