### PR TITLE
M1194 show IC upload loading info and file name if no image thumbnail available

### DIFF
--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -455,7 +455,14 @@ const ImageClassificationObservationTable = ({
                           }
                         >
                           <ImageWrapper>
-                            <Thumbnail imageUrl={file.thumbnail} />
+                            {file.thumbnail ? (
+                              <Thumbnail imageUrl={file.thumbnail} />
+                            ) : (
+                              <div>
+                                <Spinner />
+                                Loading {file.original_image_name}
+                              </div>
+                            )}
                           </ImageWrapper>
                         </TdWithHoverText>
                         <StyledTd


### PR DESCRIPTION
[Ticket](https://trello.com/c/xlNMm5Ki/1194-missing-loading-word-and-image-name-when-uploading-images)

Prevent images with broken srcs from showing when there isnt a src value available Instead we show text based content.

Steps to test
Its hard to reproduce this reliably at the moment on my machine at least, but this is how you might see it:

- Create a new BPQ (you will need to run `make worker` from a second terminal tab while also running the mermaid api)
- Select image classification
- Upload a few (5) images => if you are lucky you _might_ see the new placeholder text instead of an image. The attached screenshot shows it as well.

<img width="1727" alt="Screenshot 2025-01-28 at 5 13 34 PM" src="https://github.com/user-attachments/assets/94252e41-7937-4d22-ba3a-1ed4c8d97905" />
