### PR TITLE
M1259 prevent super long project names from overflowing in notification dropdown

### DIFF
--- a/src/components/BellNotificationDropDown/BellNotificationDropDown.styles.js
+++ b/src/components/BellNotificationDropDown/BellNotificationDropDown.styles.js
@@ -45,7 +45,11 @@ export const NotificationActualDate = styled('p')`
 `
 export const NotificationTimeAgoDate = styled('p')``
 export const NotificationCloseButton = styled(CloseButton)``
-export const NotificationContent = styled('div')``
+export const NotificationContent = styled('div')`
+  word-wrap: break-word;
+  word-break: break-word; /* Ensure words break */
+  overflow-wrap: break-word; /* Ensure words wrap */
+`
 
 const getNotificationStatusColor = (props) => {
   const statusColors = {


### PR DESCRIPTION
Make sure notification card doesnt have overflowing text

[ticket](https://trello.com/c/Tm4p3cSX/1259-prevent-notification-text-overflow)

Steps top test:
- edit a project with notifications to have a super long project name (add or remove users to create notifications)
- open the notifications drop down => there should be no overflowing text
<img width="870" alt="Screenshot 2025-02-14 at 3 30 49 PM" src="https://github.com/user-attachments/assets/96be8b2b-7a4d-4b64-8afc-ee5ed923ee07" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the notification layout to ensure that long text wraps properly for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->