### PR TITLE
Image classification/m1353 click row select radio

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,7 @@
 
   - As of last readme update 4.1.1 has been tested and works
   - Some developers have had issues when versions of Yarn autogenerate a `packageManager` setting in `package.json`. This has caused tests to fail or other things to have errors. The solution in one case was to add COREPACK_ENABLE_AUTO_PIN=0 to the shell environment before running any yarn commands.
+
 - Node 20.10.0
   - Optionally but recommended, use [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to set the node version: run `nvm use`
 - [Docker](https://docs.docker.com/get-docker/)

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.js
@@ -12,6 +12,25 @@ const confirmed = colorHelper(COLORS.confirmed)
 const unconfirmed = colorHelper(COLORS.unconfirmed)
 const white = colorHelper(theme.color.white)
 
+export const RowThatLooksLikeAnEvenTr = styled.div`
+  display: flex;
+  padding: 10px;
+  gap: 20px;
+  background-color: ${theme.color.tableRowEven};
+`
+export const ClickableRowThatLooksLikeAnEvenTr = styled(RowThatLooksLikeAnEvenTr)`
+  &:hover {
+    cursor: pointer;
+    background-color: ${theme.color.tableRowHover};
+  }
+`
+
+export const LabelThatLooksLikeATh = styled.div(
+  (props) => css`
+    ${thStyles(props)}
+  `,
+)
+
 export const Footer = styled.div`
   display: flex;
   justify-content: space-between;
@@ -104,16 +123,17 @@ export const TdUnconfirmed = styled(Td)`
     $hasUnconfirmedPoint ? unconfirmed.mix(white, 0.7) : undefined};
 `
 
-export const EditPointPopupTable = styled(Table)`
+export const EditPointPopupWrapper = styled.div`
   border: ${`2px solid ${COLORS.current}`};
 `
 
-export const PopupTd = styled(Td)`
-  background-color: ${theme.color.tableRowEven};
-  border: none;
+export const PointPopupSectionHeader = styled.div`
+  ${thStyles}
+  display: flex;
+  justify-content: space-between;
 `
 
-export const PopupTdForRadio = styled(PopupTd)`
+export const PopupWrapperForRadio = styled.div`
   width: 15px;
 `
 
@@ -201,17 +221,6 @@ export const PopupIconButton = styled(IconButton)`
 `
 export const PopupZoomButtonContainer = styled.div`
   display: flex;
-`
-export const LabelThatLooksLikeATh = styled.div(
-  (props) => css`
-    ${thStyles(props)}
-  `,
-)
-export const RowThatLooksLikeAnEvenTr = styled.div`
-  display: flex;
-  padding: 10px;
-  gap: 20px;
-  background-color: ${theme.color.tableRowEven};
 `
 
 export const LabelPopup = styled.div`

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ClassifierGuesses.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ClassifierGuesses.js
@@ -1,11 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Tr } from '../../../../generic/Table/table'
-import { PopupTd, PopupTdForRadio } from '../ImageAnnotationModal.styles'
+import {
+  PopupWrapperForRadio,
+  ClickableRowThatLooksLikeAnEvenTr,
+} from '../ImageAnnotationModal.styles'
 import {
   imageClassificationPointPropType,
   imageClassificationResponsePropType,
 } from '../../../../../App/mermaidData/mermaidDataProptypes'
+import { RowSpaceBetween } from '../../../../generic/positioning'
 
 const moveAnnotationToFront = (array, index) => {
   const newArray = [...array]
@@ -47,8 +50,8 @@ const ClassifierGuesses = ({
   }
 
   return classifierGuessesSortedByScore.map((annotation) => (
-    <Tr key={annotation.id}>
-      <PopupTdForRadio>
+    <ClickableRowThatLooksLikeAnEvenTr key={annotation.id} as="label">
+      <PopupWrapperForRadio>
         <input
           type="radio"
           id={annotation.ba_gr}
@@ -56,10 +59,12 @@ const ClassifierGuesses = ({
           checked={annotation.ba_gr === selectedPoint.annotations[0].ba_gr}
           onChange={() => selectClassifierGuess(annotation.id)}
         />
-      </PopupTdForRadio>
-      <PopupTd>{annotation.ba_gr_label}</PopupTd>
-      <PopupTd align="right">{annotation.score}%</PopupTd>
-    </Tr>
+      </PopupWrapperForRadio>
+      <RowSpaceBetween>
+        <span>{annotation.ba_gr_label}</span>
+        <span>{annotation.score}%</span>
+      </RowSpaceBetween>
+    </ClickableRowThatLooksLikeAnEvenTr>
   ))
 }
 

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
@@ -1,12 +1,12 @@
 import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
-import { Tr, Th } from '../../../../generic/Table/table'
 import { imageClassificationResponsePropType } from '../../../../../App/mermaidData/mermaidDataProptypes'
 import { databaseSwitchboardPropTypes } from '../../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboard'
 import SelectAttributeFromClassifierGuesses from './SelectAttributeFromClassifierGuesses'
 import ClassifierGuesses from './ClassifierGuesses'
 import {
-  EditPointPopupTable,
+  EditPointPopupWrapper,
+  PointPopupSectionHeader,
   PopupBottomRow,
   PopupConfirmButton,
   PopupIconButton,
@@ -62,31 +62,30 @@ const ImageAnnotationPopup = ({
 
   return (
     <>
-      {areAnyClassifierGuesses ? (
-        <EditPointPopupTable aria-labelledby="table-label">
-          <thead>
-            <Tr>
-              <Th colSpan={2}>Classifier Guesses</Th>
-              <Th align="right">Confidence</Th>
-            </Tr>
-          </thead>
-          <tbody>
+      <form>
+        {areAnyClassifierGuesses ? (
+          <EditPointPopupWrapper aria-labelledby="table-label">
+            <PointPopupSectionHeader>
+              <span>Classifier Guesses</span>
+              <span>Confidence</span>
+            </PointPopupSectionHeader>
+
             <ClassifierGuesses
               selectedPoint={selectedPoint}
               dataToReview={dataToReview}
               setDataToReview={setDataToReview}
               setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
             />
-          </tbody>
-        </EditPointPopupTable>
-      ) : null}
-      <SelectAttributeFromClassifierGuesses
-        selectedPoint={selectedPoint}
-        dataToReview={dataToReview}
-        setDataToReview={setDataToReview}
-        setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
-        databaseSwitchboardInstance={databaseSwitchboardInstance}
-      />
+          </EditPointPopupWrapper>
+        ) : null}
+        <SelectAttributeFromClassifierGuesses
+          selectedPoint={selectedPoint}
+          dataToReview={dataToReview}
+          setDataToReview={setDataToReview}
+          setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
+          databaseSwitchboardInstance={databaseSwitchboardInstance}
+        />
+      </form>
       <PopupBottomRow>
         <PopupZoomButtonContainer>
           <PopupIconButton type="button" onClick={resetZoom}>
@@ -105,7 +104,7 @@ const ImageAnnotationPopup = ({
           {isSelectedPointConfirmed ? 'Confirmed' : 'Confirm'}
         </PopupConfirmButton>
         <PopupZoomButtonContainer>
-          <Tooltip tooltipText="Next Unconfirmed Point">
+          <Tooltip tooltipText="Next Unconfirmed Point" id="next-unconfirmed-point">
             <PopupIconButton
               type="button"
               onClick={selectNextUnconfirmedPoint}

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -624,7 +624,7 @@ const ImageClassificationObservationTable = ({
 }
 
 ImageClassificationObservationTable.propTypes = {
-  setUploadedFiles: PropTypes.func.isRequired,
+  setUploadedFiles: PropTypes.func,
   areValidationsShowing: PropTypes.bool.isRequired,
   collectRecord: benthicPhotoQuadratPropType,
   ignoreObservationValidations: PropTypes.func.isRequired,


### PR DESCRIPTION
[Ticket](https://trello.com/c/tXjjuaqS/1353-entire-row-of-classifier-guess-should-be-clickable-not-just-radio-button)

Changes:
- removed use of table from containing and laying our form inputs
- used label tag to have whole row clickable for classifier guesses

Steps to test:
- open the review modal for a benthic photo quadrat record ([here is a record](https://preview.app2.datamermaid.org/1183/projects/bacd3529-e0f4-40f4-a089-992c5bd5cc02/collecting/benthicpqt/a395e9ad-1ca5-4582-b84d-cc8d53fc6f1f) with an already uploaded BPQ image)
- click on an unconfirmed point to open the point popup
- select an attribute growth form
- click the label of one of the classifier guesses (not the radio itself) => this should select the associated radio

