### PR TITLE
M1217 ensure contents of table cells dont leak into other table cells when filter is used

### DIFF
--- a/src/components/FilterSearchToolbar/FilterSearchToolbar.js
+++ b/src/components/FilterSearchToolbar/FilterSearchToolbar.js
@@ -126,7 +126,7 @@ FilterSearchToolbar.propTypes = {
   id: PropTypes.string,
   name: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
-  globalSearchText: PropTypes.string.isRequired,
+  globalSearchText: PropTypes.string,
   handleGlobalFilterChange: PropTypes.func.isRequired,
   type: PropTypes.string,
 }

--- a/src/components/SampleUnitPopups/SubmittedSampleUnitPopup/SubmittedSampleUnitPopup.js
+++ b/src/components/SampleUnitPopups/SubmittedSampleUnitPopup/SubmittedSampleUnitPopup.js
@@ -20,14 +20,14 @@ const SubmittedSampleUnitPopup = ({ rowRecord, sampleUnitNumbersRow }) => {
   const popupTitle = `${sample_unit_method} ${site_name}`
 
   const sampleUnitsWithPopup = sampleUnitNumbersRow.map((row, index) => {
-    const { label: transectNumberLabel, management, sample_date, updated_by, observers } = row
+    const { label: transectNumberLabel, management, sample_date, updated_by, observers, id } = row
 
     const managementName =
       management.name === API_NULL_NAME
         ? language.pages.usersAndTransectsTable.missingMRName
         : management.name
 
-    const keyName = transectNumberLabel + site_name + managementName + updated_by + sample_date
+    const keyName = transectNumberLabel + site_name + managementName + updated_by + sample_date + id
 
     return (
       <SampleUnitNumber tabIndex="0" id={index} key={keyName}>

--- a/src/components/pages/UsersAndTransects/UsersAndTransects.js
+++ b/src/components/pages/UsersAndTransects/UsersAndTransects.js
@@ -487,53 +487,56 @@ const UsersAndTransects = () => {
       <StickyTableOverflowWrapper>
         <StickyOverviewTable {...getTableProps()}>
           <OverviewThead>
-            {headerGroups.map((headerGroup) => (
-              <Tr key={headerGroup.id} {...headerGroup.getHeaderGroupProps()}>
-                {headerGroup.headers.map((column) => {
-                  const isMultiSortColumn = headerGroup.headers.some(
-                    (header) => header.sortedIndex > 0,
-                  )
-                  const ThClassName = column.parent ? column.parent.id : undefined
+            {headerGroups.map((headerGroup) => {
+              const headerGroupProps = headerGroup.getHeaderGroupProps()
+              return (
+                <Tr {...headerGroupProps} key={headerGroupProps.key}>
+                  {headerGroup.headers.map((column) => {
+                    const isMultiSortColumn = headerGroup.headers.some(
+                      (header) => header.sortedIndex > 0,
+                    )
+                    const ThClassName = column.parent ? column.parent.id : undefined
 
-                  const headerAlignment =
-                    column.Header === 'Site' || column.Header === 'Method' ? 'left' : 'right'
-                  const isUserHeader = ThClassName === 'user-headers'
-                  const userProfileId = isUserHeader ? column.id : null
+                    const headerAlignment =
+                      column.Header === 'Site' || column.Header === 'Method' ? 'left' : 'right'
+                    const isUserHeader = ThClassName === 'user-headers'
+                    const userProfileId = isUserHeader ? column.id : null
 
-                  return (
-                    <OverviewTh
-                      {...column.getHeaderProps(getTableColumnHeaderProps(column))}
-                      key={column.id}
-                      isSortedDescending={column.isSortedDesc}
-                      sortedIndex={column.sortedIndex}
-                      isMultiSortColumn={isMultiSortColumn}
-                      isSortingEnabled={!column.disableSortBy}
-                      disabledHover={column.disableSortBy}
-                      align={headerAlignment}
-                      className={ThClassName}
-                    >
-                      {isUserHeader ? (
-                        <UserColumnHeader>
-                          {column.render('Header')}{' '}
-                          <ActiveRecordsCount>
-                            {getUserHeaderCount(userProfileId)}
-                          </ActiveRecordsCount>
-                        </UserColumnHeader>
-                      ) : (
-                        column.render('Header')
-                      )}
-                    </OverviewTh>
-                  )
-                })}
-              </Tr>
-            ))}
+                    return (
+                      <OverviewTh
+                        {...column.getHeaderProps(getTableColumnHeaderProps(column))}
+                        key={column.id}
+                        isSortedDescending={column.isSortedDesc}
+                        sortedIndex={column.sortedIndex}
+                        isMultiSortColumn={isMultiSortColumn}
+                        isSortingEnabled={!column.disableSortBy}
+                        disabledHover={column.disableSortBy}
+                        align={headerAlignment}
+                        className={ThClassName}
+                      >
+                        {isUserHeader ? (
+                          <UserColumnHeader>
+                            {column.render('Header')}{' '}
+                            <ActiveRecordsCount>
+                              {getUserHeaderCount(userProfileId)}
+                            </ActiveRecordsCount>
+                          </UserColumnHeader>
+                        ) : (
+                          column.render('Header')
+                        )}
+                      </OverviewTh>
+                    )
+                  })}
+                </Tr>
+              )
+            })}
           </OverviewThead>
           <tbody {...getTableBodyProps()}>
             {page.map((row) => {
               prepareRow(row)
 
               return (
-                <OverviewTr key={row.id} {...row.getRowProps()}>
+                <OverviewTr {...row.getRowProps()} key={row.id}>
                   {row.cells.map((cell) => {
                     const cellColumnId = cell.column.id
                     const cellColumnGroupId = cell.column.parent.id


### PR DESCRIPTION
[Ticket ](https://trello.com/c/f7ZuOUv3/1217-duplicate-transects-appeared-on-the-observer-and-transects-table-after-filtering-by-method?filter=member:mnunes24)

**Steps to test (copied from ticket)** (note I needed to do a variant of this to reproduce the bug which I will note below)
Create any SU, validate and submit
Create another SU, same method and metadata as #1 (incuding the transect number), but different depth. Validate and submit.
Go to the Observers and Transects page and filter by method you choose in step #1 and #2
Observe the table. The table will show more than two SUs with the same site, method, and transect (identical urls when hovering over the SUs).
Remove the filter, then re-add another filter. Observe the table again. More number will be added next to the submitted SUs from #1 and #2.

Melissa variant steps to test:
Do the same as above, but change the method and keep all the other metadata the same. Then toggle the filter. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **PropTypes Updates**
	- Modified `FilterSearchToolbar` to make `globalSearchText` prop optional
	- Updated `SubmittedSampleUnitPopup` to include `id` in `sampleUnitNumbersRow` prop type
	- Improved prop type definitions for better type checking and component validation

- **Code Structure**
	- Refined rendering of table headers in `UsersAndTransects` component
	- Enhanced key prop handling for improved React component rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->