### PR TITLE
M1296 make sure users table show user initials or a fall back user icon if no user picture available

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
-import React, { useLayoutEffect, useState } from 'react'
+import React, { useState } from 'react'
 
 import {
   UserButton,
@@ -8,8 +8,6 @@ import {
   HeaderButtonThatLooksLikeLink,
   StyledHeader,
   LogoImg,
-  CurrentUserImg,
-  BiggerIconUser,
   StyledNavLink,
   NotificationIndicator,
   UserMenuButton,
@@ -21,12 +19,12 @@ import {
   BiggerIconMenu,
   LoggedInAs,
   HeaderIconWrapper,
-  UserCircle,
 } from './Header.styles'
 import { currentUserPropType } from '../../App/mermaidData/mermaidDataProptypes'
 import { IconGlobe, IconLibraryBooks } from '../icons'
 import { useBellNotifications } from '../../App/BellNotificationContext'
 import { useOnlineStatus } from '../../library/onlineStatusContext'
+import { UserIcon } from '../UserIcon/UserIcon'
 import BellNotificationDropDown from '../BellNotificationDropDown/BellNotificationDropDown'
 import HideShow from '../generic/HideShow'
 import Logo from '../../assets/mermaid-logo.svg'
@@ -95,23 +93,13 @@ const Header = ({ logout = () => {}, currentUser = undefined }) => {
   const closeProfileModal = () => setIsProfileModalOpen(false)
   const { notifications } = useBellNotifications()
   const { isAppOnline } = useOnlineStatus()
-  const [hasImageError, setHasImageError] = useState(false)
-  const currentUserFirstInitial = currentUser?.first_name?.charAt(0).toUpperCase()
-  const currentUserLastInitial = currentUser?.last_name?.charAt(0).toUpperCase()
-  const isProfileImageButtonShowing = currentUser?.picture && !hasImageError
-  const isInitialsButtonShowing = currentUserFirstInitial || currentUserLastInitial
-
-  useLayoutEffect(
-    function resetImageErrorWhenUserPictureChanges() {
-      // we clear the error before (re)rendering the image tag (which may or may not trigger an error)
-      setHasImageError(false)
-    },
-    [currentUser],
-  )
-
-  const handleImageError = () => {
-    setHasImageError(true)
-  }
+  const {
+    first_name: currentUserFirstName,
+    last_name: currentUserLastName,
+    picture: currentUserImageUrl,
+    email: currentUserEmail,
+    full_name: currentUserFullName,
+  } = currentUser ?? {}
 
   const UserMenuDropDownContent = () => (
     <OfflineHide>
@@ -120,30 +108,17 @@ const Header = ({ logout = () => {}, currentUser = undefined }) => {
     </OfflineHide>
   )
 
-  const profileImageButton = isProfileImageButtonShowing ? (
+  const userIconButton = (
     <UserButton aria-label="User account dropdown">
-      <CurrentUserImg src={currentUser?.picture} alt="User picture" onError={handleImageError} />
-    </UserButton>
-  ) : null
-  const initialsButton =
-    isInitialsButtonShowing && !isProfileImageButtonShowing ? (
-      <UserButton aria-label="User account dropdown">
-        <UserCircle>
-          {currentUserFirstInitial}
-          {currentUserLastInitial}
-        </UserCircle>
-      </UserButton>
-    ) : null
-
-  const fallbackButton = (
-    <UserButton aria-label="User account dropdown">
-      <BiggerIconUser />
+      <UserIcon
+        firstName={currentUserFirstName}
+        lastName={currentUserLastName}
+        userImageUrl={currentUserImageUrl}
+      />
     </UserButton>
   )
 
-  const userIconButton = profileImageButton || initialsButton || fallbackButton
-
-  const userDisplayName = currentUser?.first_name || currentUser?.full_name || currentUser?.email
+  const userDisplayName = currentUserFirstName || currentUserFullName || currentUserEmail
 
   return (
     <>

--- a/src/components/Header/Header.styles.js
+++ b/src/components/Header/Header.styles.js
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components/macro'
-import { IconBell, IconOpenInNew, IconExcel, IconMenu, IconUser } from '../icons'
+import { IconBell, IconOpenInNew, IconExcel, IconMenu } from '../icons'
 import theme from '../../theme'
 import { ButtonThatLooksLikeLink } from '../generic/buttons'
 import { hoverState, mediaQueryTabletLandscapeOnly } from '../../library/styling/mediaQueries'
@@ -26,35 +26,6 @@ export const UserButton = styled('button')`
   background: none;
   border: none;
 `
-
-export const UserCircle = styled.div`
-  width: ${theme.typography.largeIconSize};
-  height: ${theme.typography.largeIconSize};
-  border-radius: 50%;
-  text-align: center;
-  line-height: ${theme.typography.largeIconSize};
-  font-weight: bold;
-  color: ${theme.color.primaryColor};
-  letter-spacing: 0.1rem;
-  background-color: ${theme.color.white};
-  font-size: ${theme.typography.smallFontSize};
-`
-
-export const CurrentUserImg = styled('img')`
-  height: calc(${theme.spacing.headerHeight} - 10px);
-  width: calc(${theme.spacing.headerHeight} - 10px);
-  border-radius: 50%;
-  ${hoverState(
-    css`
-      outline: solid 3px ${theme.color.callout};
-    `,
-  )};
-  ${mediaQueryTabletLandscapeOnly(css`
-    height: calc(${theme.spacing.headerHeight} - 15px);
-    margin-top: 7px;
-  `)}
-`
-
 export const HeaderIconWrapper = styled('div')`
   margin-right: 0.3em;
 `
@@ -175,11 +146,6 @@ export const BiggerIconBell = styled(IconBell)`
 `
 export const BiggerIconMenu = styled(IconMenu)`
   ${biggerIcons}
-`
-export const BiggerIconUser = styled(IconUser)`
-  ${biggerIcons}
-  color: white;
-  position: inherit;
 `
 export const NotificationIndicator = styled.span`
   color: red;

--- a/src/components/UserIcon/UserIcon.js
+++ b/src/components/UserIcon/UserIcon.js
@@ -1,0 +1,60 @@
+import PropTypes from 'prop-types'
+import React, { useLayoutEffect, useState } from 'react'
+
+import { UserProfilePicture, FallbackUserIcon, UserCircle } from './UserIcon.styles'
+
+export const UserIcon = ({
+  firstName = undefined,
+  lastName = undefined,
+  userImageUrl = undefined,
+  className = undefined,
+  dark = false,
+}) => {
+  const [hasImageError, setHasImageError] = useState(false)
+
+  const currentUserFirstInitial = firstName?.charAt(0).toUpperCase()
+  const currentUserLastInitial = lastName?.charAt(0).toUpperCase()
+  const isInitialsButtonViewable = currentUserFirstInitial || currentUserLastInitial
+  const isProfileImageButtonViewable = userImageUrl && !hasImageError
+
+  useLayoutEffect(
+    function resetImageErrorWhenUserPictureChanges() {
+      // we clear the error before (re)rendering the image tag (which may or may not trigger an error)
+      setHasImageError(false)
+    },
+    [userImageUrl],
+  )
+
+  const handleImageError = () => {
+    setHasImageError(true)
+  }
+
+  const profilePicture = isProfileImageButtonViewable ? (
+    <UserProfilePicture
+      src={userImageUrl}
+      alt="User picture"
+      onError={handleImageError}
+      className={className}
+    />
+  ) : null
+
+  const circleWithInitials =
+    isInitialsButtonViewable && !isProfileImageButtonViewable ? (
+      <UserCircle className={className} $dark={dark}>
+        {currentUserFirstInitial}
+        {currentUserLastInitial}
+      </UserCircle>
+    ) : null
+
+  return (
+    profilePicture || circleWithInitials || <FallbackUserIcon className={className} $dark={dark} />
+  )
+}
+
+UserIcon.propTypes = {
+  firstName: PropTypes.string,
+  lastName: PropTypes.string,
+  userImageUrl: PropTypes.string,
+  className: PropTypes.string,
+  dark: PropTypes.bool,
+}

--- a/src/components/UserIcon/UserIcon.styles.js
+++ b/src/components/UserIcon/UserIcon.styles.js
@@ -1,0 +1,38 @@
+import { css } from 'styled-components'
+import styled from 'styled-components/macro'
+
+import { hoverState, mediaQueryTabletLandscapeOnly } from '../../library/styling/mediaQueries'
+import { IconUser } from '../icons'
+import theme from '../../theme'
+
+export const UserProfilePicture = styled.img`
+  width: ${theme.typography.largeIconSize};
+  height: ${theme.typography.largeIconSize};
+  border-radius: 50%;
+  ${hoverState(
+    css`
+      outline: solid 3px ${theme.color.callout};
+    `,
+  )};
+  ${mediaQueryTabletLandscapeOnly(css`
+    height: calc(${theme.spacing.headerHeight} - 15px);
+    margin-top: 7px;
+  `)}
+`
+export const UserCircle = styled.div`
+  width: ${theme.typography.largeIconSize};
+  height: ${theme.typography.largeIconSize};
+  border-radius: 50%;
+  text-align: center;
+  line-height: ${theme.typography.largeIconSize};
+  font-weight: bold;
+  color: ${(props) => (props.$dark ? theme.color.white : theme.color.primaryColor)};
+  letter-spacing: 0.1rem;
+  background-color: ${(props) => (props.$dark ? theme.color.primaryColor : theme.color.white)};
+  font-size: ${theme.typography.smallFontSize};
+`
+export const FallbackUserIcon = styled(IconUser)`
+  color: ${(props) => (props.$dark ? theme.color.primaryColor : theme.color.white)};
+  width: ${theme.typography.largeIconSize};
+  height: ${theme.typography.largeIconSize};
+`

--- a/src/components/pages/ProjectInfo/EditCitationModal.js
+++ b/src/components/pages/ProjectInfo/EditCitationModal.js
@@ -16,6 +16,7 @@ import { IconRefresh } from '../../icons'
 import { Textarea } from '../../generic/form'
 import language from '../../../language'
 import Modal, { RightFooter } from '../../generic/Modal/Modal'
+import { PENDING_USER_PROFILE_NAME } from '../../../library/constants/constants'
 
 const modalLanguage = language.pages.projectInfo.editCitationModal
 
@@ -51,7 +52,7 @@ export const EditCitationModal = ({
   const isAdminsPlural = admins.length > 1
 
   const otherProjectMembers = projectProfiles
-    .filter((profile) => !profile.is_admin && profile.profile_name !== '(pending user)')
+    .filter((profile) => !profile.is_admin && profile.profile_name !== PENDING_USER_PROFILE_NAME)
     .map((profile) => profile.profile_name)
   const otherProjectMembersString = otherProjectMembers.join(', ')
   const isOtherProjectMembersPlural = otherProjectMembers.length > 1

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -2,23 +2,23 @@ import { toast } from 'react-toastify'
 import { usePagination, useSortBy, useGlobalFilter, useTable } from 'react-table'
 import { useParams } from 'react-router-dom'
 import React, { useState, useEffect, useMemo, useCallback } from 'react'
-import styled, { css } from 'styled-components/macro'
 
+import {
+  ActiveSampleUnitsIconAlert,
+  InfoParagraph,
+  InlineStyle,
+  NameCellStyle,
+  TableRadioLabel,
+  ToolbarRowWrapper,
+  UserTableTd,
+} from './Users.styles'
 import { ButtonSecondary, ButtonCaution, IconButton, ButtonPrimary } from '../../generic/buttons'
 import { ContentPageLayout } from '../../Layout'
 import { getProfileNameOrEmailForPendingUser } from '../../../library/getProfileNameOrEmailForPendingUser'
 import { getTableColumnHeaderProps } from '../../../library/getTableColumnHeaderProps'
 import { getTableFilteredRows } from '../../../library/getTableFilteredRows'
 import { getToastArguments } from '../../../library/getToastArguments'
-import { hoverState, mediaQueryPhoneOnly } from '../../../library/styling/mediaQueries'
-import {
-  IconAccount,
-  IconAccountConvert,
-  IconPlus,
-  IconInfo,
-  IconAlert,
-  IconAccountRemove,
-} from '../../icons'
+import { IconAccountConvert, IconPlus, IconInfo, IconAccountRemove } from '../../icons'
 import {
   reactTableNaturalSort,
   reactTableNaturalSortReactNodesSecondChild,
@@ -28,7 +28,6 @@ import { splitSearchQueryStrings } from '../../../library/splitSearchQueryString
 import {
   Tr,
   Th,
-  Td,
   TableNavigation,
   StickyTableOverflowWrapper,
   GenericStickyTable,
@@ -48,7 +47,6 @@ import PageSelector from '../../generic/Table/PageSelector'
 import PageSizeSelector from '../../generic/Table/PageSizeSelector'
 import PageUnavailable from '../PageUnavailable'
 import RemoveUserModal from '../../RemoveUserModal'
-import theme from '../../../theme'
 import TransferSampleUnitsModal from '../../TransferSampleUnitsModal'
 import useDocumentTitle from '../../../library/useDocumentTitle'
 import useIsMounted from '../../../library/useIsMounted'
@@ -59,80 +57,12 @@ import {
   getIsUserAdminForProject,
   getIsProjectProfileReadOnly,
 } from '../../../App/currentUserProfileHelpers'
-import { PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
+import { PENDING_USER_PROFILE_NAME, PAGE_SIZE_DEFAULT } from '../../../library/constants/constants'
 import { useHttpResponseErrorHandler } from '../../../App/HttpResponseErrorHandlerContext'
 import { LabelContainer } from '../../generic/form'
 import ColumnHeaderToolTip from '../../ColumnHeaderToolTip/ColumnHeaderToolTip'
 import UserRolesInfoModal from '../../UserRolesInfoModal/UserRolesInfoModal'
-
-const ToolbarRowWrapper = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-gap: ${theme.spacing.small};
-  ${mediaQueryPhoneOnly(css`
-    grid-template-rows: 1fr 1fr;
-    grid-template-columns: auto;
-  `)}
-`
-
-const InfoParagraph = styled('div')`
-  margin-bottom: 1.5em;
-`
-
-const InlineStyle = styled('div')`
-  display: inline-flex;
-  margin-bottom: ${theme.spacing.small};
-`
-
-const ActiveSampleUnitsIconAlert = styled(IconAlert)`
-  color: ${theme.color.textColor};
-  margin: 0 ${theme.spacing.small};
-`
-const ProfileImage = styled('div')`
-  border-radius: 50%;
-  ${(props) =>
-    props.img &&
-    css`
-      background-image: url(${props.img});
-      background-position: center center;
-      background-size: ${props.theme.typography.xLargeIconSize};
-    `}
-  width: ${theme.typography.xLargeIconSize};
-  height: ${theme.typography.xLargeIconSize};
-  margin-right: 1rem;
-`
-
-const NameCellStyle = styled('div')`
-  display: flex;
-  white-space: nowrap;
-  align-items: center;
-  svg {
-    width: ${(props) => props.theme.typography.xLargeIconSize};
-    height: ${(props) => props.theme.typography.xLargeIconSize};
-  }
-`
-const UserTableTd = styled(Td)`
-  position: relative;
-`
-const TableRadioLabel = styled.label(
-  (props) => css`
-    top: 0;
-    right: 0;
-    cursor: ${props.cursor};
-    bottom: 0;
-    left: 0;
-    position: absolute;
-    display: grid;
-    place-items: center;
-    ${hoverState(css`
-      border: solid 1px ${theme.color.primaryColor};
-    `)}
-
-    input {
-      cursor: ${props.cursor};
-    }
-  `,
-)
+import { UserIcon } from '../../UserIcon/UserIcon'
 
 const getRoleLabel = (roleCode) => {
   return {
@@ -616,6 +546,12 @@ const Users = () => {
         role,
         profile: userId,
       } = profile
+      const nameParts = (profile_name ?? '')
+        .replace(PENDING_USER_PROFILE_NAME, 'pending user')
+        .split(' ')
+      const firstName = nameParts[0]
+      const lastNameIndex = nameParts.length - 1
+      const lastName = lastNameIndex === 0 ? undefined : nameParts[lastNameIndex]
 
       const userHasActiveSampleUnits = getDoesUserHaveActiveSampleUnits(profile)
       const isUserRoleReadOnly = getIsProjectProfileReadOnly(profile)
@@ -636,7 +572,12 @@ const Users = () => {
       return {
         name: (
           <NameCellStyle>
-            {picture ? <ProfileImage img={picture} /> : <IconAccount />}
+            <UserIcon
+              userImageUrl={picture}
+              firstName={firstName}
+              lastName={lastName}
+              dark={true}
+            />{' '}
             {profile_name}
           </NameCellStyle>
         ),

--- a/src/components/pages/Users/Users.js
+++ b/src/components/pages/Users/Users.js
@@ -771,29 +771,33 @@ const Users = () => {
       <StickyTableOverflowWrapper>
         <GenericStickyTable {...getTableProps()} cursor={isTableUpdating ? 'wait' : 'pointer'}>
           <thead>
-            {headerGroups.map((headerGroup) => (
-              <Tr key={headerGroup.id} {...headerGroup.getHeaderGroupProps()}>
-                {headerGroup.headers.map((column) => {
-                  const isMultiSortColumn = headerGroup.headers.some(
-                    (header) => header.sortedIndex > 0,
-                  )
+            {headerGroups.map((headerGroup) => {
+              const headerProps = headerGroup.getHeaderGroupProps()
 
-                  return (
-                    <Th
-                      {...column.getHeaderProps(getTableColumnHeaderProps(column))}
-                      key={column.id}
-                      isSortedDescending={column.isSortedDesc}
-                      sortedIndex={column.sortedIndex}
-                      isMultiSortColumn={isMultiSortColumn}
-                      isSortingEnabled={!column.disableSortBy}
-                      disabledHover={column.disableSortBy}
-                    >
-                      <span id="header-span">{column.render('Header')}</span>
-                    </Th>
-                  )
-                })}
-              </Tr>
-            ))}
+              return (
+                <Tr {...headerProps} key={headerProps.key}>
+                  {headerGroup.headers.map((column) => {
+                    const isMultiSortColumn = headerGroup.headers.some(
+                      (header) => header.sortedIndex > 0,
+                    )
+
+                    return (
+                      <Th
+                        {...column.getHeaderProps(getTableColumnHeaderProps(column))}
+                        key={column.id}
+                        isSortedDescending={column.isSortedDesc}
+                        sortedIndex={column.sortedIndex}
+                        isMultiSortColumn={isMultiSortColumn}
+                        isSortingEnabled={!column.disableSortBy}
+                        disabledHover={column.disableSortBy}
+                      >
+                        <span id="header-span">{column.render('Header')}</span>
+                      </Th>
+                    )
+                  })}
+                </Tr>
+              )
+            })}
           </thead>
           <tbody {...getTableBodyProps()}>
             {page.map((row) => {
@@ -805,7 +809,7 @@ const Users = () => {
                     const { key: _, ...restCellProps } = cell.getCellProps()
                     const uniqueKey = `${row.id}-${cell.column.id}`
                     return (
-                      <UserTableTd key={uniqueKey} {...restCellProps} align={cell.column.align}>
+                      <UserTableTd {...restCellProps} align={cell.column.align} key={uniqueKey}>
                         {cell.render('Cell')}
                       </UserTableTd>
                     )

--- a/src/components/pages/Users/Users.styles.js
+++ b/src/components/pages/Users/Users.styles.js
@@ -1,0 +1,59 @@
+import { css } from 'styled-components'
+import styled from 'styled-components/macro'
+import theme from '../../../theme'
+import { hoverState, mediaQueryPhoneOnly } from '../../../library/styling/mediaQueries'
+import { IconAlert } from '../../icons'
+import { Td } from '../../generic/Table/table'
+
+export const ToolbarRowWrapper = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: ${theme.spacing.small};
+  ${mediaQueryPhoneOnly(css`
+    grid-template-rows: 1fr 1fr;
+    grid-template-columns: auto;
+  `)}
+`
+
+export const InfoParagraph = styled('div')`
+  margin-bottom: 1.5em;
+`
+
+export const InlineStyle = styled('div')`
+  display: inline-flex;
+  margin-bottom: ${theme.spacing.small};
+`
+
+export const ActiveSampleUnitsIconAlert = styled(IconAlert)`
+  color: ${theme.color.textColor};
+  margin: 0 ${theme.spacing.small};
+`
+
+export const NameCellStyle = styled('div')`
+  display: flex;
+  gap: 1rem;
+  white-space: nowrap;
+  align-items: center;
+`
+export const UserTableTd = styled(Td)`
+  position: relative;
+`
+export const TableRadioLabel = styled.label(
+  (props) => css`
+    top: 0;
+    right: 0;
+    cursor: ${props.cursor};
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    display: grid;
+    place-items: center;
+    ${hoverState(css`
+      border: solid 1px ${theme.color.primaryColor};
+    `)}
+
+    input {
+      cursor: ${props.cursor};
+    }
+  `,
+)

--- a/src/library/constants/constants.js
+++ b/src/library/constants/constants.js
@@ -19,3 +19,5 @@ export const apiDataTypes = {
 }
 Object.freeze(PROJECT_CODES)
 Object.freeze(apiDataTypes)
+
+export const PENDING_USER_PROFILE_NAME = '(pending user)'

--- a/src/library/observerHelpers.js
+++ b/src/library/observerHelpers.js
@@ -1,7 +1,9 @@
+import { PENDING_USER_PROFILE_NAME } from './constants/constants'
+
 export const getObserverNameToUse = ({ profile_name, email, profile }) => {
   const emailOrAlternative = email ?? `${profile_name}: ${profile}`
 
-  return profile_name === '(pending user)' ? emailOrAlternative : profile_name
+  return profile_name === PENDING_USER_PROFILE_NAME ? emailOrAlternative : profile_name
 }
 
 export const getObserverNameOptions = (users) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2068,6 +2068,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/js@npm:8.57.1":
+  version: 8.57.1
+  resolution: "@eslint/js@npm:8.57.1"
+  checksum: 10c0/b489c474a3b5b54381c62e82b3f7f65f4b8a5eaaed126546520bf2fede5532a8ed53212919fed1e9048dcf7f37167c8561d58d0ba4492a4244004e7793805223
+  languageName: node
+  linkType: hard
+
 "@floating-ui/core@npm:^1.0.0":
   version: 1.6.1
   resolution: "@floating-ui/core@npm:1.6.1"
@@ -2170,6 +2177,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@humanwhocodes/config-array@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "@humanwhocodes/config-array@npm:0.13.0"
+  dependencies:
+    "@humanwhocodes/object-schema": "npm:^2.0.3"
+    debug: "npm:^4.3.1"
+    minimatch: "npm:^3.0.5"
+  checksum: 10c0/205c99e756b759f92e1f44a3dc6292b37db199beacba8f26c2165d4051fe73a4ae52fdcfd08ffa93e7e5cb63da7c88648f0e84e197d154bbbbe137b2e0dd332e
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/module-importer@npm:^1.0.1":
   version: 1.0.1
   resolution: "@humanwhocodes/module-importer@npm:1.0.1"
@@ -2177,7 +2195,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/object-schema@npm:^2.0.2":
+"@humanwhocodes/object-schema@npm:^2.0.2, @humanwhocodes/object-schema@npm:^2.0.3":
   version: 2.0.3
   resolution: "@humanwhocodes/object-schema@npm:2.0.3"
   checksum: 10c0/80520eabbfc2d32fe195a93557cef50dfe8c8905de447f022675aaf66abc33ae54098f5ea78548d925aa671cd4ab7c7daa5ad704fe42358c9b5e7db60f80696c
@@ -7679,7 +7697,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.3.0, eslint@npm:^8.55.0":
+"eslint@npm:^8.3.0":
   version: 8.57.0
   resolution: "eslint@npm:8.57.0"
   dependencies:
@@ -7724,6 +7742,54 @@ __metadata:
   bin:
     eslint: bin/eslint.js
   checksum: 10c0/00bb96fd2471039a312435a6776fe1fd557c056755eaa2b96093ef3a8508c92c8775d5f754768be6b1dddd09fdd3379ddb231eeb9b6c579ee17ea7d68000a529
+  languageName: node
+  linkType: hard
+
+"eslint@npm:^8.55.0":
+  version: 8.57.1
+  resolution: "eslint@npm:8.57.1"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.2.0"
+    "@eslint-community/regexpp": "npm:^4.6.1"
+    "@eslint/eslintrc": "npm:^2.1.4"
+    "@eslint/js": "npm:8.57.1"
+    "@humanwhocodes/config-array": "npm:^0.13.0"
+    "@humanwhocodes/module-importer": "npm:^1.0.1"
+    "@nodelib/fs.walk": "npm:^1.2.8"
+    "@ungap/structured-clone": "npm:^1.2.0"
+    ajv: "npm:^6.12.4"
+    chalk: "npm:^4.0.0"
+    cross-spawn: "npm:^7.0.2"
+    debug: "npm:^4.3.2"
+    doctrine: "npm:^3.0.0"
+    escape-string-regexp: "npm:^4.0.0"
+    eslint-scope: "npm:^7.2.2"
+    eslint-visitor-keys: "npm:^3.4.3"
+    espree: "npm:^9.6.1"
+    esquery: "npm:^1.4.2"
+    esutils: "npm:^2.0.2"
+    fast-deep-equal: "npm:^3.1.3"
+    file-entry-cache: "npm:^6.0.1"
+    find-up: "npm:^5.0.0"
+    glob-parent: "npm:^6.0.2"
+    globals: "npm:^13.19.0"
+    graphemer: "npm:^1.4.0"
+    ignore: "npm:^5.2.0"
+    imurmurhash: "npm:^0.1.4"
+    is-glob: "npm:^4.0.0"
+    is-path-inside: "npm:^3.0.3"
+    js-yaml: "npm:^4.1.0"
+    json-stable-stringify-without-jsonify: "npm:^1.0.1"
+    levn: "npm:^0.4.1"
+    lodash.merge: "npm:^4.6.2"
+    minimatch: "npm:^3.1.2"
+    natural-compare: "npm:^1.4.0"
+    optionator: "npm:^0.9.3"
+    strip-ansi: "npm:^6.0.1"
+    text-table: "npm:^0.2.0"
+  bin:
+    eslint: bin/eslint.js
+  checksum: 10c0/1fd31533086c1b72f86770a4d9d7058ee8b4643fd1cfd10c7aac1ecb8725698e88352a87805cf4b2ce890aa35947df4b4da9655fb7fdfa60dbb448a43f6ebcf1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[Ticket](https://trello.com/c/lZ2LwV6r/1296-use-new-user-icon-logic-in-users-table?filter=member:mnunes24)

Steps to test:
- view the users page 
- each user should have a user icon beside their name

if no image is present from Auth0, the app will show a circle with initials if a first name or last name are available, otherwise it will show a figurehead icon

<img width="599" alt="Screenshot 2025-02-20 at 2 13 43 PM" src="https://github.com/user-attachments/assets/fcc592ac-5e80-460f-b1a1-f0c715ebffca" />
<img width="599" alt="Screenshot 2025-02-20 at 2 13 33 PM" src="https://github.com/user-attachments/assets/9b50a8f9-7faf-4dd9-826f-41018bea0e16" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a unified user icon display that dynamically shows a profile image, initials, or fallback icon across the header and user pages.
  - Added a constant for pending user profiles to improve maintainability.

- **Refactor**
  - Simplified user data handling in the header and user listings by consolidating rendering logic and removing redundant error handling.

- **Style**
  - Enhanced the visual presentation and responsiveness of user-related elements, ensuring a consistent and streamlined experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->