### PR TITLE
image classification - three small tickets in one PR

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,7 @@
 
   - As of last readme update 4.1.1 has been tested and works
   - Some developers have had issues when versions of Yarn autogenerate a `packageManager` setting in `package.json`. This has caused tests to fail or other things to have errors. The solution in one case was to add COREPACK_ENABLE_AUTO_PIN=0 to the shell environment before running any yarn commands.
+
 - Node 20.10.0
   - Optionally but recommended, use [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to set the node version: run `nvm use`
 - [Docker](https://docs.docker.com/get-docker/)

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
@@ -25,6 +25,7 @@ import { getPatchesCenters } from './getPatchesCenters'
 
 const DEFAULT_CENTER = [0, 0] // this value doesn't matter, default to null island
 const DEFAULT_ZOOM = 2 // needs to be > 1 otherwise bounds become > 180 and > 85
+const ZOOM_DURATION = 800
 
 const IMAGE_CLASSIFICATION_COLOR_EXP = [
   'case',
@@ -45,7 +46,7 @@ const pointLabelPopup = new maplibregl.Popup({
 })
 
 const easeToDefaultView = (map) =>
-  map.current.easeTo({ center: DEFAULT_CENTER, zoom: DEFAULT_ZOOM, duration: 500 })
+  map.current.easeTo({ center: DEFAULT_CENTER, zoom: DEFAULT_ZOOM, duration: ZOOM_DURATION })
 
 // HACK: MapLibre's unproject() (used to get pixel coords) doesn't let you pass zoom as parameter.
 // So to ensure that our points remain in the same position we:
@@ -371,7 +372,10 @@ const ImageAnnotationModalMap = ({
       if (!bounds || !map.current) {
         return
       }
-      map.current.fitBounds(bounds, { padding: 250 })
+      map.current.fitBounds(bounds, {
+        padding: 250,
+        duration: ZOOM_DURATION,
+      })
     },
     [map],
   )
@@ -405,27 +409,32 @@ const ImageAnnotationModalMap = ({
   }, [])
 
   const selectNextUnconfirmedPoint = useCallback(() => {
-    map.current.setZoom(DEFAULT_ZOOM)
-    const { features } = getPointsGeojson()
+    const handleEaseToFinished = () => {
+      const { features } = getPointsGeojson()
 
-    const selectedPointFeaturesIndex = features.findIndex(
-      (feature) => feature.properties.id === selectedPoint.id,
-    )
-    const backSectionOfFeaturesArray = features.slice(selectedPointFeaturesIndex + 1)
+      const selectedPointFeaturesIndex = features.findIndex(
+        (feature) => feature.properties.id === selectedPoint.id,
+      )
+      const backSectionOfFeaturesArray = features.slice(selectedPointFeaturesIndex + 1)
 
-    const frontSectionOfFeaturesArray = features.slice(0, selectedPointFeaturesIndex)
-    const featuresArrayOrderedForSearching = [
-      ...backSectionOfFeaturesArray,
-      ...frontSectionOfFeaturesArray,
-    ]
-    const nextUnconfirmedFeature = featuresArrayOrderedForSearching.find(
-      (feature) => !feature.properties.isConfirmed,
-    )
+      const frontSectionOfFeaturesArray = features.slice(0, selectedPointFeaturesIndex)
+      const featuresArrayOrderedForSearching = [
+        ...backSectionOfFeaturesArray,
+        ...frontSectionOfFeaturesArray,
+      ]
+      const nextUnconfirmedFeature = featuresArrayOrderedForSearching.find(
+        (feature) => !feature.properties.isConfirmed,
+      )
+      const handleZoomToBoundsFinished = () => {
+        selectFeature(nextUnconfirmedFeature)
+      }
 
-    zoomToBounds(getBounds(nextUnconfirmedFeature))
-    map.current.once('idle', () => {
-      selectFeature(nextUnconfirmedFeature)
-    })
+      map.current.once('idle', handleZoomToBoundsFinished)
+      zoomToBounds(getBounds(nextUnconfirmedFeature))
+    }
+
+    map.current.once('idle', handleEaseToFinished)
+    map.current.easeTo({ center: DEFAULT_CENTER, zoom: DEFAULT_ZOOM, duration: ZOOM_DURATION })
   }, [getPointsGeojson, map, selectFeature, selectedPoint.id, zoomToBounds])
 
   const _displayEditPointPopupOnPointClick = useEffect(() => {

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
@@ -175,6 +175,8 @@ const ImageAnnotationModalMap = ({
       minZoom: DEFAULT_ZOOM,
       renderWorldCopies: false, // prevents the image from repeating
       dragRotate: false,
+      touchZoomRotate: false,
+      touchPitch: false,
       accessToken: process.env.REACT_APP_MAPBOX_ACCESS_TOKEN,
     })
 

--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.js
@@ -579,7 +579,7 @@ const ImageClassificationObservationTable = ({
                           <StyledTd colSpan={3} textAlign="center">
                             {`${totalUnknown} Unclassified point${totalUnknown > 1 ? 's' : ''}`}
                           </StyledTd>
-                          <StyledTd colSpan={2} />
+                          <StyledTd />
                         </StyledTr>
                       )}
                     </React.Fragment>


### PR DESCRIPTION
Tickets:
- https://trello.com/c/8YqIJT8v/1345-review-column-should-span-to-the-unclassified-row-as-well
- https://trello.com/c/fgV3EzJE/1352-disable-tilt-on-image
- https://trello.com/c/2Xrlzgyx/1348-the-zoom-when-clicking-next-attribute-is-jarring


Description of work:
- tweak a colspan so background colour on hover works as expected
- disable tilt and rotate image classification image when using touch device
- smooth out some zooming for image (that hacks a map to to achieve zoom and pan functions).


Steps to test: 
- watch the video in the first ticket and make sure that doesnt happen 
- view the app on a touch device, review a uploaded classified image, use two fingers to see if you can rotate or tilt the image. This shouldnt be possible
- click a unconfirmed point (blue square). click the next button (right arrow at bottom). The zoom animation should be less jarring than before