### PR TITLE
M377 use dashes for empty but required values in specified tables

### DIFF
--- a/src/components/pages/Collect/Collect.js
+++ b/src/components/pages/Collect/Collect.js
@@ -47,6 +47,7 @@ import { getIsUserReadOnlyForProject } from '../../../App/currentUserProfileHelp
 import { PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
 import { RECORD_STATUS_LABELS } from './collectConstants'
 import { TrCollectRecordStatus } from './Collect.styles'
+import { getIsEmptyStringOrWhitespace } from '../../../library/getIsEmptyStringOrWhitespace'
 
 const Collect = () => {
   const [collectRecordsForUiDisplay, setCollectRecordsForUiDisplay] = useState([])
@@ -349,9 +350,16 @@ const Collect = () => {
                   $recordStatusLabel={row.values.status}
                 >
                   {row.cells.map((cell) => {
+                    const isCellEmpty =
+                      cell.value === undefined ||
+                      cell.value === null ||
+                      getIsEmptyStringOrWhitespace(cell.value)
+
+                    const cellContents = isCellEmpty ? '-' : cell.render('Cell')
+
                     return (
                       <Td {...cell.getCellProps()} align={cell.column.align} key={cell.column.id}>
-                        {cell.render('Cell')}
+                        {cellContents}
                       </Td>
                     )
                   })}

--- a/src/components/pages/ManagementRegimesOverview/ManagementRegimesOverview.js
+++ b/src/components/pages/ManagementRegimesOverview/ManagementRegimesOverview.js
@@ -40,6 +40,7 @@ import { PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
 import MethodsFilterDropDown from '../../MethodsFilterDropDown/MethodsFilterDropDown'
 import FilterIndicatorPill from '../../generic/FilterIndicatorPill/FilterIndicatorPill'
 import useDocumentTitle from '../../../library/useDocumentTitle'
+import { getIsEmptyStringOrWhitespace } from '../../../library/getIsEmptyStringOrWhitespace'
 
 const groupManagementRegimes = (records) => {
   return records.reduce((accumulator, record) => {
@@ -172,7 +173,7 @@ const ManagementRegimesOverview = () => {
 
       const rowRecordManagementRegimes = managementRegimeRecordNames.reduce(
         (accumulator, record) => {
-          accumulator[record.id] = rowRecordManagementRegimesWithoutNonEmptyValues[record.id] || '-'
+          accumulator[record.id] = rowRecordManagementRegimesWithoutNonEmptyValues[record.id] || ''
 
           return accumulator
         },
@@ -365,7 +366,10 @@ const ManagementRegimesOverview = () => {
                 )
               })
               const mrTransectNumberRowCellsWithNonEmptyValue = mrTransectNumberRowCells.filter(
-                (cell) => cell.value !== '-',
+                (cell) =>
+                  cell.value !== undefined &&
+                  cell.value !== null &&
+                  !getIsEmptyStringOrWhitespace(cell.value),
               )
 
               const mrTransectNumberRowCellValues = mrTransectNumberRowCellsWithNonEmptyValue?.map(
@@ -392,7 +396,10 @@ const ManagementRegimesOverview = () => {
                       cellColumnGroupId === 'first-transect-header'
 
                     const managementRegimeCellNonEmpty =
-                      cell.value !== '-' && !areSiteOrMethodOrEmptyHeaderColumns
+                      cell.value !== undefined &&
+                      cell.value !== null &&
+                      !getIsEmptyStringOrWhitespace(cell.value) &&
+                      !areSiteOrMethodOrEmptyHeaderColumns
 
                     const isCellValueLessThanMaxSampleUnitCount =
                       managementRegimeCellNonEmpty &&

--- a/src/components/pages/UsersAndTransects/UsersAndTransects.js
+++ b/src/components/pages/UsersAndTransects/UsersAndTransects.js
@@ -46,8 +46,9 @@ import { PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
 import MethodsFilterDropDown from '../../MethodsFilterDropDown/MethodsFilterDropDown'
 import FilterIndicatorPill from '../../generic/FilterIndicatorPill/FilterIndicatorPill'
 import useDocumentTitle from '../../../library/useDocumentTitle'
+import { getIsEmptyStringOrWhitespace } from '../../../library/getIsEmptyStringOrWhitespace'
 
-const EMPTY_VALUE = '-'
+const EMPTY_TABLE_CELL_VALUE = '-'
 
 const UserColumnHeader = styled.span`
   display: flex;
@@ -248,7 +249,7 @@ const UsersAndTransects = () => {
 
       const submittedTransectNumbersRow = submittedTransectNumbers.reduce((accumulator, number) => {
         if (!accumulator[number]) {
-          accumulator[number] = EMPTY_VALUE
+          accumulator[number] = EMPTY_TABLE_CELL_VALUE
         }
 
         if (rowNumbers.includes(number)) {
@@ -284,7 +285,7 @@ const UsersAndTransects = () => {
               recordProfileSummary={rowRecord.profile_summary[record.profileId]}
             />
           ) : (
-            EMPTY_VALUE
+            EMPTY_TABLE_CELL_VALUE
           )
 
           return accumulator
@@ -442,7 +443,7 @@ const UsersAndTransects = () => {
 
     return userTableCellData.reduce((accumulator, userCollectRecord) => {
       const collectRecordCount =
-        userCollectRecord !== '-'
+        userCollectRecord !== EMPTY_TABLE_CELL_VALUE
           ? userCollectRecord.props.recordProfileSummary.collect_records.length
           : 0
 
@@ -558,29 +559,43 @@ const UsersAndTransects = () => {
 
                     const filteredEmptyCellValuesLength =
                       cellRowValuesForSubmittedTransectNumbers.filter(
-                        (value) => value[1] === EMPTY_VALUE,
+                        (value) => value[1] === EMPTY_TABLE_CELL_VALUE,
                       ).length
 
                     const isNotRowWithAllEmptyCellValues =
                       filteredEmptyCellValuesLength < submittedTransectNumbers.length
 
                     const isSubmittedNumberCellHightLighted =
-                      cell.value === EMPTY_VALUE &&
+                      cell.value === EMPTY_TABLE_CELL_VALUE &&
                       isNotBleachingMethodRow &&
                       isNotRowWithAllEmptyCellValues &&
                       isCellInSubmittedTransectNumberColumns
 
                     const isCollectingNumberCellHighLighted =
-                      cell.value !== EMPTY_VALUE &&
+                      cell.value !== EMPTY_TABLE_CELL_VALUE &&
                       !isCellInSubmittedTransectNumberColumns &&
                       !areSiteOrMethodOrEmptyHeaderColumns
 
                     const cellAlignment = areSiteOrMethodOrEmptyHeaderColumns ? 'left' : 'right'
 
-                    const cellClassName =
+                    const isCellHighlighted =
                       isSubmittedNumberCellHightLighted || isCollectingNumberCellHighLighted
-                        ? `${cellColumnGroupId} highlighted`
-                        : cellColumnGroupId
+
+                    const cellClassName = isCellHighlighted
+                      ? `${cellColumnGroupId} highlighted`
+                      : cellColumnGroupId
+
+                    const isCellEmpty =
+                      cell.value === EMPTY_TABLE_CELL_VALUE ||
+                      cell.value === null ||
+                      cell.value === undefined ||
+                      getIsEmptyStringOrWhitespace(cell.value)
+
+                    const emptyCellContents = isCellHighlighted ? EMPTY_TABLE_CELL_VALUE : null
+
+                    const cellContents = (
+                      <>{isCellEmpty ? emptyCellContents : cell.render('Cell')} </>
+                    )
 
                     return (
                       <OverviewTd
@@ -590,7 +605,7 @@ const UsersAndTransects = () => {
                         className={cellClassName}
                       >
                         <span>
-                          {cell.render('Cell')}{' '}
+                          {cellContents}
                           {isSubmittedNumberCellHightLighted && (
                             <EmptySampleUnitPopup
                               tableCellData={cell}

--- a/src/library/getIsEmptyStringOrWhitespace.js
+++ b/src/library/getIsEmptyStringOrWhitespace.js
@@ -1,0 +1,7 @@
+export const getIsEmptyStringOrWhitespace = (value) => {
+  if (typeof value !== 'string') {
+    return false
+  }
+
+  return value.trim() === ''
+}

--- a/src/library/getIsEmptyStringOrWhitespace.test.js
+++ b/src/library/getIsEmptyStringOrWhitespace.test.js
@@ -1,0 +1,83 @@
+import { getIsEmptyStringOrWhitespace } from './getIsEmptyStringOrWhitespace'
+
+test('getIsEmptyStringOrWhitespace on empty string', () => {
+  expect(getIsEmptyStringOrWhitespace('')).toBe(true)
+})
+test('getIsEmptyStringOrWhitespace on string with whitespace', () => {
+  expect(getIsEmptyStringOrWhitespace('    ')).toBe(true)
+})
+test('getIsEmptyStringOrWhitespace on string with content', () => {
+  expect(getIsEmptyStringOrWhitespace('hello')).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on number', () => {
+  expect(getIsEmptyStringOrWhitespace(0)).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on empty array', () => {
+  expect(getIsEmptyStringOrWhitespace([])).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on array with content', () => {
+  expect(getIsEmptyStringOrWhitespace([1, 2, 3])).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on empty object', () => {
+  expect(getIsEmptyStringOrWhitespace({})).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on object with content', () => {
+  expect(getIsEmptyStringOrWhitespace({ key: 'value' })).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on null', () => {
+  expect(getIsEmptyStringOrWhitespace(null)).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on undefined', () => {
+  expect(getIsEmptyStringOrWhitespace(undefined)).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on boolean', () => {
+  expect(getIsEmptyStringOrWhitespace(false)).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on function', () => {
+  expect(getIsEmptyStringOrWhitespace(() => {})).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on Infinity', () => {
+  expect(getIsEmptyStringOrWhitespace(Infinity)).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on Map', () => {
+  expect(getIsEmptyStringOrWhitespace(new Map())).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on Symbol', () => {
+  expect(getIsEmptyStringOrWhitespace(Symbol('symbol'))).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on empty Set', () => {
+  expect(getIsEmptyStringOrWhitespace(new Set())).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on Set with content', () => {
+  expect(getIsEmptyStringOrWhitespace(new Set([1, 2, 3]))).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on Date', () => {
+  expect(getIsEmptyStringOrWhitespace(new Date())).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on RegExp', () => {
+  expect(getIsEmptyStringOrWhitespace(/regex/)).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on TypedArray', () => {
+  expect(getIsEmptyStringOrWhitespace(new Uint8Array())).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on Buffer', () => {
+  expect(getIsEmptyStringOrWhitespace(Buffer.from(''))).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on NaN', () => {
+  expect(getIsEmptyStringOrWhitespace(NaN)).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on ArrayBuffer', () => {
+  expect(getIsEmptyStringOrWhitespace(new ArrayBuffer())).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on DataView', () => {
+  expect(getIsEmptyStringOrWhitespace(new DataView(new ArrayBuffer()))).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on Date object', () => {
+  expect(getIsEmptyStringOrWhitespace(new Date())).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on Error object', () => {
+  expect(getIsEmptyStringOrWhitespace(new Error())).toBe(false)
+})
+test('getIsEmptyStringOrWhitespace on Promise object', () => {
+  expect(getIsEmptyStringOrWhitespace(Promise.resolve())).toBe(false)
+})


### PR DESCRIPTION
[Ticket](https://trello.com/c/8fJnGx7i/377-make-use-of-dash-consistent)

To test check that:
- empty values in collect record table have dashes (click on 'collecting' in side nav)
- empty values in observers and transects page (click on same name in side nav to view) show dashes, but only if they have a yellow background
- no empty values in management regimes overview page (click on same name in side nav to view) have dashes. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved table display logic to consistently handle empty or whitespace-only values by showing a designated placeholder or empty value across key pages.
  
- **Tests**
  - Introduced comprehensive tests to ensure robust detection of empty content across various data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->