### PR TITLE
M1231 add new row to data sharing table

### DIFF
--- a/src/components/DataSharingInfoModal/DataSharingInfoModal.js
+++ b/src/components/DataSharingInfoModal/DataSharingInfoModal.js
@@ -187,6 +187,18 @@ const DataSharingInfoModal = ({ isOpen, onDismiss }) => {
               <IconCheck />
             </Tcell>
           </Tr>
+          <Tr>
+            <Tcell cellWithText>Colonies bleached and benthic percent cover</Tcell>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+            <TcellWithIconClose>
+              <IconClose />
+            </TcellWithIconClose>
+            <Tcell>
+              <IconCheck />
+            </Tcell>
+          </Tr>
         </tbody>
       </Table>
     </TableOverflowWrapper>


### PR DESCRIPTION
Add new row to data sharing table

Steps to test:
- go to data sharing page
- click on the 'learn more' button
- see the new row at the bottom for 'Colonies bleached and benthic percent cover'

<img width="999" alt="Screenshot 2025-01-31 at 2 22 25 PM" src="https://github.com/user-attachments/assets/0199a8b0-9353-4c58-94b4-322d95d6e1a2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced data sharing information modal with additional details about coral health and benthic cover metrics
  - Added visual indicators (close and check icons) to represent status of transect-level observations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->