### PR TITLE
Image classification/m1262 IC keep table up to date as uploads complete

### DIFF
--- a/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
@@ -140,6 +140,13 @@ const ImageUploadModal = ({
 
       // Start processing the file as soon as it's validated.
       const uploadedFile = await processSingleImage(file)
+      const isFirstUploadedFile = uploadedFile && uploadedFiles.length === 0
+      if (isFirstUploadedFile) {
+        // wait for first image to be successfully
+        // uploaded before initiating polling
+        // to avoid hitting the API unecessarily
+        pollCollectRecordUntilAllImagesProcessed()
+      }
       if (uploadedFile) {
         uploadedFiles.push(uploadedFile)
         onFilesUpload()
@@ -179,14 +186,12 @@ const ImageUploadModal = ({
   const handleFileChange = (event) => {
     const files = Array.from(event.target.files)
     validateAndUploadFiles(files)
-    pollCollectRecordUntilAllImagesProcessed()
   }
 
   const handleDrop = (event) => {
     event.preventDefault()
     const files = Array.from(event.dataTransfer.files)
     validateAndUploadFiles(files)
-    pollCollectRecordUntilAllImagesProcessed()
   }
 
   const handleDragOver = (event) => {


### PR DESCRIPTION
[Ticket 1](https://trello.com/c/uCuS3bjz/1258-slow-ic-multiple-image-upload-doesnt-update-observations-table-properly-as-files-are-uploaded)
[Ticket 2](https://trello.com/c/bcebdJmB/1262-cant-view-more-than-one-uploaded-ic-image-in-table-until-browser-refresh)

Description:
- sometimes with slow connections checking if all server files have been processed will be true before an image has a chance to actually upload. This resulted in polling for image changes to stop before any uploads were complete. The fix is to also check if any files are uploading before stopping polling, and also not to start polling before any files are uploaded.
- This fix also fixed another bug where if any previously uploaded files were present, subsequent uploads would stop polling immediately.
- both of these bugs were hidden by pervious implementation where overreactivity was initiating polling multiple times a second. The overactivity hid the issue, but it was also hammering the API.

Steps to test: 
- dev test skipped to balance reviewer's workload for the time being

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Based on the comprehensive summary, here are the release notes:

## Release Notes

- **New Features**
  - Added image classification functionality for benthic photo quadrat records
  - Introduced image upload, annotation, and classification capabilities
  - Implemented sample unit input selector for image classification

- **Improvements**
  - Enhanced modal components with more configurable props
  - Added new icons and styling components
  - Improved error handling and validation for image uploads

- **Bug Fixes**
  - Updated prop types to make certain properties optional
  - Fixed styling inconsistencies in various components

- **Performance**
  - Optimized map and image scaling utilities
  - Added memoization for complex rendering logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->