### PR TITLE
M875 change some heading names in the observers and transects table

### DIFF
--- a/src/components/pages/UsersAndTransects/UsersAndTransects.js
+++ b/src/components/pages/UsersAndTransects/UsersAndTransects.js
@@ -211,7 +211,7 @@ const UsersAndTransects = () => {
         disableSortBy: true,
       },
       {
-        Header: () => <HeaderCenter>Submitted Transect Number</HeaderCenter>,
+        Header: () => <HeaderCenter>Submitted</HeaderCenter>,
         id: 'transect-numbers',
         columns: getSubmittedTransectNumberColumnHeaders,
         disableSortBy: true,
@@ -223,7 +223,7 @@ const UsersAndTransects = () => {
         disableSortBy: true,
       },
       {
-        Header: () => <HeaderCenter>Transect Number / User</HeaderCenter>,
+        Header: () => <HeaderCenter>Collecting</HeaderCenter>,
         id: 'user-headers',
         columns: getUserColumnHeaders,
         disableSortBy: true,


### PR DESCRIPTION
[Ticket](https://trello.com/c/7FfAWPiW/875-change-name-of-column-transect-number-user-in-the-observers-and-transects-overview-to-something-like-to-be-submitted-or-in-progr)

Steps to test:
- go to a project that has collecting and submitted records
- go to the observers and transects page
- verify the column heading change (to 'Submitted' and 'Collecting')

<img width="855" alt="Screenshot 2025-02-26 at 10 09 39 AM" src="https://github.com/user-attachments/assets/172cc41f-7837-4f78-b92b-02bf6fcfc666" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated table headers on the Users and Transects page:
		- "Submitted Transect Number" is now "Submitted".
		- "Transect Number / User" is now "Collecting".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->