### PR TITLE
M1056 recursively get all paginated projecttags from api

### DIFF
--- a/src/App/mermaidData/databaseSwitchboard/ProjectsMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/ProjectsMixin.js
@@ -1,5 +1,6 @@
 import axios from '../../../library/axiosRetry'
 import { getAuthorizationHeaders } from '../../../library/getAuthorizationHeaders'
+import { getPaginatedMermaidData } from '../getPaginatedMermeidData'
 
 const ProjectsMixin = (Base) =>
   class extends Base {
@@ -70,15 +71,18 @@ const ProjectsMixin = (Base) =>
     }
 
     getProjectTags = async function getProjectTags() {
-      return this._isOnlineAuthenticatedAndReady
-        ? axios
-            .get(
-              `${this._apiBaseUrl}/projecttags/?limit=5000`,
-              await getAuthorizationHeaders(this._getAccessToken),
-            )
-            .then((apiResults) => apiResults.data.results)
-            .catch(() => Promise.reject(this._notAuthenticatedAndReadyError))
-        : Promise.reject(this._notAuthenticatedAndReadyError)
+      if (!this._isOnlineAuthenticatedAndReady) {
+        return Promise.reject(this._notAuthenticatedAndReadyError)
+      }
+
+      return await getPaginatedMermaidData({
+        url: `${this._apiBaseUrl}/projecttags/`,
+        authorizationHeaders: await getAuthorizationHeaders(this._getAccessToken),
+        axios,
+        errorCallback: () => {
+          Promise.reject(this._notAuthenticatedAndReadyError)
+        },
+      })
     }
 
     getProjectProfiles = function getProjectProfiles(projectId) {

--- a/src/App/mermaidData/getPaginatedMermeidData.js
+++ b/src/App/mermaidData/getPaginatedMermeidData.js
@@ -1,0 +1,26 @@
+export const getPaginatedMermaidData = async ({
+  url,
+  authorizationHeaders,
+  axios,
+  errorCallback,
+}) => {
+  const dataItems = []
+  const initialUrl = url
+
+  const loadPaginatedDataItems = async (url) => {
+    try {
+      const response = await axios.get(url, authorizationHeaders)
+      const paginatedDataItems = response.data.results
+      const nextPageUrl = response.data.next
+      dataItems.push(...paginatedDataItems)
+
+      if (nextPageUrl) {
+        await loadPaginatedDataItems(response.data.next)
+      }
+    } catch (error) {
+      errorCallback(error)
+    }
+  }
+  await loadPaginatedDataItems(initialUrl)
+  return dataItems
+}


### PR DESCRIPTION
[Ticket](https://trello.com/c/Znwe6wcB/1056-audit-and-handle-pagination-better)


Recursively load paginated project tags 

Steps to test:
- load project info page
- type into the org autocomplete. Are all the orgs there that you expect? (currently the default limit on results returned is more than the orgs we have so its hard to test this in reality). In the code I set a param to limit to 10 results per page just to test, then removed the limit completely. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced project tag retrieval with optimized, successive data loading for a smoother user experience.
- **Refactor**
  - Streamlined the data fetching workflow with improved error handling to ensure more reliable operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->