### PR TITLE
Image classification/ 2 small tickets

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,7 @@
 
   - As of last readme update 4.1.1 has been tested and works
   - Some developers have had issues when versions of Yarn autogenerate a `packageManager` setting in `package.json`. This has caused tests to fail or other things to have errors. The solution in one case was to add COREPACK_ENABLE_AUTO_PIN=0 to the shell environment before running any yarn commands.
+
 - Node 20.10.0
   - Optionally but recommended, use [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to set the node version: run `nvm use`
 - [Docker](https://docs.docker.com/get-docker/)

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
@@ -304,16 +304,17 @@ const ImageAnnotationModalMap = ({
   }, [])
 
   useEffect(
-    function configurePatchesPopup() {
+    function configurePatchesLabels() {
       if (!map.current) {
         return
       }
-      const displayPointFeatureLabel = ({ features }) => {
+      const handlePatchMouseEnter = ({ features }) => {
+        map.current.getCanvas().style.cursor = 'pointer'
+
         if (areLabelsShowing) {
           return
         }
         const [{ properties }] = features
-        map.current.getCanvas().style.cursor = 'pointer'
         const label = properties.isUnclassified ? 'Unclassified' : properties.ba_gr_label
         const confirmedStatus = properties.isConfirmed ? 'confirmed' : 'unconfirmed'
         const pointStatus = properties.isUnclassified ? 'unclassified' : confirmedStatus
@@ -339,18 +340,18 @@ const ImageAnnotationModalMap = ({
           }
         })
       }
-      const hidePointFeatureLabel = () => {
+      const handlePatchMouseLeave = () => {
         map.current.getCanvas().style.cursor = ''
         pointLabelPopup.remove()
       }
 
-      map.current.on('mouseenter', 'patches-fill-layer', displayPointFeatureLabel)
-      map.current.on('mouseleave', 'patches-fill-layer', hidePointFeatureLabel)
+      map.current.on('mouseenter', 'patches-fill-layer', handlePatchMouseEnter)
+      map.current.on('mouseleave', 'patches-fill-layer', handlePatchMouseLeave)
 
       const currentMap = map.current
       return () => {
-        currentMap.off('mouseenter', 'patches-fill-layer', displayPointFeatureLabel)
-        currentMap.off('mouseleave', 'patches-fill-layer', hidePointFeatureLabel)
+        currentMap.off('mouseenter', 'patches-fill-layer', handlePatchMouseEnter)
+        currentMap.off('mouseleave', 'patches-fill-layer', handlePatchMouseLeave)
       }
     },
     [areLabelsShowing, map],

--- a/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
+++ b/src/components/pages/ImageClassification/ImageUploadModal/ImageUploadModal.js
@@ -171,6 +171,7 @@ const ImageUploadModal = ({
         toast.update(toastId.current, {
           render: uploadText.success,
           type: toast.TYPE.SUCCESS,
+          autoClose: true,
         })
       }
     }


### PR DESCRIPTION
Tickets: 
- https://trello.com/c/Xp6X6xGK/1354-cursor-needs-to-be-the-hand-pointer-on-points-when-in-label-view
- https://trello.com/c/oNPLGZM4/1347-file-uploaded-successfully-notification-never-goes-away

Description of work:
- unsure a pointer cursor when hovering an image classification 'patch'/data 'point' (box)
- auto close a toast that shows upload progress once all uploads uploaded