### PR TITLE
M1169 show 'Saved' isn collect record status table if there is no validation status

### DIFF
--- a/src/components/pages/Collect/collectConstants.js
+++ b/src/components/pages/Collect/collectConstants.js
@@ -14,5 +14,6 @@ export const RECORD_STATUS_LABELS = {
   [VALIDATION_STATUS.ok]: 'Ready to submit',
   [VALIDATION_STATUS.stale]: 'Saved',
   [VALIDATION_STATUS.warning]: 'Warnings',
+  [undefined]: 'Saved', // if a record is created offline, it will have no validation status yet.
 }
 Object.freeze(RECORD_STATUS_LABELS)


### PR DESCRIPTION
Show 'Saved' in collect record status table if there is no validation status

Steps to test:
- make the app offline
- create a new collect record
- return to the collect page that lists all the collect records
- the record you just created should show as 'Saved' in the status column. There should blanks in that column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced record handling for offline creation: Records now display a "Saved" status until their validation is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->