### PR TITLE
Image classification/m1186 keep ic upload toast open

### DIFF
--- a/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
@@ -85,7 +85,9 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles, setIs
 
     // Show the persistent uploading toast and store the toastId
     if (!toastId.current) {
-      toastId.current = toast.info(renderUploadProgress(0, files.length, handleCancelUpload))
+      toastId.current = toast.info(renderUploadProgress(0, files.length, handleCancelUpload), {
+        autoClose: false,
+      })
     }
 
     isCancelledRef.current = false
@@ -146,7 +148,6 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles, setIs
         toast.update(toastId.current, {
           render: uploadText.success,
           type: toast.TYPE.SUCCESS,
-          autoClose: 5000,
         })
       }
     }


### PR DESCRIPTION
Ticket
https://trello.com/c/VFX2JFDl/1186-when-uploading-images-keep-the-toast-visible-until-all-the-images-are-uploaded?filter=member:mnunes24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Based on the comprehensive summary of changes, here are the release notes:

## Release Notes

- **New Features**
  - Added image classification functionality to the application
  - Introduced image upload and annotation capabilities
  - Implemented a new modal for image annotations with advanced interaction features

- **Improvements**
  - Enhanced user interface for sample unit observations
  - Added more robust error handling for file uploads
  - Improved table and modal components with new styling and interaction options

- **Bug Fixes**
  - Updated validation logic for observations
  - Fixed prop type checking across multiple components

- **Documentation**
  - Added comprehensive language support for new image classification features
  - Updated endpoint documentation for image-related operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->