### PR TITLE
Image classification/m1245 right positioned tooltips for ic map controls

### DIFF
--- a/src/components/generic/tooltip.js
+++ b/src/components/generic/tooltip.js
@@ -74,17 +74,11 @@ const TooltipWrapper = styled('div')`
   }
 `
 
-export const TooltipWithText = ({
-  text,
-  tooltipText,
-  id,
-  $position = 'bottom',
-  ...restOfProps
-}) => {
+export const TooltipWithText = ({ text, tooltipText, id, position = 'bottom', ...restOfProps }) => {
   return (
     <TooltipP tabIndex="0" id={id} {...restOfProps}>
       {text}
-      <TooltipPopup role="tooltip" aria-labelledby={id} $position={$position}>
+      <TooltipPopup role="tooltip" aria-labelledby={id} $position={position}>
         {tooltipText}
       </TooltipPopup>
     </TooltipP>
@@ -95,14 +89,16 @@ TooltipWithText.propTypes = {
   text: PropTypes.node.isRequired,
   tooltipText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   id: PropTypes.string.isRequired,
-  $position: PropTypes.oneOf(['bottom', 'right']),
+  position: PropTypes.oneOf(['bottom', 'right']),
 }
 
-export const Tooltip = ({ children, tooltipText, id, $position = 'bottom' }) => {
+export const Tooltip = ({ children, tooltipText, id, className, position = 'bottom' }) => {
   return (
-    <TooltipWrapper>
+    // className is so that we can override styles using styled-components,
+    // which we need to do for image classification map control buttons
+    <TooltipWrapper className={className}>
       {children}
-      <TooltipPopup role="tooltip" aria-labelledby={id} $position={$position}>
+      <TooltipPopup role="tooltip" aria-labelledby={id} $position={position}>
         {tooltipText}
       </TooltipPopup>
     </TooltipWrapper>
@@ -113,5 +109,6 @@ Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
   tooltipText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   id: PropTypes.string.isRequired,
-  $position: PropTypes.oneOf(['bottom', 'right']),
+  position: PropTypes.oneOf(['bottom', 'right']),
+  className: PropTypes.string,
 }

--- a/src/components/generic/tooltip.js
+++ b/src/components/generic/tooltip.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
 import theme from '../../theme'
 
 export const TooltipP = styled('p')`
@@ -17,6 +17,35 @@ export const TooltipP = styled('p')`
     display: block;
   }
 `
+
+const tooltipCssByPosition = {
+  bottom: css`
+    top: 4rem;
+    padding-top: calc(4rem - 15px);
+    clip-path: polygon(
+      calc(50% - 10px) 15px,
+      50% 0,
+      calc(50% + 10px) 15px,
+      100% 15px,
+      100% 100%,
+      0 100%,
+      0 15px
+    );
+  `,
+  right: css`
+    left: 4rem;
+    padding-left: calc(4rem - 50%);
+    clip-path: polygon(
+      15px calc(50% - 6px),
+      0 50%,
+      15px calc(50% + 6px),
+      15px 100%,
+      100% 100%,
+      100% 0,
+      15px 0
+    );
+  `,
+}
 export const TooltipPopup = styled('span')`
   display: none;
   min-width: 26ch;
@@ -26,21 +55,11 @@ export const TooltipPopup = styled('span')`
   color: ${theme.color.white};
   position: absolute;
   font-size: ${theme.typography.smallFontSize};
-  clip-path: polygon(
-    calc(50% - 10px) 15px,
-    50% 0,
-    calc(50% + 10px) 15px,
-    100% 15px,
-    100% 100%,
-    0 100%,
-    0 15px
-  );
   padding: ${theme.spacing.small};
-  padding-top: calc(4rem - 15px);
-  top: 4rem;
   white-space: normal;
   z-index: 100;
   text-align: center;
+  ${({ $position }) => tooltipCssByPosition[$position]};
 `
 
 const TooltipWrapper = styled('div')`
@@ -55,11 +74,17 @@ const TooltipWrapper = styled('div')`
   }
 `
 
-export const TooltipWithText = ({ text, tooltipText, id, ...restOfProps }) => {
+export const TooltipWithText = ({
+  text,
+  tooltipText,
+  id,
+  $position = 'bottom',
+  ...restOfProps
+}) => {
   return (
     <TooltipP tabIndex="0" id={id} {...restOfProps}>
       {text}
-      <TooltipPopup role="tooltip" aria-labelledby={id}>
+      <TooltipPopup role="tooltip" aria-labelledby={id} $position={$position}>
         {tooltipText}
       </TooltipPopup>
     </TooltipP>
@@ -70,13 +95,14 @@ TooltipWithText.propTypes = {
   text: PropTypes.node.isRequired,
   tooltipText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   id: PropTypes.string.isRequired,
+  $position: PropTypes.oneOf(['bottom', 'right']),
 }
 
-export const Tooltip = ({ children, tooltipText, id }) => {
+export const Tooltip = ({ children, tooltipText, id, $position = 'bottom' }) => {
   return (
     <TooltipWrapper>
       {children}
-      <TooltipPopup role="tooltip" aria-labelledby={id}>
+      <TooltipPopup role="tooltip" aria-labelledby={id} $position={$position}>
         {tooltipText}
       </TooltipPopup>
     </TooltipWrapper>
@@ -87,4 +113,5 @@ Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
   tooltipText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   id: PropTypes.string.isRequired,
+  $position: PropTypes.oneOf(['bottom', 'right']),
 }

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
@@ -6,6 +6,7 @@ import { IMAGE_CLASSIFICATION_COLORS as COLORS } from '../../../../library/const
 import LoadingIndicator from '../../../LoadingIndicator/LoadingIndicator'
 import { RowSpaceBetween } from '../../../generic/positioning'
 import { ButtonPrimary, IconButton, buttonSecondaryCss } from '../../../generic/buttons'
+import { Tooltip } from '../../../generic/tooltip'
 
 const confirmed = colorHelper(COLORS.confirmed)
 const unconfirmed = colorHelper(COLORS.unconfirmed)
@@ -144,18 +145,22 @@ export const MapControlButton = styled.button`
   box-sizing: border-box;
   height: 29px;
   width: 29px;
+  &:hover { {
+    background-color: ${({ $isSelected }) =>
+      $isSelected ? theme.color.primaryHover : theme.color.secondaryHover};
+  }
 `
-export const MapResetButton = styled(MapControlButton)`
+export const MapResetTooltip = styled(Tooltip)`
   position: absolute;
   top: 75px;
   left: 10px;
 `
-export const ToggleTableButton = styled(MapControlButton)`
+export const ToggleTableTooltip = styled(Tooltip)`
   position: absolute;
   top: 110px;
   left: 10px;
 `
-export const ToggleLabelsButton = styled(MapControlButton)`
+export const ToggleLabelsTooltip = styled(Tooltip)`
   position: absolute;
   top: 145px;
   left: 10px;

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
@@ -14,14 +14,14 @@ import {
   ImageAnnotationMapWrapper,
   LabelPopup,
   LoadingIndicatorImageClassificationImage,
-  MapResetButton,
-  ToggleLabelsButton,
-  ToggleTableButton,
+  MapControlButton,
+  MapResetTooltip,
+  ToggleLabelsTooltip,
+  ToggleTableTooltip,
 } from './ImageAnnotationModal.styles'
 import ImageAnnotationPopup from './ImageAnnotationPopup/ImageAnnotationPopup'
 import EditPointPopupWrapper from './ImageAnnotationPopup/EditPointPopupWrapper'
 import { getPatchesCenters } from './getPatchesCenters'
-import { Tooltip } from '../../../generic/tooltip'
 
 const DEFAULT_CENTER = [0, 0] // this value doesn't matter, default to null island
 const DEFAULT_ZOOM = 2 // needs to be > 1 otherwise bounds become > 180 and > 85
@@ -552,23 +552,30 @@ const ImageAnnotationModalMap = ({
         }}
       />
       {hasMapLoaded ? (
-        <MapResetButton type="button" onClick={resetZoom} title="reset zoom">
-          <Tooltip tooltipText="Reset Zoom" id="reset-zoom" $position="right">
+        <MapResetTooltip tooltipText="Reset Zoom" id="reset-zoom" position="right">
+          <MapControlButton type="button" onClick={resetZoom} title="reset zoom">
             <IconReset />
-          </Tooltip>
-        </MapResetButton>
+          </MapControlButton>
+        </MapResetTooltip>
       ) : null}
-      <ToggleTableButton type="button" onClick={toggleTable} $isSelected={isTableShowing}>
-        <Tooltip tooltipText="Toggle Table Visibility" id="table-visibility" $position="right">
+      <ToggleTableTooltip
+        tooltipText="Toggle Table Visibility"
+        id="table-visibility"
+        position="right"
+      >
+        <MapControlButton type="button" onClick={toggleTable} $isSelected={isTableShowing}>
           <IconTable />
-        </Tooltip>
-      </ToggleTableButton>
-      <ToggleLabelsButton type="button" onClick={toggleLabels} $isSelected={areLabelsShowing}>
-        <Tooltip tooltipText="Toggle Labels Visibility" id="toggle-labels" $position="right">
+        </MapControlButton>
+      </ToggleTableTooltip>
+      <ToggleLabelsTooltip
+        tooltipText="Toggle Labels Visibility"
+        id="toggle-labels"
+        position="right"
+      >
+        <MapControlButton type="button" onClick={toggleLabels} $isSelected={areLabelsShowing}>
           <IconLabel />
-        </Tooltip>
-      </ToggleLabelsButton>
-
+        </MapControlButton>
+      </ToggleLabelsTooltip>
       {selectedPoint.id ? (
         <EditPointPopupWrapper
           map={map.current}

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
@@ -21,6 +21,7 @@ import {
 import ImageAnnotationPopup from './ImageAnnotationPopup/ImageAnnotationPopup'
 import EditPointPopupWrapper from './ImageAnnotationPopup/EditPointPopupWrapper'
 import { getPatchesCenters } from './getPatchesCenters'
+import { Tooltip } from '../../../generic/tooltip'
 
 const DEFAULT_CENTER = [0, 0] // this value doesn't matter, default to null island
 const DEFAULT_ZOOM = 2 // needs to be > 1 otherwise bounds become > 180 and > 85
@@ -551,15 +552,21 @@ const ImageAnnotationModalMap = ({
         }}
       />
       {hasMapLoaded ? (
-        <MapResetButton type="button" onClick={resetZoom}>
-          <IconReset />
+        <MapResetButton type="button" onClick={resetZoom} title="reset zoom">
+          <Tooltip tooltipText="Reset Zoom" id="reset-zoom" $position="right">
+            <IconReset />
+          </Tooltip>
         </MapResetButton>
       ) : null}
       <ToggleTableButton type="button" onClick={toggleTable} $isSelected={isTableShowing}>
-        <IconTable />
+        <Tooltip tooltipText="Toggle Table Visibility" id="table-visibility" $position="right">
+          <IconTable />
+        </Tooltip>
       </ToggleTableButton>
       <ToggleLabelsButton type="button" onClick={toggleLabels} $isSelected={areLabelsShowing}>
-        <IconLabel />
+        <Tooltip tooltipText="Toggle Labels Visibility" id="toggle-labels" $position="right">
+          <IconLabel />
+        </Tooltip>
       </ToggleLabelsButton>
 
       {selectedPoint.id ? (


### PR DESCRIPTION
Description:
- create ability for existing tooltip to be right positioned based on props
- use it for IC map controls (reset zoom, toggle labels, toggle table visibility)

Steps to test:
- open a BPQ record with IC
- over over the three map control buttons => see the tooltip show up


<img width="1014" alt="Screenshot 2025-01-28 at 1 48 01 PM" src="https://github.com/user-attachments/assets/178d0b02-501f-4592-b105-db215ebab210" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added image classification functionality to the application
  - Introduced image upload and annotation capabilities
  - Implemented sample unit input selector for image-based observations

- **Improvements**
  - Enhanced modal and table components with new styling and interactions
  - Added support for geospatial image annotation
  - Improved error handling and user feedback for file uploads

- **Dependencies**
  - Added Turf.js geospatial libraries
  - Updated icon and styling components

- **Bug Fixes**
  - Refined prop type validations
  - Improved online/offline handling for image classification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->