### PR TITLE
M1328 more wording changes

### DIFF
--- a/qualityAssuranceChecklist.md
+++ b/qualityAssuranceChecklist.md
@@ -58,7 +58,7 @@ The purpose of this list is to provide a list of features to be manually checked
 
 - [ ] edit sample unit
 
-## Observers and sample units
+## Sample Units / Observers
 
 ## Management regimes overview
 

--- a/src/components/NavMenu/NavMenu.js
+++ b/src/components/NavMenu/NavMenu.js
@@ -160,7 +160,8 @@ const NavMenu = ({ subNavNode = null }) => {
               </li>
               <li>
                 <NavLinkSidebar to={`${projectUrl}/management-regimes-overview`}>
-                  <IconManagementRegimesOverview /> <span>Management Regimes Overview</span>
+                  <IconManagementRegimesOverview />
+                  <span>{language.pages.managementRegimesOverview.navTitle}</span>
                 </NavLinkSidebar>
               </li>
             </ul>

--- a/src/language.js
+++ b/src/language.js
@@ -665,7 +665,11 @@ const pages = {
     title: 'Management Regimes',
   },
   usersAndTransectsTable: {
-    title: 'Observers and Sample Units',
+    title: (
+      <>
+        Sample Units / <br /> Observers
+      </>
+    ),
     filterToolbarText: 'Filter this table by site',
     missingSiteName: '(Missing Site Name)',
     missingMRName: '(Missing MR Name)',
@@ -679,7 +683,12 @@ const pages = {
     ],
   },
   managementRegimesOverview: {
-    title: 'Management Regimes Overview',
+    navTitle: (
+      <>
+        Sample Units / <br /> Management Regimes
+      </>
+    ),
+    title: 'Submitted / Management Regime',
     noDataMainText: 'This project has no submitted sample units yet.',
     noDataSubText:
       'This page will show the Management Regime of submitted sample units by method and site.',


### PR DESCRIPTION
Just wording changes

Steps to test:
- is nav link "Sample Units / Observers with a line break after the '/'?
- is nav link "Sample Units / Management Regimes"  with a line break adter the '/'?
- is the page title associated with Sample Units / Management Regimes nav link "Submitted / Management Regime" (singular)?
![Screenshot 2025-03-11 at 9 54 45 AM](https://github.com/user-attachments/assets/dd1cbbd6-a15c-444d-9372-d028ec73fb69)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised the checklist header to improve clarity.

- **New Features**
  - Updated navigation link text to leverage dynamic language settings, enabling localization.
  - Enhanced page titles with improved formatting for clearer, more structured display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->