### PR TITLE
M1297 ensure project info button disabled state is disabled after successful save of citation edits

### DIFF
--- a/src/components/pages/ProjectInfo/ProjectInfo.js
+++ b/src/components/pages/ProjectInfo/ProjectInfo.js
@@ -149,7 +149,8 @@ const ProjectInfo = () => {
 
       databaseSwitchboardInstance
         .saveProject({ projectId, editedValues: valuesToUse })
-        .then(() => {
+        .then((updatedProject) => {
+          setProjectBeingEdited(updatedProject) // to ensure isSuggestedCitationDirty is fresh
           setSaveButtonState(buttonGroupStates.saved)
           toast.success(...getToastArguments(language.success.projectSave))
           actions.resetForm({ values }) // resets formik's dirty state


### PR DESCRIPTION
Ticket: https://trello.com/c/JSGNCtud/1297-save-button-label-not-changing