### PR TITLE
M1244 fix polling after ic upload so that it doesnt hammer api with excessive calls

### DIFF
--- a/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
@@ -21,7 +21,14 @@ const renderUploadProgress = (processedCount, totalFiles, handleCancelUpload) =>
   </div>
 )
 
-const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles, setIsUploading }) => {
+const ImageUploadModal = ({
+  existingFiles,
+  isOpen,
+  onClose,
+  onFilesUpload,
+  pollCollectRecordUntilAllImagesProcessed,
+  setIsUploading,
+}) => {
   const isCancelledRef = useRef(false)
   const fileInputRef = useRef(null)
   const { recordId, projectId } = useParams()
@@ -172,12 +179,14 @@ const ImageUploadModal = ({ isOpen, onClose, onFilesUpload, existingFiles, setIs
   const handleFileChange = (event) => {
     const files = Array.from(event.target.files)
     validateAndUploadFiles(files)
+    pollCollectRecordUntilAllImagesProcessed()
   }
 
   const handleDrop = (event) => {
     event.preventDefault()
     const files = Array.from(event.dataTransfer.files)
     validateAndUploadFiles(files)
+    pollCollectRecordUntilAllImagesProcessed()
   }
 
   const handleDragOver = (event) => {
@@ -237,6 +246,7 @@ ImageUploadModal.propTypes = {
   onFilesUpload: PropTypes.func.isRequired,
   existingFiles: PropTypes.array.isRequired,
   setIsUploading: PropTypes.func.isRequired,
+  pollCollectRecordUntilAllImagesProcessed: PropTypes.func.isRequired,
 }
 
 export default ImageUploadModal

--- a/src/components/pages/ImageClassification/getIsImageProcessed.js
+++ b/src/components/pages/ImageClassification/getIsImageProcessed.js
@@ -1,0 +1,3 @@
+export const getIsImageProcessed = (status) => {
+  return status === 3 || status === 4
+}

--- a/src/components/pages/ImageClassification/imageClassificationConstants.js
+++ b/src/components/pages/ImageClassification/imageClassificationConstants.js
@@ -1,0 +1,2 @@
+export const EXCLUDE_PARAMS_FOR_GET_ALL_IMAGES_IN_COLLECT_RECORD =
+  'data,created_by,updated_by,updated_on,original_image_width,original_image_height,location,comments,image,photo_timestamp'


### PR DESCRIPTION
Steps to test:
- go to a BPQ record with IC
- upload multiple images with network speed throttled (4g sufficient)
- look in the network tab => polling for all images for the collect record should happen no more frequently than 5 second intervals