### PR TITLE
M1286 show API form errors in error toast for GFCR

### DIFF
--- a/src/components/generic/miscellaneous.js
+++ b/src/components/generic/miscellaneous.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components'
+
+import theme from '../../theme'
+
+export const Figure = styled.figure`
+  all: unset;
+  & figcaption {
+    font-weight: bold;
+    margin-bottom: ${theme.spacing.small};
+  }
+`
+export const Dl = styled.dl`
+  all: unset;
+  & dt {
+    margin-top: ${theme.spacing.medium};
+    font-weight: bold;
+  }
+  & dt:first-child {
+    margin-top: 0;
+  }
+  & dd {
+    margin-left: ${theme.spacing.medium};
+  }
+`

--- a/src/components/pages/ProjectInfo/EditCitationModal.styles.js
+++ b/src/components/pages/ProjectInfo/EditCitationModal.styles.js
@@ -2,6 +2,7 @@ import styled, { css } from 'styled-components'
 
 import { MODAL_CONTENT_HEIGHT } from '../../generic/Modal/Modal'
 import theme from '../../../theme'
+import { Dl } from '../../generic/miscellaneous'
 
 const citationLabelStyles = css`
   display: block;
@@ -25,17 +26,9 @@ export const ProjectInfoWrapper = styled.div`
   overflow-y: auto;
 `
 
-export const CitationDefinitionList = styled.dl`
-  all: unset;
-  & > dt {
-    font-weight: bold;
-    margin-top: ${theme.spacing.medium};
-  }
-  & > dt:first-child {
-    margin-top: 0;
-  }
+export const CitationDefinitionList = styled(Dl)`
   & > dd {
-    all: unset;
+    margin-left: 0;
   }
 `
 export const CitationModalColumn = styled.div`

--- a/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { toast } from 'react-toastify'
+import { Slide, toast } from 'react-toastify'
 import { useFormik } from 'formik'
 import { useParams, useNavigate } from 'react-router-dom'
 
@@ -31,10 +31,12 @@ import PageUnavailable from '../../PageUnavailable'
 import IdsNotFound from '../../IdsNotFound/IdsNotFound'
 import { ButtonSecondary } from '../../../generic/buttons'
 import { IconInfo } from '../../../icons'
+import { Dl, Figure } from '../../../generic/miscellaneous'
+import { P } from '../../../generic/text'
 
 const ButtonContainer = styled.div`
-  display: 'flex';
-  justify-content: 'right';
+  display: flex;
+  justify-content: right;
 `
 
 const HelpButton = styled(ButtonSecondary)`
@@ -65,6 +67,12 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
   const indicatorSetTypeName = indicatorSetType === 'report' ? 'Report' : 'Target'
 
   const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
+
+  useEffect(function closeToastsWhenLeavingPage() {
+    return () => {
+      toast.dismiss()
+    }
+  }, [])
 
   const _getSupportingData = useEffect(() => {
     if (!isAppOnline) {
@@ -166,7 +174,30 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
         setSaveButtonState(buttonGroupStates.unsaved)
 
         if (error && isAppOnline) {
-          toast.error(...getToastArguments(language.error.gfcrIndicatorSetSave))
+          const questionErrors = Object.entries(error.response.data)
+
+          const errorMarkup = (
+            <>
+              <P>{language.error.gfcrIndicatorSetSave}</P>
+              <Figure>
+                <figcaption>Form errors: </figcaption>
+                <Dl>
+                  {questionErrors.map(([key, value]) => (
+                    <div key={key}>
+                      <dt>{key.replace('f', 'F ').replace('_', '.')}</dt>
+                      <dd>{value}</dd>
+                    </div>
+                  ))}
+                </Dl>
+              </Figure>
+            </>
+          )
+
+          toast.dismiss()
+          toast.error(errorMarkup, {
+            transition: Slide,
+            autoClose: questionErrors.length ? false : 5000,
+          })
 
           handleHttpResponseError({
             error,

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F6Form.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F6Form.js
@@ -103,7 +103,7 @@ F6Form.propTypes = {
   handleInputBlur: PropTypes.func.isRequired,
   handleInputFocus: PropTypes.func.isRequired,
   getFieldValueTotal: PropTypes.func.isRequired,
-  displayHelp: PropTypes.string,
+  displayHelp: PropTypes.bool,
 }
 
 export default F6Form


### PR DESCRIPTION
[Ticket](https://trello.com/c/6o1G4Iv0/1286-dig-into-where-api-error-toast-messages-went-for-gfcr)

steps to test:
- in a GFCR report, enter giant numbers in multiple fields (eg 57238957238578239758375823758923)
- click save => there should now be form error info in the toast showing multiple errors for each questions with errors

<img width="870" alt="Screenshot 2025-02-14 at 12 03 56 PM" src="https://github.com/user-attachments/assets/61d6b464-020b-48d0-b83c-377e3952bb05" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error notifications now include smooth transition effects and detailed error summaries for improved user feedback.
  
- **Style**
  - Introduced refined styling for media displays and information lists, featuring improved spacing and typography for a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->