### PR TITLE
M1169 add collect record status column to records table, as well as border colour for each status

### DIFF
--- a/src/components/pages/Collect/Collect.js
+++ b/src/components/pages/Collect/Collect.js
@@ -45,6 +45,8 @@ import {
 } from '../../../App/mermaidData/recordProtocolHelpers'
 import { getIsUserReadOnlyForProject } from '../../../App/currentUserProfileHelpers'
 import { PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
+import { RECORD_STATUS_LABELS } from './collectConstants'
+import { TrCollectRecordStatus } from './Collect.styles'
 
 const Collect = () => {
   const [collectRecordsForUiDisplay, setCollectRecordsForUiDisplay] = useState([])
@@ -138,13 +140,18 @@ const Collect = () => {
         accessor: 'observers',
         sortType: reactTableNaturalSort,
       },
+      {
+        Header: 'Status',
+        accessor: 'status',
+        sortType: reactTableNaturalSort,
+      },
     ],
     [],
   )
 
   const tableCellData = useMemo(
     () =>
-      collectRecordsForUiDisplay.map(({ id, data, uiLabels }) => {
+      collectRecordsForUiDisplay.map(({ id, data, uiLabels, validations }) => {
         const isQuadratSampleUnit = getIsQuadratSampleUnit(data.protocol)
 
         return {
@@ -165,6 +172,7 @@ const Collect = () => {
           depth: uiLabels.depth,
           sampleDate: uiLabels.sampleDate,
           observers: uiLabels.observers,
+          status: RECORD_STATUS_LABELS[validations.status],
         }
       }),
     [collectRecordsForUiDisplay, currentProjectPath],
@@ -335,7 +343,11 @@ const Collect = () => {
               prepareRow(row)
 
               return (
-                <Tr key={row.id} {...row.getRowProps()}>
+                <TrCollectRecordStatus
+                  key={row.id}
+                  {...row.getRowProps()}
+                  $recordStatusLabel={row.values.status}
+                >
                   {row.cells.map((cell) => {
                     return (
                       <Td key={cell.column.id} {...cell.getCellProps()} align={cell.column.align}>
@@ -343,7 +355,7 @@ const Collect = () => {
                       </Td>
                     )
                   })}
-                </Tr>
+                </TrCollectRecordStatus>
               )
             })}
           </tbody>

--- a/src/components/pages/Collect/Collect.styles.js
+++ b/src/components/pages/Collect/Collect.styles.js
@@ -1,0 +1,15 @@
+import { RECORD_STATUS_LABELS } from './collectConstants'
+import { Tr } from '../../generic/Table/table'
+import styled from 'styled-components'
+import theme from '../../../theme'
+
+const RECORD_STATUS_COLORS = {
+  [RECORD_STATUS_LABELS.error]: theme.color.cautionColor,
+  [RECORD_STATUS_LABELS.ok]: '#298217',
+  [RECORD_STATUS_LABELS.stale]: theme.color.primaryColor,
+  [RECORD_STATUS_LABELS.warning]: theme.color.warningColor,
+}
+
+export const TrCollectRecordStatus = styled(Tr)`
+  border-left: 4px solid ${({ $recordStatusLabel }) => RECORD_STATUS_COLORS[$recordStatusLabel]};
+`

--- a/src/components/pages/Collect/collectConstants.js
+++ b/src/components/pages/Collect/collectConstants.js
@@ -1,0 +1,18 @@
+export const VALIDATION_STATUS = {
+  error: 'error',
+  ignore: 'ignore',
+  ok: 'ok',
+  stale: 'stale',
+  warning: 'warning',
+}
+Object.freeze(VALIDATION_STATUS)
+
+export const RECORD_STATUS_LABELS = {
+  // VALIDATION_STATUS.ignore is only used for the status of
+  // individual validations, not the overall validations object.
+  [VALIDATION_STATUS.error]: 'Errors',
+  [VALIDATION_STATUS.ok]: 'Ready to submit',
+  [VALIDATION_STATUS.stale]: 'Saved',
+  [VALIDATION_STATUS.warning]: 'Warnings',
+}
+Object.freeze(RECORD_STATUS_LABELS)


### PR DESCRIPTION
[Ticket](https://trello.com/c/YslpaBlf/1169-show-cr-validation-status-in-collecting)

Steps to test:
- go to a project's collect record page
- on the right side of the table, see the new 'status' column
- on the left side of the table notice the new ~~border-right~~ border-left colour that corresponds with status
- click on the new status column => it should be sortable

<img width="949" alt="Screenshot 2025-01-31 at 4 07 09 PM" src="https://github.com/user-attachments/assets/3a9e65b8-5889-42dd-bb5a-ae46df14741b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a status column to the Collect page table
  - Implemented visual differentiation for record statuses
  - Introduced user-friendly status labels for records

- **Improvements**
  - Enhanced table row rendering to display record status
  - Added color-coded status indicators for better data visualization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->