### PR TITLE
M1339 use organization autocomplete search text as initial new organization suggestion value

### DIFF
--- a/src/components/NewOrganizationModal/NewOrganizationModal.js
+++ b/src/components/NewOrganizationModal/NewOrganizationModal.js
@@ -1,6 +1,5 @@
 import { toast } from 'react-toastify'
-import { useFormik } from 'formik'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
@@ -17,21 +16,25 @@ const ModalInputRow = styled(InputRow)`
   display: block;
   border: none;
 `
-const NewOrganizationModal = ({ isOpen, onDismiss, onSubmit }) => {
-  const formik = useFormik({
-    initialValues: { newOrganizationSuggestion: '' },
-  })
-
-  const isInputDirty =
-    formik.values.newOrganizationSuggestion !== formik.initialValues.newOrganizationSuggestion
+const NewOrganizationModal = ({ isOpen, onDismiss, onSubmit, initialValue = '' }) => {
+  const [newOrganizationSuggestion, setNewOrganizationSuggestion] = useState(initialValue)
+  const isSubmitButtonDisabled = newOrganizationSuggestion === ''
+  useEffect(
+    function useOrganizationSelectSearchTextAsInitialValue() {
+      if (initialValue) {
+        setNewOrganizationSuggestion(initialValue)
+      }
+    },
+    [initialValue],
+  )
 
   const resetAndCloseModal = () => {
-    formik.resetForm()
+    setNewOrganizationSuggestion('')
     onDismiss()
   }
 
   const handleOnSubmit = () => {
-    onSubmit(formik.values.newOrganizationSuggestion)
+    onSubmit(newOrganizationSuggestion)
     resetAndCloseModal()
     toast.success(...getToastArguments(language.success.newOrganizationAdd))
   }
@@ -49,11 +52,9 @@ const NewOrganizationModal = ({ isOpen, onDismiss, onSubmit }) => {
             aria-labelledby="modal-input-for-org-label"
             aria-describedby="modal-input-for-org-descp"
             id="modal-input-for-org"
-            value={formik.values.newOrganizationSuggestion}
+            value={newOrganizationSuggestion}
             autoFocus
-            onChange={(event) =>
-              formik.setFieldValue('newOrganizationSuggestion', event.target.value)
-            }
+            onChange={(event) => setNewOrganizationSuggestion(event.target.value)}
           />
           {helperText && <HelperText id="modal-input-for-org-descp">{helperText}</HelperText>}
         </div>
@@ -64,7 +65,7 @@ const NewOrganizationModal = ({ isOpen, onDismiss, onSubmit }) => {
   const footerContent = (
     <RightFooter>
       <ButtonSecondary onClick={resetAndCloseModal}>Cancel</ButtonSecondary>
-      <ButtonPrimary onClick={handleOnSubmit} disabled={!isInputDirty}>
+      <ButtonPrimary onClick={handleOnSubmit} disabled={isSubmitButtonDisabled}>
         <IconSend />
         Send to MERMAID for review
       </ButtonPrimary>
@@ -86,6 +87,7 @@ NewOrganizationModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onDismiss: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
+  initialValue: PropTypes.string,
 }
 
 export default NewOrganizationModal

--- a/src/components/generic/InputAutocomplete/InputAutocomplete.js
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.js
@@ -45,6 +45,7 @@ const InputAutocomplete = ({
   onKeyDown = undefined,
   options,
   value = '',
+  onInputValueChange = undefined,
   ...restOfProps
 }) => {
   const optionMatchingValueProp = useMemo(
@@ -82,6 +83,8 @@ const InputAutocomplete = ({
     (changes) => {
       const { selectedItem, inputValue } = changes
 
+      onInputValueChange?.(inputValue)
+
       const shouldMenuBeOpen = inputValue?.length >= 1 && inputValue !== selectedValue.label
 
       if (selectedItem) {
@@ -97,7 +100,7 @@ const InputAutocomplete = ({
         setIsMenuOpen(false)
       }
     },
-    [selectedValue.label, onChange],
+    [onInputValueChange, selectedValue.label, onChange],
   )
 
   const handleInputValueChange = useCallback(
@@ -196,6 +199,7 @@ InputAutocomplete.propTypes = {
   onKeyDown: PropTypes.func,
   options: inputOptionsPropTypes.isRequired,
   value: PropTypes.string,
+  onInputValueChange: PropTypes.func,
 }
 
 export default InputAutocomplete

--- a/src/components/pages/ProjectInfo/ProjectInfo.js
+++ b/src/components/pages/ProjectInfo/ProjectInfo.js
@@ -59,6 +59,7 @@ const ProjectInfo = () => {
   const [isEditCitationModalOpen, setIsEditCitationModalOpen] = useState(false)
   const [citationToUse, setCitationToUse] = useState('')
   const [projectProfiles, setProjectProfiles] = useState([])
+  const [organizationAutocompleteSearchText, setOrganizationAutocompleteSearchText] = useState('')
 
   const { currentUser } = useCurrentUser()
   const { currentProject: projectBeingEdited, setCurrentProject: setProjectBeingEdited } =
@@ -329,6 +330,7 @@ const ProjectInfo = () => {
             }}
             noResultsText={language.pages.projectInfo.noOrganizationFound}
             noResultsAction={noOrganizationResult}
+            onInputValueChange={setOrganizationAutocompleteSearchText}
           />
         </InputAutocompleteWrapper>
         <OrganizationList
@@ -428,6 +430,7 @@ const ProjectInfo = () => {
 
           formik.setFieldValue('tags', [...existingOrganizations, selectedItemLabel])
         }}
+        initialValue={organizationAutocompleteSearchText}
       />
       <EditCitationModal
         citationToUse={citationToUse}


### PR DESCRIPTION
[Ticket](https://trello.com/c/qY2L015v/1339-populate-the-new-organization-name-field-with-what-they-typed-in-the-organizations-field?filter=member:mnunes24)

Description:
- when a user types into the organization autocomplete and no options are returned, they can click to add a new org. The initial value for that new org suggestion will now be the search text from the autocomplete

Steps to test:
- enter a bunch of junk into the org autocomplete
- click 'Suggest a New Organization to MERMAID' => the new org input in the modal should have the same text you just typed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced organization entry experience with dynamic default values that update in real time.
	- Improved autocomplete for organization search, offering immediate feedback as you type.
  
- **Refactor**
	- Streamlined form handling in the organization modal for a smoother and more responsive submission process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->