### PR TITLE
M1056 getting all paginated GFCR indicator sets

### DIFF
--- a/src/App/mermaidData/databaseSwitchboard/GfcrMixin.js
+++ b/src/App/mermaidData/databaseSwitchboard/GfcrMixin.js
@@ -1,5 +1,6 @@
 import axios from '../../../library/axiosRetry'
 import { getAuthorizationHeaders } from '../../../library/getAuthorizationHeaders'
+import { getPaginatedMermaidData } from '../getPaginatedMermeidData'
 
 const GfcrMixin = (Base) =>
   class extends Base {
@@ -8,14 +9,18 @@ const GfcrMixin = (Base) =>
         Promise.reject(this._operationMissingParameterError)
       }
 
-      return this._isOnlineAuthenticatedAndReady
-        ? axios
-            .get(
-              `${this._apiBaseUrl}/projects/${projectId}/indicatorsets/`,
-              await getAuthorizationHeaders(this._getAccessToken),
-            )
-            .then((apiResults) => apiResults.data)
-        : Promise.reject(this._notAuthenticatedAndReadyError)
+      if (!this._isOnlineAuthenticatedAndReady) {
+        return Promise.reject(this._notAuthenticatedAndReadyError)
+      }
+
+      return await getPaginatedMermaidData({
+        url: `${this._apiBaseUrl}/projects/${projectId}/indicatorsets/`,
+        authorizationHeaders: await getAuthorizationHeaders(this._getAccessToken),
+        axios,
+        errorCallback: () => {
+          return Promise.reject(this._notAuthenticatedAndReadyError)
+        },
+      })
     }
 
     saveIndicatorSet = async function saveIndicatorSet(projectId, editedValues) {

--- a/src/components/pages/gfcrPages/Gfcr/Gfcr.js
+++ b/src/components/pages/gfcrPages/Gfcr/Gfcr.js
@@ -64,7 +64,7 @@ const Gfcr = () => {
       Promise.all([databaseSwitchboardInstance.getIndicatorSets(projectId)])
         .then(([indicatorSetsResponse]) => {
           if (isMounted.current) {
-            setGfcrIndicatorSets(indicatorSetsResponse.results)
+            setGfcrIndicatorSets(indicatorSetsResponse)
           }
 
           setIsLoading(false)

--- a/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.js
@@ -81,7 +81,7 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
         .then(([choicesResponse, indicatorSetsResponse]) => {
           if (isMounted.current) {
             setChoices(choicesResponse)
-            setGfcrIndicatorSets(indicatorSetsResponse.results)
+            setGfcrIndicatorSets(indicatorSetsResponse)
           }
 
           setIsLoading(false)


### PR DESCRIPTION
[Ticket](https://trello.com/c/Znwe6wcB/1056-audit-and-handle-pagination-better)

Get all paginated GCFR indicator sets

Steps to test (WARNING, I am very unfamiliar with this feature, but Joe it looks like you have worked on it, so I am relying on you a little extra to catch any dumb oversights I might have made with this one)
- enable GFCR for a project
- create a couple of new reports or indicators
- ensure that they load properly 

(like other pagination PRs, this test only tests that the fetch works since there arent enough indicators to need to get the next 'page' of indicators, however its been manually tested by setting a query parm to `limit=1`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the indicator sets fetching mechanism by centralizing error handling and integrating a dedicated pagination function.
  - Adjusted state management across pages to now handle the complete response object, ensuring consistent and accurate data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->