### PR TITLE
M1226 IC next unconfirmed button

### DIFF
--- a/src/components/TransferSampleUnitsModal/TransferSampleUnitsModal.js
+++ b/src/components/TransferSampleUnitsModal/TransferSampleUnitsModal.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 
 import { ButtonPrimary, ButtonSecondary } from '../generic/buttons'
 import language from '../../language'
-import { IconArrowRight } from '../icons'
+import { IconArrowRightCircle } from '../icons'
 import { Select } from '../generic/form'
 import { Column } from '../generic/positioning'
 import InlineMessage from '../generic/InlineMessage'
@@ -98,7 +98,7 @@ const TransferSampleUnitsModal = ({
               <strong>{getProfileNameOrEmailForPendingUser(fromUser)}</strong>
             </p>
           </ModalBoxItem>
-          <IconArrowRight />
+          <IconArrowRightCircle />
           <ModalBoxItem>
             <label id="modal-transfer-units-to-label" htmlFor="modal-transfer-units-to">
               Transfer sample units to:

--- a/src/components/generic/tooltip.js
+++ b/src/components/generic/tooltip.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components/macro'
 import theme from '../../theme'
 
-export const Tooltip = styled('p')`
+export const TooltipP = styled('p')`
   white-space: nowrap;
   border-style: dotted;
   border-width: 0 0 ${theme.spacing.borderMedium} 0;
@@ -40,21 +40,51 @@ export const TooltipPopup = styled('span')`
   top: 4rem;
   white-space: normal;
   z-index: 100;
+  text-align: center;
+`
+
+const TooltipWrapper = styled('div')`
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  cursor: pointer;
+  &:hover span,
+  &:focus span {
+    transition: ${theme.timing.hoverTransition};
+    display: block;
+  }
 `
 
 export const TooltipWithText = ({ text, tooltipText, id, ...restOfProps }) => {
   return (
-    <Tooltip tabIndex="0" id={id} {...restOfProps}>
+    <TooltipP tabIndex="0" id={id} {...restOfProps}>
       {text}
       <TooltipPopup role="tooltip" aria-labelledby={id}>
         {tooltipText}
       </TooltipPopup>
-    </Tooltip>
+    </TooltipP>
   )
 }
 
 TooltipWithText.propTypes = {
   text: PropTypes.node.isRequired,
+  tooltipText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  id: PropTypes.string.isRequired,
+}
+
+export const Tooltip = ({ children, tooltipText, id }) => {
+  return (
+    <TooltipWrapper>
+      {children}
+      <TooltipPopup role="tooltip" aria-labelledby={id}>
+        {tooltipText}
+      </TooltipPopup>
+    </TooltipWrapper>
+  )
+}
+
+Tooltip.propTypes = {
+  children: PropTypes.node.isRequired,
   tooltipText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   id: PropTypes.string.isRequired,
 }

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -5,7 +5,8 @@ import accountGroup from '@iconify-icons/mdi/account-group'
 import accountRemove from '@iconify-icons/mdi/account-remove'
 import alert from '@iconify-icons/mdi/alert'
 import arrowBack from '@iconify-icons/mdi/arrow-back'
-import arrowRight from '@iconify-icons/mdi/arrow-right-bold-circle'
+import arrowRight from '@iconify-icons/mdi/arrow-right-bold'
+import arrowRightCircle from '@iconify-icons/mdi/arrow-right-bold-circle'
 import asterisk from '@iconify-icons/mdi/asterisk'
 import bellIcon from '@iconify-icons/mdi/bell'
 import book from '@iconify-icons/mdi/book'
@@ -75,6 +76,7 @@ export const IconAdmin = (props) => <InlineIcon icon={fileAccountOutline} {...pr
 export const IconAlert = (props) => <WarningIcon icon={alert} {...props} />
 export const IconArrowBack = (props) => <InlineIcon icon={arrowBack} {...props} />
 export const IconArrowRight = (props) => <InlineIcon icon={arrowRight} {...props} />
+export const IconArrowRightCircle = (props) => <InlineIcon icon={arrowRightCircle} {...props} />
 export const IconBell = (props) => <InlineIcon icon={bellIcon} {...props} />
 export const IconBook = (props) => <InlineIcon icon={book} {...props} />
 export const IconCheck = (props) => <InlineIcon icon={checkIcon} {...props} />

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
@@ -13,7 +13,8 @@ import {
   PopupZoomButtonContainer,
 } from '../ImageAnnotationModal.styles'
 import './ImageAnnotationPopup.css'
-import { IconZoomIn, IconZoomOut } from '../../../../icons'
+import { IconArrowRight, IconZoomIn, IconZoomOut } from '../../../../icons'
+import { Tooltip } from '../../../../generic/tooltip'
 
 const ImageAnnotationPopup = ({
   dataToReview,
@@ -21,13 +22,20 @@ const ImageAnnotationPopup = ({
   pointId,
   databaseSwitchboardInstance,
   setIsDataUpdatedSinceLastSave,
-  closePopup,
   resetZoom,
   zoomToSelectedPoint,
+  selectNextUnconfirmedPoint,
 }) => {
   const selectedPoint = dataToReview.points.find((point) => point.id === pointId)
   const isSelectedPointConfirmed = selectedPoint.annotations[0]?.is_confirmed
+  const areAnyClassifierGuesses = !!selectedPoint.annotations.filter(
+    (annotation) => annotation.is_machine_created,
+  ).length
+
   const isSelectedPointUnclassified = selectedPoint.annotations.length === 0
+  const areAllPointsConfirmed = dataToReview.points.every(
+    (point) => point.annotations[0]?.is_confirmed,
+  )
 
   const confirmPoint = useCallback(
     (pointId) => {
@@ -48,14 +56,13 @@ const ImageAnnotationPopup = ({
 
       setDataToReview((previousState) => ({ ...previousState, points: updatedPoints }))
       setIsDataUpdatedSinceLastSave(true)
-      closePopup()
     },
-    [closePopup, dataToReview.points, setDataToReview, setIsDataUpdatedSinceLastSave],
+    [dataToReview.points, setDataToReview, setIsDataUpdatedSinceLastSave],
   )
 
   return (
     <>
-      {isSelectedPointUnclassified ? null : (
+      {areAnyClassifierGuesses ? (
         <EditPointPopupTable aria-labelledby="table-label">
           <thead>
             <Tr>
@@ -72,7 +79,7 @@ const ImageAnnotationPopup = ({
             />
           </tbody>
         </EditPointPopupTable>
-      )}
+      ) : null}
       <SelectAttributeFromClassifierGuesses
         selectedPoint={selectedPoint}
         dataToReview={dataToReview}
@@ -97,6 +104,17 @@ const ImageAnnotationPopup = ({
         >
           {isSelectedPointConfirmed ? 'Confirmed' : 'Confirm'}
         </PopupConfirmButton>
+        <PopupZoomButtonContainer>
+          <Tooltip tooltipText="Next Unconfirmed Point">
+            <PopupIconButton
+              type="button"
+              onClick={selectNextUnconfirmedPoint}
+              disabled={areAllPointsConfirmed}
+            >
+              <IconArrowRight />
+            </PopupIconButton>
+          </Tooltip>
+        </PopupZoomButtonContainer>
       </PopupBottomRow>
     </>
   )
@@ -108,9 +126,9 @@ ImageAnnotationPopup.propTypes = {
   pointId: PropTypes.string.isRequired,
   databaseSwitchboardInstance: databaseSwitchboardPropTypes,
   setIsDataUpdatedSinceLastSave: PropTypes.func.isRequired,
-  closePopup: PropTypes.func.isRequired,
   resetZoom: PropTypes.func.isRequired,
   zoomToSelectedPoint: PropTypes.func.isRequired,
+  selectNextUnconfirmedPoint: PropTypes.func.isRequired,
 }
 
 export default ImageAnnotationPopup

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/usePointsGeoJson.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/usePointsGeoJson.js
@@ -1,57 +1,69 @@
+import { useCallback } from 'react'
+
 export const usePointsGeoJson = ({ dataToReview, map, imageScale }) => {
   const halfPatchSize = dataToReview ? dataToReview.patch_size / 2 : undefined
 
-  const getPointsGeojson = () => ({
-    type: 'FeatureCollection',
-    features: dataToReview.points.map((point) => {
-      // Row and Column represent the center of the patch in pixels,
-      // Crop size is the size of the patch in pixels
-      // We calculate the corners of the patch in pixels, then convert to lng, lat
-      const topLeft = map.current.unproject([
-        (point.column - halfPatchSize) * imageScale,
-        (point.row - halfPatchSize) * imageScale,
-      ])
-      const bottomLeft = map.current.unproject([
-        (point.column - halfPatchSize) * imageScale,
-        (point.row + halfPatchSize) * imageScale,
-      ])
-      const bottomRight = map.current.unproject([
-        (point.column + halfPatchSize) * imageScale,
-        (point.row + halfPatchSize) * imageScale,
-      ])
-      const topRight = map.current.unproject([
-        (point.column + halfPatchSize) * imageScale,
-        (point.row - halfPatchSize) * imageScale,
-      ])
-      const isPointInLeftHalfOfImage = point.column < dataToReview.original_image_width / 2
-      const isPointInTopHalfOfImage = point.row < dataToReview.original_image_height / 2
+  const getPointsGeojson = useCallback(
+    () => ({
+      type: 'FeatureCollection',
+      features: dataToReview.points.map((point) => {
+        // Row and Column represent the center of the patch in pixels,
+        // Crop size is the size of the patch in pixels
+        // We calculate the corners of the patch in pixels, then convert to lng, lat
+        const topLeft = map.current.unproject([
+          (point.column - halfPatchSize) * imageScale,
+          (point.row - halfPatchSize) * imageScale,
+        ])
+        const bottomLeft = map.current.unproject([
+          (point.column - halfPatchSize) * imageScale,
+          (point.row + halfPatchSize) * imageScale,
+        ])
+        const bottomRight = map.current.unproject([
+          (point.column + halfPatchSize) * imageScale,
+          (point.row + halfPatchSize) * imageScale,
+        ])
+        const topRight = map.current.unproject([
+          (point.column + halfPatchSize) * imageScale,
+          (point.row - halfPatchSize) * imageScale,
+        ])
+        const isPointInLeftHalfOfImage = point.column < dataToReview.original_image_width / 2
+        const isPointInTopHalfOfImage = point.row < dataToReview.original_image_height / 2
 
-      return {
-        type: 'Feature',
-        properties: {
-          id: point.id,
-          ba_gr: point.annotations[0]?.ba_gr,
-          ba_gr_label: point.annotations[0]?.ba_gr_label,
-          isUnclassified: !point.annotations.length,
-          isConfirmed: !!point.annotations[0]?.is_confirmed,
-          isPointInLeftHalfOfImage,
-          isPointInTopHalfOfImage,
-        },
-        geometry: {
-          type: 'Polygon',
-          coordinates: [
-            [
-              [topLeft.lng, topLeft.lat],
-              [bottomLeft.lng, bottomLeft.lat],
-              [bottomRight.lng, bottomRight.lat],
-              [topRight.lng, topRight.lat],
-              [topLeft.lng, topLeft.lat],
+        return {
+          type: 'Feature',
+          properties: {
+            id: point.id,
+            ba_gr: point.annotations[0]?.ba_gr,
+            ba_gr_label: point.annotations[0]?.ba_gr_label,
+            isUnclassified: !point.annotations.length,
+            isConfirmed: !!point.annotations[0]?.is_confirmed,
+            isPointInLeftHalfOfImage,
+            isPointInTopHalfOfImage,
+          },
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [topLeft.lng, topLeft.lat],
+                [bottomLeft.lng, bottomLeft.lat],
+                [bottomRight.lng, bottomRight.lat],
+                [topRight.lng, topRight.lat],
+                [topLeft.lng, topLeft.lat],
+              ],
             ],
-          ],
-        },
-      }
+          },
+        }
+      }),
     }),
-  })
+    [
+      dataToReview?.original_image_height,
+      dataToReview?.original_image_width,
+      dataToReview?.points,
+      halfPatchSize,
+      imageScale,
+      map,
+    ],
+  )
 
   return { getPointsGeojson }
 }


### PR DESCRIPTION
[Ticket](https://trello.com/c/ocCH6g2a/1226-image-classification-add-next-confirmed-point-button)

Steps to test:
- open a BPQ record with image classification
- click the IC review button
- click on a point in the image
- hover over the arrow button beside the confirm button => you should see a tooltip
- click the button, it should zoom you to the next unconfirmed (classified or unclassified) point (the zoom is weird due to constraints with us hacking an image onto a map)
- confirm all the points on the map => the next unconfirmed point button should now be disabled
