### PR TITLE
M1233 GFCR: ensure integer numbers are integers, and decimal numbers are restricted to two decimal places.

### DIFF
--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/InvestmentModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/InvestmentModal.js
@@ -1,29 +1,30 @@
 import PropTypes from 'prop-types'
 import React, { useState, useEffect, useCallback, useMemo } from 'react'
 
-import language from '../../../../../language'
-import { Textarea } from '../../../../generic/form'
-import Modal, { RightFooter } from '../../../../generic/Modal/Modal'
 import {
   StyledModalInputRow,
   StyledModalFooterWrapper,
   StyledModalLeftFooter,
 } from '../subPages/subPages.styles'
-import { useFormik } from 'formik'
+import { ButtonCaution, ButtonSecondary } from '../../../../generic/buttons'
 import { buttonGroupStates } from '../../../../../library/buttonGroupStates'
 import { choicesPropType } from '../../../../../App/mermaidData/mermaidDataProptypes'
-import { ButtonCaution, ButtonSecondary } from '../../../../generic/buttons'
-import SaveButton from './SaveButton'
-import { getInvestmentInitialValues } from './investmentInitialValues'
-import { useDatabaseSwitchboardInstance } from '../../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
-import { useParams } from 'react-router-dom'
-import { useHttpResponseErrorHandler } from '../../../../../App/HttpResponseErrorHandlerContext'
-import { toast } from 'react-toastify'
-import { getToastArguments } from '../../../../../library/getToastArguments'
-import InputNoRowSelectWithLabelAndValidation from '../../../../mermaidInputs/InputNoRowSelectWithLabelAndValidation'
-import { getOptions } from '../../../../../library/getOptions'
-import InputNoRowWithLabelAndValidation from '../../../../mermaidInputs/InputNoRowWithLabelAndValidation'
 import { displayErrorMessagesGFCR } from '../../../../../library/displayErrorMessagesGFCR'
+import { formikHandleNumericTwoDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
+import { getInvestmentInitialValues } from './investmentInitialValues'
+import { getOptions } from '../../../../../library/getOptions'
+import { getToastArguments } from '../../../../../library/getToastArguments'
+import { Textarea } from '../../../../generic/form'
+import { toast } from 'react-toastify'
+import { useDatabaseSwitchboardInstance } from '../../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
+import { useFormik } from 'formik'
+import { useHttpResponseErrorHandler } from '../../../../../App/HttpResponseErrorHandlerContext'
+import { useParams } from 'react-router-dom'
+import InputNoRowSelectWithLabelAndValidation from '../../../../mermaidInputs/InputNoRowSelectWithLabelAndValidation'
+import InputNoRowWithLabelAndValidation from '../../../../mermaidInputs/InputNoRowWithLabelAndValidation'
+import language from '../../../../../language'
+import Modal, { RightFooter } from '../../../../generic/Modal/Modal'
+import SaveButton from './SaveButton'
 
 const modalLanguage = language.gfcrInvestmentModal
 
@@ -288,6 +289,13 @@ const InvestmentModal = ({
             helperText={modalLanguage.getInvestmentAmountHelper()}
             showHelperText={displayHelp}
             required={true}
+            onChange={(event) =>
+              formikHandleNumericTwoDecimalInputChange({
+                formik,
+                event,
+                fieldName: 'investment_amount',
+              })
+            }
           />
         </StyledModalInputRow>
         <hr />

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/RevenueModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/RevenueModal.js
@@ -1,29 +1,30 @@
 import PropTypes from 'prop-types'
 import React, { useState, useEffect, useCallback, useMemo } from 'react'
 
-import language from '../../../../../language'
-import { Textarea } from '../../../../generic/form'
-import Modal, { RightFooter } from '../../../../generic/Modal/Modal'
 import {
   StyledModalInputRow,
   StyledModalFooterWrapper,
   StyledModalLeftFooter,
 } from '../subPages/subPages.styles'
-import { useFormik } from 'formik'
+import { ButtonCaution, ButtonSecondary } from '../../../../generic/buttons'
 import { buttonGroupStates } from '../../../../../library/buttonGroupStates'
 import { choicesPropType } from '../../../../../App/mermaidData/mermaidDataProptypes'
-import { ButtonCaution, ButtonSecondary } from '../../../../generic/buttons'
-import SaveButton from './SaveButton'
+import { displayErrorMessagesGFCR } from '../../../../../library/displayErrorMessagesGFCR'
+import { formikHandleNumericTwoDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
+import { getOptions } from '../../../../../library/getOptions'
 import { getRevenueInitialValues } from './revenueInitialValues'
 import { getToastArguments } from '../../../../../library/getToastArguments'
+import { Textarea } from '../../../../generic/form'
 import { toast } from 'react-toastify'
 import { useDatabaseSwitchboardInstance } from '../../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
-import { useParams } from 'react-router-dom'
+import { useFormik } from 'formik'
 import { useHttpResponseErrorHandler } from '../../../../../App/HttpResponseErrorHandlerContext'
+import { useParams } from 'react-router-dom'
 import InputNoRowSelectWithLabelAndValidation from '../../../../mermaidInputs/InputNoRowSelectWithLabelAndValidation'
-import { getOptions } from '../../../../../library/getOptions'
 import InputNoRowWithLabelAndValidation from '../../../../mermaidInputs/InputNoRowWithLabelAndValidation'
-import { displayErrorMessagesGFCR } from '../../../../../library/displayErrorMessagesGFCR'
+import language from '../../../../../language'
+import Modal, { RightFooter } from '../../../../generic/Modal/Modal'
+import SaveButton from './SaveButton'
 
 const modalLanguage = language.gfcrRevenueModal
 
@@ -290,6 +291,13 @@ const RevenueModal = ({
             helperText={modalLanguage.getAnnualRevenueHelper()}
             showHelperText={displayHelp}
             required={true}
+            onChange={(event) =>
+              formikHandleNumericTwoDecimalInputChange({
+                formik,
+                event,
+                fieldName: 'revenue_amount',
+              })
+            }
           />
         </StyledModalInputRow>
         <hr />

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F1Form.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F1Form.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
+import { formikHandleNumericTwoDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
 import { formikPropType } from '../../../../../library/formikPropType'
-import language from '../../../../../language'
-import { enforceNumberInput } from '../../../../../library/enforceNumberInput'
-import { StyledGfcrInputWrapper } from './subPages.styles'
-import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
 import { H2 } from '../../../../generic/text'
+import { StyledGfcrInputWrapper } from './subPages.styles'
+import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
+import language from '../../../../../language'
+import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
 
 const { gfcrIndicatorSet: gfcrIndicatorSetLanguage } = language.pages
 
@@ -29,7 +29,9 @@ const F1Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         onFocus={(event) => handleInputFocus(event)}
         helperText={gfcrIndicatorSetLanguage.getF1_1_helper()}
         showHelperText={displayHelp}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) =>
+          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f1_1' })
+        }
       />
       <TextareaWithLabelAndValidation
         id="f1_notes"

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F2Form.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F2Form.js
@@ -1,13 +1,13 @@
-import React from 'react'
 import PropTypes from 'prop-types'
+import React from 'react'
 
-import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
+import { formikHandleNumericTwoDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
 import { formikPropType } from '../../../../../library/formikPropType'
-import language from '../../../../../language'
-import { enforceNumberInput } from '../../../../../library/enforceNumberInput'
-import { StyledGfcrInputWrapper } from './subPages.styles'
-import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
 import { H2 } from '../../../../generic/text'
+import { StyledGfcrInputWrapper } from './subPages.styles'
+import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
+import language from '../../../../../language'
+import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
 
 const { gfcrIndicatorSet: gfcrIndicatorSetLanguage } = language.pages
 
@@ -27,7 +27,9 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         {...formik.getFieldProps('f2_1a')}
         onBlur={(event) => handleInputBlur(formik, event, 'f2_1a')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) =>
+          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_1a' })
+        }
         helperText={gfcrIndicatorSetLanguage.getF2_1a_helper()}
         showHelperText={displayHelp}
       />
@@ -43,7 +45,9 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         {...formik.getFieldProps('f2_1b')}
         onBlur={(event) => handleInputBlur(formik, event, 'f2_1b')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) =>
+          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_1b' })
+        }
         helperText={gfcrIndicatorSetLanguage.getF2_1b_helper()}
         showHelperText={displayHelp}
       />
@@ -59,7 +63,9 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         {...formik.getFieldProps('f2_2a')}
         onBlur={(event) => handleInputBlur(formik, event, 'f2_2a')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) =>
+          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_2a' })
+        }
         helperText={gfcrIndicatorSetLanguage.getF2_2a_helper()}
         showHelperText={displayHelp}
       />
@@ -75,7 +81,9 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         {...formik.getFieldProps('f2_2b')}
         onBlur={(event) => handleInputBlur(formik, event, 'f2_2b')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) =>
+          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_2b' })
+        }
         helperText={gfcrIndicatorSetLanguage.getF2_2b_helper()}
         showHelperText={displayHelp}
       />
@@ -91,7 +99,9 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         {...formik.getFieldProps('f2_3a')}
         onBlur={(event) => handleInputBlur(formik, event, 'f2_3a')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) =>
+          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_3a' })
+        }
         helperText={gfcrIndicatorSetLanguage.getF2_3a_helper()}
         showHelperText={displayHelp}
       />
@@ -107,7 +117,9 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         {...formik.getFieldProps('f2_3b')}
         onBlur={(event) => handleInputBlur(formik, event, 'f2_3b')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) =>
+          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_3b' })
+        }
         helperText={gfcrIndicatorSetLanguage.getF2_3b_helper()}
         showHelperText={displayHelp}
       />
@@ -123,7 +135,9 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         {...formik.getFieldProps('f2_4')}
         onBlur={(event) => handleInputBlur(formik, event, 'f2_4')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) =>
+          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_4' })
+        }
         helperText={gfcrIndicatorSetLanguage.getF2_4_helper()}
         showHelperText={displayHelp}
       />
@@ -139,7 +153,9 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         {...formik.getFieldProps('f2_5')}
         onBlur={(event) => handleInputBlur(formik, event, 'f2_5')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) =>
+          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_5' })
+        }
         helperText={gfcrIndicatorSetLanguage.getF2_5_helper()}
         showHelperText={displayHelp}
       />

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F3Form.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F3Form.js
@@ -1,14 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
+import {
+  formikHandleIntegerInputChange,
+  formikHandleNumericTwoDecimalInputChange,
+} from '../../../../../library/formikHandleInputTypes'
 import { formikPropType } from '../../../../../library/formikPropType'
-import language from '../../../../../language'
-import { enforceNumberInput } from '../../../../../library/enforceNumberInput'
-import { StyledGfcrInputWrapper, StyledGfcrSubInputWrapper } from './subPages.styles'
-import { InputRow } from '../../../../generic/form'
-import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
 import { H2 } from '../../../../generic/text'
+import { InputRow } from '../../../../generic/form'
+import { StyledGfcrInputWrapper, StyledGfcrSubInputWrapper } from './subPages.styles'
+import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
+import language from '../../../../../language'
+import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
 
 const { gfcrIndicatorSet: gfcrIndicatorSetLanguage } = language.pages
 
@@ -28,7 +31,9 @@ const F3Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
         {...formik.getFieldProps('f3_1')}
         onBlur={(event) => handleInputBlur(formik, event, 'f3_1')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) =>
+          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f3_1' })
+        }
         helperText={gfcrIndicatorSetLanguage.getF3_1_helper()}
         showHelperText={displayHelp}
       />
@@ -43,7 +48,7 @@ const F3Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
         {...formik.getFieldProps('f3_2')}
         onBlur={(event) => handleInputBlur(formik, event, 'f3_2')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) => formikHandleIntegerInputChange({ formik, event, fieldName: 'f3_2' })}
         helperText={gfcrIndicatorSetLanguage.getF3_2_helper()}
         showHelperText={displayHelp}
       />
@@ -58,7 +63,7 @@ const F3Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
         {...formik.getFieldProps('f3_3')}
         onBlur={(event) => handleInputBlur(formik, event, 'f3_3')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) => formikHandleIntegerInputChange({ formik, event, fieldName: 'f3_3' })}
         helperText={gfcrIndicatorSetLanguage.getF3_3_helper()}
         showHelperText={displayHelp}
       />
@@ -73,7 +78,7 @@ const F3Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
         {...formik.getFieldProps('f3_4')}
         onBlur={(event) => handleInputBlur(formik, event, 'f3_4')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) => formikHandleIntegerInputChange({ formik, event, fieldName: 'f3_4' })}
         helperText={gfcrIndicatorSetLanguage.getF3_4_helper()}
         showHelperText={displayHelp}
       />
@@ -89,7 +94,9 @@ const F3Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             {...formik.getFieldProps('f3_5a')}
             onBlur={(event) => handleInputBlur(formik, event, 'f3_5a')}
             onFocus={(event) => handleInputFocus(event)}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f3_5a' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF3_5_men_helper()}
             showHelperText={displayHelp}
           />
@@ -102,7 +109,9 @@ const F3Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             {...formik.getFieldProps('f3_5b')}
             onBlur={(event) => handleInputBlur(formik, event, 'f3_5b')}
             onFocus={(event) => handleInputFocus(event)}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f3_5b' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF3_5_women_helper()}
             showHelperText={displayHelp}
           />
@@ -124,7 +133,9 @@ const F3Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             type="number"
             {...formik.getFieldProps('f3_5c')}
             onBlur={(event) => handleInputBlur(formik, event, 'f3_5c')}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f3_5c' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF3_5_youth_helper()}
             showHelperText={displayHelp}
           />
@@ -136,7 +147,9 @@ const F3Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             type="number"
             {...formik.getFieldProps('f3_5d')}
             onBlur={(event) => handleInputBlur(formik, event, 'f3_5d')}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f3_5d' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF3_5_indigenous_helper()}
             showHelperText={displayHelp}
           />
@@ -155,7 +168,7 @@ const F3Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
         validationMessages={formik.errors.title}
         onBlur={(event) => handleInputBlur(formik, event, 'f3_6')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) => formikHandleIntegerInputChange({ formik, event, fieldName: 'f3_6' })}
         helperText={gfcrIndicatorSetLanguage.getF3_6_helper()}
         showHelperText={displayHelp}
       />

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F4Form.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F4Form.js
@@ -1,17 +1,17 @@
-import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
-import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
-import { formikPropType } from '../../../../../library/formikPropType'
-import language from '../../../../../language'
-import { enforceNumberInput } from '../../../../../library/enforceNumberInput'
-import { StyledGfcrInputWrapper, StyledGfcrSubInputWrapper } from './subPages.styles'
-import { InputRow } from '../../../../generic/form'
 import { ButtonPrimary } from '../../../../generic/buttons'
-import theme from '../../../../../theme'
-import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
+import { formikHandleNumericTwoDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
+import { formikPropType } from '../../../../../library/formikPropType'
 import { H2 } from '../../../../generic/text'
+import { InputRow } from '../../../../generic/form'
+import { StyledGfcrInputWrapper, StyledGfcrSubInputWrapper } from './subPages.styles'
+import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
+import language from '../../../../../language'
+import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
+import theme from '../../../../../theme'
 
 const StyledButtonPrimary = styled(ButtonPrimary)`
   width: 100%;
@@ -179,7 +179,9 @@ const F4Form = ({
           onFocus={(event) => handleInputFocus(event)}
           helperText={gfcrIndicatorSetLanguage.getF4_1_helper()}
           showHelperText={displayHelp}
-          onKeyDown={(event) => enforceNumberInput(event)}
+          onChange={(event) =>
+            formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f4_1' })
+          }
         />
         {isReport && <StyledValueUpdateText>{f41ValueUpdateText}</StyledValueUpdateText>}
       </StyledInputRowQuestions>
@@ -198,7 +200,9 @@ const F4Form = ({
           onFocus={(event) => handleInputFocus(event)}
           helperText={gfcrIndicatorSetLanguage.getF4_2_helper()}
           showHelperText={displayHelp}
-          onKeyDown={(event) => enforceNumberInput(event)}
+          onChange={(event) =>
+            formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f4_2' })
+          }
         />
         {isReport && <StyledValueUpdateText>{f42ValueUpdateText}</StyledValueUpdateText>}
       </StyledInputRowQuestions>
@@ -217,7 +221,9 @@ const F4Form = ({
           onFocus={(event) => handleInputFocus(event)}
           helperText={gfcrIndicatorSetLanguage.getF4_3_helper()}
           showHelperText={displayHelp}
-          onKeyDown={(event) => enforceNumberInput(event)}
+          onChange={(event) =>
+            formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f4_3' })
+          }
         />
         {isReport && <StyledValueUpdateText>{f43ValueUpdateText}</StyledValueUpdateText>}
       </StyledInputRowQuestions>

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F5Form.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F5Form.js
@@ -1,14 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
+import { formikHandleIntegerInputChange } from '../../../../../library/formikHandleInputTypes'
 import { formikPropType } from '../../../../../library/formikPropType'
-import language from '../../../../../language'
-import { enforceNumberInput } from '../../../../../library/enforceNumberInput'
-import { StyledGfcrInputWrapper, StyledGfcrSubInputWrapper } from './subPages.styles'
-import { InputRow } from '../../../../generic/form'
-import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
 import { H2 } from '../../../../generic/text'
+import { InputRow } from '../../../../generic/form'
+import { StyledGfcrInputWrapper, StyledGfcrSubInputWrapper } from './subPages.styles'
+import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
+import language from '../../../../../language'
+import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
 
 const { gfcrIndicatorSet: gfcrIndicatorSetLanguage } = language.pages
 
@@ -27,7 +27,7 @@ const F5Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
         {...formik.getFieldProps('f5_1')}
         onBlur={(event) => handleInputBlur(formik, event, 'f5_1')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) => formikHandleIntegerInputChange({ formik, event, fieldName: 'f5_1' })}
         helperText={gfcrIndicatorSetLanguage.getF5_1_helper()}
         showHelperText={displayHelp}
       />
@@ -42,7 +42,7 @@ const F5Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
         {...formik.getFieldProps('f5_2')}
         onBlur={(event) => handleInputBlur(formik, event, 'f5_2')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) => formikHandleIntegerInputChange({ formik, event, fieldName: 'f5_2' })}
         helperText={gfcrIndicatorSetLanguage.getF5_2_helper()}
         showHelperText={displayHelp}
       />
@@ -57,7 +57,7 @@ const F5Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
         {...formik.getFieldProps('f5_3')}
         onBlur={(event) => handleInputBlur(formik, event, 'f5_3')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) => formikHandleIntegerInputChange({ formik, event, fieldName: 'f5_3' })}
         helperText={gfcrIndicatorSetLanguage.getF5_3_helper()}
         showHelperText={displayHelp}
       />
@@ -73,7 +73,9 @@ const F5Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             {...formik.getFieldProps('f5_4a')}
             onBlur={(event) => handleInputBlur(formik, event, 'f5_4a')}
             onFocus={(event) => handleInputFocus(event)}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f5_4a' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF5_4_men_helper()}
             showHelperText={displayHelp}
           />
@@ -86,7 +88,9 @@ const F5Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             {...formik.getFieldProps('f5_4b')}
             onBlur={(event) => handleInputBlur(formik, event, 'f5_4b')}
             onFocus={(event) => handleInputFocus(event)}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f5_4b' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF5_4_women_helper()}
             showHelperText={displayHelp}
           />
@@ -108,7 +112,9 @@ const F5Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             type="number"
             {...formik.getFieldProps('f5_4c')}
             onBlur={(event) => handleInputBlur(formik, event, 'f5_4c')}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f5_4c' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF5_4_youth_helper()}
             showHelperText={displayHelp}
           />
@@ -120,7 +126,9 @@ const F5Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             type="number"
             {...formik.getFieldProps('f5_4d')}
             onBlur={(event) => handleInputBlur(formik, event, 'f5_4d')}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f5_4d' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF5_4_indigenous_helper()}
             showHelperText={displayHelp}
           />
@@ -139,7 +147,7 @@ const F5Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
         validationMessages={formik.errors.title}
         onBlur={(event) => handleInputBlur(formik, event, 'f5_5')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) => formikHandleIntegerInputChange({ formik, event, fieldName: 'f5_5' })}
         helperText={gfcrIndicatorSetLanguage.getF5_5_helper()}
         showHelperText={displayHelp}
       />
@@ -156,7 +164,7 @@ const F5Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
         validationMessages={formik.errors.title}
         onBlur={(event) => handleInputBlur(formik, event, 'f5_6')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) => formikHandleIntegerInputChange({ formik, event, fieldName: 'f5_6' })}
         helperText={gfcrIndicatorSetLanguage.getF5_6_helper()}
         showHelperText={displayHelp}
       />

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F6Form.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F6Form.js
@@ -1,14 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
+import { formikHandleIntegerInputChange } from '../../../../../library/formikHandleInputTypes'
 import { formikPropType } from '../../../../../library/formikPropType'
-import language from '../../../../../language'
-import { enforceNumberInput } from '../../../../../library/enforceNumberInput'
-import { StyledGfcrInputWrapper, StyledGfcrSubInputWrapper } from './subPages.styles'
-import { InputRow } from '../../../../generic/form'
-import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
 import { H2 } from '../../../../generic/text'
+import { InputRow } from '../../../../generic/form'
+import { StyledGfcrInputWrapper, StyledGfcrSubInputWrapper } from './subPages.styles'
+import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
+import language from '../../../../../language'
+import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
 
 const { gfcrIndicatorSet: gfcrIndicatorSetLanguage } = language.pages
 
@@ -28,7 +28,9 @@ const F6Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             {...formik.getFieldProps('f6_1a')}
             onBlur={(event) => handleInputBlur(formik, event, 'f6_1a')}
             onFocus={(event) => handleInputFocus(event)}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f6_1a' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF6_1_men_helper()}
             showHelperText={displayHelp}
           />
@@ -41,7 +43,9 @@ const F6Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             {...formik.getFieldProps('f6_1b')}
             onBlur={(event) => handleInputBlur(formik, event, 'f6_1b')}
             onFocus={(event) => handleInputFocus(event)}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f6_1b' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF6_1_women_helper()}
             showHelperText={displayHelp}
           />
@@ -63,7 +67,9 @@ const F6Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             type="number"
             {...formik.getFieldProps('f6_1c')}
             onBlur={(event) => handleInputBlur(formik, event, 'f6_1c')}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f6_1c' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF6_1_youth_helper()}
             showHelperText={displayHelp}
           />
@@ -75,7 +81,9 @@ const F6Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             type="number"
             {...formik.getFieldProps('f6_1d')}
             onBlur={(event) => handleInputBlur(formik, event, 'f6_1d')}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f6_1d' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF6_1_indigenous_helper()}
             showHelperText={displayHelp}
           />

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F7Form.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F7Form.js
@@ -1,14 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
+import { formikHandleIntegerInputChange } from '../../../../../library/formikHandleInputTypes'
 import { formikPropType } from '../../../../../library/formikPropType'
-import language from '../../../../../language'
-import { enforceNumberInput } from '../../../../../library/enforceNumberInput'
-import { StyledGfcrInputWrapper, StyledGfcrSubInputWrapper } from './subPages.styles'
-import { InputRow } from '../../../../generic/form'
-import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
 import { H2 } from '../../../../generic/text'
+import { InputRow } from '../../../../generic/form'
+import { StyledGfcrInputWrapper, StyledGfcrSubInputWrapper } from './subPages.styles'
+import InputWithLabelAndValidation from '../../../../mermaidInputs/InputWithLabelAndValidation'
+import language from '../../../../../language'
+import TextareaWithLabelAndValidation from '../../../../mermaidInputs/TextareaWithLabelAndValidation'
 
 const { gfcrIndicatorSet: gfcrIndicatorSetLanguage } = language.pages
 
@@ -28,7 +28,9 @@ const F7Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             {...formik.getFieldProps('f7_1a')}
             onBlur={(event) => handleInputBlur(formik, event, 'f7_1a')}
             onFocus={(event) => handleInputFocus(event)}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f7_1a' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF7_1_men_helper()}
             showHelperText={displayHelp}
           />
@@ -40,7 +42,9 @@ const F7Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             type="number"
             {...formik.getFieldProps('f7_1b')}
             onBlur={(event) => handleInputBlur(formik, event, 'f7_1b')}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f7_1b' })
+            }
             onFocus={(event) => handleInputFocus(event)}
             helperText={gfcrIndicatorSetLanguage.getF7_1_women_helper()}
             showHelperText={displayHelp}
@@ -63,7 +67,9 @@ const F7Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             type="number"
             {...formik.getFieldProps('f7_1c')}
             onBlur={(event) => handleInputBlur(formik, event, 'f7_1c')}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f7_1c' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF7_1_youth_helper()}
             showHelperText={displayHelp}
           />
@@ -75,7 +81,9 @@ const F7Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             type="number"
             {...formik.getFieldProps('f7_1d')}
             onBlur={(event) => handleInputBlur(formik, event, 'f7_1d')}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f7_1d' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF7_1_indigenous_helper()}
             showHelperText={displayHelp}
           />
@@ -93,7 +101,9 @@ const F7Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             {...formik.getFieldProps('f7_2a')}
             onBlur={(event) => handleInputBlur(formik, event, 'f7_2a')}
             onFocus={(event) => handleInputFocus(event)}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f7_2a' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF7_2_men_helper()}
             showHelperText={displayHelp}
           />
@@ -106,7 +116,9 @@ const F7Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             {...formik.getFieldProps('f7_2b')}
             onBlur={(event) => handleInputBlur(formik, event, 'f7_2b')}
             onFocus={(event) => handleInputFocus(event)}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f7_2b' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF7_2_women_helper()}
             showHelperText={displayHelp}
           />
@@ -128,7 +140,9 @@ const F7Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             type="number"
             {...formik.getFieldProps('f7_2c')}
             onBlur={(event) => handleInputBlur(formik, event, 'f7_2c')}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f7_2c' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF7_2_youth_helper()}
             showHelperText={displayHelp}
           />
@@ -140,7 +154,9 @@ const F7Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
             type="number"
             {...formik.getFieldProps('f7_2d')}
             onBlur={(event) => handleInputBlur(formik, event, 'f7_2d')}
-            onKeyDown={(event) => enforceNumberInput(event)}
+            onChange={(event) =>
+              formikHandleIntegerInputChange({ formik, event, fieldName: 'f7_2d' })
+            }
             helperText={gfcrIndicatorSetLanguage.getF7_2_indigenous_helper()}
             showHelperText={displayHelp}
           />
@@ -157,7 +173,7 @@ const F7Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
         {...formik.getFieldProps('f7_3')}
         onBlur={(event) => handleInputBlur(formik, event, 'f7_3')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) => formikHandleIntegerInputChange({ formik, event, fieldName: 'f7_3' })}
         helperText={gfcrIndicatorSetLanguage.getF7_3_helper()}
         showHelperText={displayHelp}
       />
@@ -172,7 +188,7 @@ const F7Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
         {...formik.getFieldProps('f7_4')}
         onBlur={(event) => handleInputBlur(formik, event, 'f7_4')}
         onFocus={(event) => handleInputFocus(event)}
-        onKeyDown={(event) => enforceNumberInput(event)}
+        onChange={(event) => formikHandleIntegerInputChange({ formik, event, fieldName: 'f7_4' })}
         helperText={gfcrIndicatorSetLanguage.getF7_4_helper()}
         showHelperText={displayHelp}
       />

--- a/src/library/formikHandleInputTypes.js
+++ b/src/library/formikHandleInputTypes.js
@@ -1,0 +1,33 @@
+export const formikHandleNumericTwoDecimalInputChange = ({ formik, event, fieldName }) => {
+  const originalInputValue = event.target.value
+  const isNumericOrEmpty = !Number.isNaN(Number(originalInputValue))
+  const indexOfDecimal = originalInputValue.indexOf('.')
+  const hasDecimal = indexOfDecimal !== -1
+  const hasMoreThanTwoDecimals =
+    hasDecimal && originalInputValue.slice(indexOfDecimal + 1).length > 2
+
+  if (isNumericOrEmpty && hasMoreThanTwoDecimals) {
+    const truncatedValue = Math.trunc(Number(originalInputValue) * 100) / 100
+    const modifiedInputValue = truncatedValue.toFixed(2)
+
+    formik.setFieldValue(fieldName, modifiedInputValue)
+  }
+  if (isNumericOrEmpty && !hasMoreThanTwoDecimals) {
+    formik.setFieldValue(fieldName, originalInputValue)
+  }
+}
+
+export const formikHandleIntegerInputChange = ({ formik, event, fieldName }) => {
+  const originalInputValue = event.target.value
+  const isNumericOrEmpty = !Number.isNaN(Number(originalInputValue))
+  const indexOfDecimal = originalInputValue.indexOf('.')
+  const hasDecimal = indexOfDecimal !== -1
+
+  if (isNumericOrEmpty && !hasDecimal) {
+    formik.setFieldValue(fieldName, originalInputValue)
+  }
+  if (isNumericOrEmpty && hasDecimal) {
+    const integerValue = originalInputValue.slice(0, indexOfDecimal)
+    formik.setFieldValue(fieldName, integerValue)
+  }
+}


### PR DESCRIPTION
[Ticket](https://trello.com/c/kAiwut7d/1233-look-at-gfcr-investment-amount-native-validation-and-consider-native-non-client-validation-generally)

Steps to test:
- go through GFCR forms. 
- integer inputs should only allow integer values (sometimes there is a trailing decimal place if the user types one, but the API removes it)
- decimal inputs should only allow 2 decimal places
- make sure to check the modals for f8-10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced numeric input fields across forms and modals to support two-decimal precision and improved integer validation.
- **Refactor**
  - Streamlined event handling for form inputs to provide more immediate feedback and a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->