### PR TITLE
M406 fix user icon displaying image, then initials, and finally a fallback icon.

### DIFF
--- a/src/App/currentUserProfileHelpers.test.js
+++ b/src/App/currentUserProfileHelpers.test.js
@@ -21,9 +21,9 @@ test('getCurrentUserProfile online returns data from the API', async () => {
 
   expect(userProfile).toEqual({
     id: 'fake-id',
-    first_name: 'FakeFirstNameOnline',
-    last_name: 'FakeLastNameOnline',
-    full_name: 'FakeFirstNameOnline FakeLastNameOnline',
+    first_name: 'W-FakeFirstNameOnline',
+    last_name: 'W-FakeLastNameOnline',
+    full_name: 'W-FakeFirstNameOnline W-FakeLastNameOnline',
   })
 })
 test('getCurrentUserProfile online returns error message upon API error', async () => {

--- a/src/App/integrationTests/App.authentication1.test.js
+++ b/src/App/integrationTests/App.authentication1.test.js
@@ -23,7 +23,7 @@ test('App renders the initial screen as expected for an online and authenticated
 
   expect(await screen.findByText('Projects', { selector: 'h1' }))
 
-  fireEvent.click(screen.getByText('FakeFirstNameOnline'))
+  fireEvent.click(screen.getByText('WW')) // user icon initials for online user
 
   // there is a logout button
   expect(screen.getByText('Logout'))
@@ -37,7 +37,7 @@ test('App: an online and authenticated user can logout', async () => {
     dexiePerUserDataInstance,
   })
 
-  fireEvent.click(await screen.findByText('FakeFirstNameOnline'))
+  fireEvent.click(await screen.findByText('WW')) // user icon initials for online user
   fireEvent.click(screen.getByText('Logout'))
   await waitFor(() =>
     expect(screen.queryByRole('heading', { name: 'Projects' })).not.toBeInTheDocument(),

--- a/src/App/integrationTests/App.authentication2.test.js
+++ b/src/App/integrationTests/App.authentication2.test.js
@@ -25,7 +25,7 @@ test('App renders the initial screen as expected for an offline user who is auth
 
   expect(await screen.findByText('Projects', { selector: 'h1' }))
 
-  fireEvent.click(screen.getByText('FakeFirstNameOffline'))
+  fireEvent.click(screen.getByText('FF')) // user icon initials for offline user
 
   // there is not a logout button
 

--- a/src/App/integrationTests/App.userProfile.test.js
+++ b/src/App/integrationTests/App.userProfile.test.js
@@ -21,9 +21,9 @@ test('App renders shows the users name from the API for an online and authentica
   // wait for page to load in lieu of being able to test for a loading indicator to have vanished
   expect(await screen.findByText('Projects', { selector: 'h1' }))
 
-  await waitFor(() => expect(screen.queryByText('FakeFirstNameOffline')).not.toBeInTheDocument())
+  await waitFor(() => expect(screen.queryByText('FF')).not.toBeInTheDocument()) // user icon initials for offline user
 
-  expect(await screen.findByText('FakeFirstNameOnline'))
+  expect(await screen.findByText('WW')) // user icon initials for online user
 })
 
 test('App renders shows the users name from offline storage for an offline user who is authenticated when online', async () => {
@@ -40,6 +40,6 @@ test('App renders shows the users name from offline storage for an offline user 
       selector: 'h1',
     }),
   )
-  await waitFor(() => expect(screen.queryByText('FakeFirstNameOnline')).not.toBeInTheDocument())
-  expect(await screen.findByText('FakeFirstNameOffline'))
+  await waitFor(() => expect(screen.queryByText('WW')).not.toBeInTheDocument()) // user icon initials for online user
+  expect(await screen.findByText('FF')) // user icon initials for offline user
 })

--- a/src/App/integrationTests/collectRecords/benthicLit/App.NewBenthicAttributeBenthicLit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicLit/App.NewBenthicAttributeBenthicLit.test.js
@@ -97,7 +97,7 @@ test('Benthic LIT observations add new benthic attribute - filling out new attri
   const userNameElement = within(modal).getByLabelText('User')
   const projectNameElement = within(modal).getByLabelText('Project')
 
-  expect(within(userNameElement).getByText('FakeFirstNameOnline FakeLastNameOnline'))
+  expect(within(userNameElement).getByText('W-FakeFirstNameOnline W-FakeLastNameOnline'))
   expect(within(projectNameElement).getByText('Project V'))
   expect(within(benthicAttributeElement).getByText('Dead Coral with Algae unicorn'))
 

--- a/src/App/integrationTests/collectRecords/benthicPit/App.NewBenthicAttributeBenthicPit.test.js
+++ b/src/App/integrationTests/collectRecords/benthicPit/App.NewBenthicAttributeBenthicPit.test.js
@@ -97,7 +97,7 @@ test('Benthic PIT observations add new benthic attribute - filling out new attri
   const userNameElement = within(modal).getByLabelText('User')
   const projectNameElement = within(modal).getByLabelText('Project')
 
-  expect(within(userNameElement).getByText('FakeFirstNameOnline FakeLastNameOnline'))
+  expect(within(userNameElement).getByText('W-FakeFirstNameOnline W-FakeLastNameOnline'))
   expect(within(projectNameElement).getByText('Project V'))
   expect(within(benthicAttributeElement).getByText('Dead Coral with Algae unicorn'))
 

--- a/src/App/integrationTests/collectRecords/bleaching/App.NewBenthicAttributeBleaching.test.js
+++ b/src/App/integrationTests/collectRecords/bleaching/App.NewBenthicAttributeBleaching.test.js
@@ -97,7 +97,7 @@ test('Bleaching collect record observations add new benthic attribute - filling 
   const userNameElement = within(modal).getByLabelText('User')
   const projectNameElement = within(modal).getByLabelText('Project')
 
-  expect(within(userNameElement).getByText('FakeFirstNameOnline FakeLastNameOnline'))
+  expect(within(userNameElement).getByText('W-FakeFirstNameOnline W-FakeLastNameOnline'))
   expect(within(projectNameElement).getByText('Project V'))
   expect(within(benthicAttributeElement).getByText('Dead Coral with Algae unicorn'))
 

--- a/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltNewSpecies.test.js
+++ b/src/App/integrationTests/collectRecords/fishBelt/App.fishBeltNewSpecies.test.js
@@ -97,7 +97,7 @@ test('Fishbelt observations add new species - filling out new species form adds 
   const userNameElement = within(modal).getByLabelText('User')
   const projectNameElement = within(modal).getByLabelText('Project')
 
-  expect(within(userNameElement).getByText('FakeFirstNameOnline FakeLastNameOnline'))
+  expect(within(userNameElement).getByText('W-FakeFirstNameOnline W-FakeLastNameOnline'))
   expect(within(projectNameElement).getByText('Project V'))
   expect(within(speciesNameElement).getByText('Nebrius ridens'))
 

--- a/src/components/Header/Header.styles.js
+++ b/src/components/Header/Header.styles.js
@@ -16,7 +16,7 @@ export const StyledHeader = styled('header')`
   z-index: 102;
   height: ${theme.spacing.headerHeight};
 `
-export const AvatarWrapper = styled('button')`
+export const UserButton = styled('button')`
   cursor: pointer;
   height: ${theme.spacing.headerHeight};
   width: ${theme.spacing.headerHeight};
@@ -26,8 +26,18 @@ export const AvatarWrapper = styled('button')`
   background: none;
   border: none;
 `
-export const AvatarWrapperFallback = styled('button')`
-  color: white;
+
+export const UserCircle = styled.div`
+  width: ${theme.typography.largeIconSize};
+  height: ${theme.typography.largeIconSize};
+  border-radius: 50%;
+  text-align: center;
+  line-height: ${theme.typography.largeIconSize};
+  font-weight: bold;
+  color: ${theme.color.primaryColor};
+  letter-spacing: 0.1rem;
+  background-color: ${theme.color.white};
+  font-size: ${theme.typography.smallFontSize};
 `
 
 export const CurrentUserImg = styled('img')`

--- a/src/testUtilities/mockMermaidApiAllSuccessful.js
+++ b/src/testUtilities/mockMermaidApiAllSuccessful.js
@@ -9,9 +9,9 @@ const mockMermaidApiAllSuccessful = setupServer(
     return res(
       ctx.json({
         id: 'fake-id',
-        first_name: 'FakeFirstNameOnline',
-        last_name: 'FakeLastNameOnline',
-        full_name: 'FakeFirstNameOnline FakeLastNameOnline',
+        first_name: 'W-FakeFirstNameOnline', // W is to differentiate online user icon initials from offline initials
+        last_name: 'W-FakeLastNameOnline', // W is to differentiate online user icon initials from offline initials
+        full_name: 'W-FakeFirstNameOnline W-FakeLastNameOnline',
       }),
     )
   }),


### PR DESCRIPTION
[Ticket](https://trello.com/c/c8HH1dc7/406-avatar-image-from-google-missing?)

Description of changes:
- add a `useLayoutEffect` to clear any error state from attempts to render the user icon with an image (previously once there was one error, it would persist no matter what)
- change user icon logic to use initials instead of full names (to fit in the header)


I noticed the google user image is rate limited and its very easy to hit the limit, so I looked into rerenders, but found no real low hanging fruit to improve app or header rerenders (seems the header has no obviously unnecessary rerenders). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user profile display in the header to show profile images, user initials, or a default icon based on available data.
- **Style**
	- Introduced a new circular design for the user icon, featuring refined typography and balanced dimensions for a modern appearance.
- **Bug Fixes**
	- Updated expected values in tests to reflect changes in user initials for both online and offline scenarios.
	- Adjusted user name expectations in various test cases to align with updated user data format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->