### PR TITLE
M1367 update some GFCR form inputs to accept 5 decimal places

### DIFF
--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/InvestmentModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/InvestmentModal.js
@@ -10,7 +10,7 @@ import { ButtonCaution, ButtonSecondary } from '../../../../generic/buttons'
 import { buttonGroupStates } from '../../../../../library/buttonGroupStates'
 import { choicesPropType } from '../../../../../App/mermaidData/mermaidDataProptypes'
 import { displayErrorMessagesGFCR } from '../../../../../library/displayErrorMessagesGFCR'
-import { formikHandleNumericTwoDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
+import { formikHandleNumericDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
 import { getInvestmentInitialValues } from './investmentInitialValues'
 import { getOptions } from '../../../../../library/getOptions'
 import { getToastArguments } from '../../../../../library/getToastArguments'
@@ -290,7 +290,7 @@ const InvestmentModal = ({
             showHelperText={displayHelp}
             required={true}
             onChange={(event) =>
-              formikHandleNumericTwoDecimalInputChange({
+              formikHandleNumericDecimalInputChange({
                 formik,
                 event,
                 fieldName: 'investment_amount',

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/RevenueModal.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/RevenueModal.js
@@ -10,7 +10,7 @@ import { ButtonCaution, ButtonSecondary } from '../../../../generic/buttons'
 import { buttonGroupStates } from '../../../../../library/buttonGroupStates'
 import { choicesPropType } from '../../../../../App/mermaidData/mermaidDataProptypes'
 import { displayErrorMessagesGFCR } from '../../../../../library/displayErrorMessagesGFCR'
-import { formikHandleNumericTwoDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
+import { formikHandleNumericDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
 import { getOptions } from '../../../../../library/getOptions'
 import { getRevenueInitialValues } from './revenueInitialValues'
 import { getToastArguments } from '../../../../../library/getToastArguments'
@@ -292,7 +292,7 @@ const RevenueModal = ({
             showHelperText={displayHelp}
             required={true}
             onChange={(event) =>
-              formikHandleNumericTwoDecimalInputChange({
+              formikHandleNumericDecimalInputChange({
                 formik,
                 event,
                 fieldName: 'revenue_amount',

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F1Form.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F1Form.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { formikHandleNumericTwoDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
+import { formikHandleNumericDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
 import { formikPropType } from '../../../../../library/formikPropType'
 import { H2 } from '../../../../generic/text'
 import { StyledGfcrInputWrapper } from './subPages.styles'
@@ -30,7 +30,12 @@ const F1Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         helperText={gfcrIndicatorSetLanguage.getF1_1_helper()}
         showHelperText={displayHelp}
         onChange={(event) =>
-          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f1_1' })
+          formikHandleNumericDecimalInputChange({
+            formik,
+            event,
+            fieldName: 'f1_1',
+            maxNumberOfDecimals: 5,
+          })
         }
       />
       <TextareaWithLabelAndValidation

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F2Form.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F2Form.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { formikHandleNumericTwoDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
+import { formikHandleNumericDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
 import { formikPropType } from '../../../../../library/formikPropType'
 import { H2 } from '../../../../generic/text'
 import { StyledGfcrInputWrapper } from './subPages.styles'
@@ -28,7 +28,12 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         onBlur={(event) => handleInputBlur(formik, event, 'f2_1a')}
         onFocus={(event) => handleInputFocus(event)}
         onChange={(event) =>
-          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_1a' })
+          formikHandleNumericDecimalInputChange({
+            formik,
+            event,
+            fieldName: 'f2_1a',
+            maxNumberOfDecimals: 5,
+          })
         }
         helperText={gfcrIndicatorSetLanguage.getF2_1a_helper()}
         showHelperText={displayHelp}
@@ -46,7 +51,12 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         onBlur={(event) => handleInputBlur(formik, event, 'f2_1b')}
         onFocus={(event) => handleInputFocus(event)}
         onChange={(event) =>
-          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_1b' })
+          formikHandleNumericDecimalInputChange({
+            formik,
+            event,
+            fieldName: 'f2_1b',
+            maxNumberOfDecimals: 5,
+          })
         }
         helperText={gfcrIndicatorSetLanguage.getF2_1b_helper()}
         showHelperText={displayHelp}
@@ -64,7 +74,12 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         onBlur={(event) => handleInputBlur(formik, event, 'f2_2a')}
         onFocus={(event) => handleInputFocus(event)}
         onChange={(event) =>
-          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_2a' })
+          formikHandleNumericDecimalInputChange({
+            formik,
+            event,
+            fieldName: 'f2_2a',
+            maxNumberOfDecimals: 5,
+          })
         }
         helperText={gfcrIndicatorSetLanguage.getF2_2a_helper()}
         showHelperText={displayHelp}
@@ -82,7 +97,12 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         onBlur={(event) => handleInputBlur(formik, event, 'f2_2b')}
         onFocus={(event) => handleInputFocus(event)}
         onChange={(event) =>
-          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_2b' })
+          formikHandleNumericDecimalInputChange({
+            formik,
+            event,
+            fieldName: 'f2_2b',
+            maxNumberOfDecimals: 5,
+          })
         }
         helperText={gfcrIndicatorSetLanguage.getF2_2b_helper()}
         showHelperText={displayHelp}
@@ -100,7 +120,12 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         onBlur={(event) => handleInputBlur(formik, event, 'f2_3a')}
         onFocus={(event) => handleInputFocus(event)}
         onChange={(event) =>
-          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_3a' })
+          formikHandleNumericDecimalInputChange({
+            formik,
+            event,
+            fieldName: 'f2_3a',
+            maxNumberOfDecimals: 5,
+          })
         }
         helperText={gfcrIndicatorSetLanguage.getF2_3a_helper()}
         showHelperText={displayHelp}
@@ -118,7 +143,12 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         onBlur={(event) => handleInputBlur(formik, event, 'f2_3b')}
         onFocus={(event) => handleInputFocus(event)}
         onChange={(event) =>
-          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_3b' })
+          formikHandleNumericDecimalInputChange({
+            formik,
+            event,
+            fieldName: 'f2_3b',
+            maxNumberOfDecimals: 5,
+          })
         }
         helperText={gfcrIndicatorSetLanguage.getF2_3b_helper()}
         showHelperText={displayHelp}
@@ -136,7 +166,12 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         onBlur={(event) => handleInputBlur(formik, event, 'f2_4')}
         onFocus={(event) => handleInputFocus(event)}
         onChange={(event) =>
-          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_4' })
+          formikHandleNumericDecimalInputChange({
+            formik,
+            event,
+            fieldName: 'f2_4',
+            maxNumberOfDecimals: 5,
+          })
         }
         helperText={gfcrIndicatorSetLanguage.getF2_4_helper()}
         showHelperText={displayHelp}
@@ -154,7 +189,12 @@ const F2Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus }) => {
         onBlur={(event) => handleInputBlur(formik, event, 'f2_5')}
         onFocus={(event) => handleInputFocus(event)}
         onChange={(event) =>
-          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f2_5' })
+          formikHandleNumericDecimalInputChange({
+            formik,
+            event,
+            fieldName: 'f2_5',
+            maxNumberOfDecimals: 5,
+          })
         }
         helperText={gfcrIndicatorSetLanguage.getF2_5_helper()}
         showHelperText={displayHelp}

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F3Form.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F3Form.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import {
   formikHandleIntegerInputChange,
-  formikHandleNumericTwoDecimalInputChange,
+  formikHandleNumericDecimalInputChange,
 } from '../../../../../library/formikHandleInputTypes'
 import { formikPropType } from '../../../../../library/formikPropType'
 import { H2 } from '../../../../generic/text'
@@ -32,7 +32,12 @@ const F3Form = ({ formik, displayHelp, handleInputBlur, handleInputFocus, getFie
         onBlur={(event) => handleInputBlur(formik, event, 'f3_1')}
         onFocus={(event) => handleInputFocus(event)}
         onChange={(event) =>
-          formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f3_1' })
+          formikHandleNumericDecimalInputChange({
+            formik,
+            event,
+            fieldName: 'f3_1',
+            maxNumberOfDecimals: 5,
+          })
         }
         helperText={gfcrIndicatorSetLanguage.getF3_1_helper()}
         showHelperText={displayHelp}

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F4Form.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/F4Form.js
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { ButtonPrimary } from '../../../../generic/buttons'
-import { formikHandleNumericTwoDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
+import { formikHandleNumericDecimalInputChange } from '../../../../../library/formikHandleInputTypes'
 import { formikPropType } from '../../../../../library/formikPropType'
 import { H2 } from '../../../../generic/text'
 import { InputRow } from '../../../../generic/form'
@@ -180,7 +180,7 @@ const F4Form = ({
           helperText={gfcrIndicatorSetLanguage.getF4_1_helper()}
           showHelperText={displayHelp}
           onChange={(event) =>
-            formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f4_1' })
+            formikHandleNumericDecimalInputChange({ formik, event, fieldName: 'f4_1' })
           }
         />
         {isReport && <StyledValueUpdateText>{f41ValueUpdateText}</StyledValueUpdateText>}
@@ -201,7 +201,7 @@ const F4Form = ({
           helperText={gfcrIndicatorSetLanguage.getF4_2_helper()}
           showHelperText={displayHelp}
           onChange={(event) =>
-            formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f4_2' })
+            formikHandleNumericDecimalInputChange({ formik, event, fieldName: 'f4_2' })
           }
         />
         {isReport && <StyledValueUpdateText>{f42ValueUpdateText}</StyledValueUpdateText>}
@@ -222,7 +222,7 @@ const F4Form = ({
           helperText={gfcrIndicatorSetLanguage.getF4_3_helper()}
           showHelperText={displayHelp}
           onChange={(event) =>
-            formikHandleNumericTwoDecimalInputChange({ formik, event, fieldName: 'f4_3' })
+            formikHandleNumericDecimalInputChange({ formik, event, fieldName: 'f4_3' })
           }
         />
         {isReport && <StyledValueUpdateText>{f43ValueUpdateText}</StyledValueUpdateText>}

--- a/src/library/formikHandleInputTypes.js
+++ b/src/library/formikHandleInputTypes.js
@@ -1,18 +1,26 @@
-export const formikHandleNumericTwoDecimalInputChange = ({ formik, event, fieldName }) => {
+export const formikHandleNumericDecimalInputChange = ({
+  formik,
+  event,
+  fieldName,
+  maxNumberOfDecimals = 2,
+}) => {
   const originalInputValue = event.target.value
   const isNumericOrEmpty = !Number.isNaN(Number(originalInputValue))
   const indexOfDecimal = originalInputValue.indexOf('.')
   const hasDecimal = indexOfDecimal !== -1
-  const hasMoreThanTwoDecimals =
-    hasDecimal && originalInputValue.slice(indexOfDecimal + 1).length > 2
+  const hasMoreThanMaxDecimals =
+    hasDecimal && originalInputValue.slice(indexOfDecimal + 1).length > maxNumberOfDecimals
 
-  if (isNumericOrEmpty && hasMoreThanTwoDecimals) {
-    const truncatedValue = Math.trunc(Number(originalInputValue) * 100) / 100
-    const modifiedInputValue = truncatedValue.toFixed(2)
+  if (isNumericOrEmpty && hasMoreThanMaxDecimals) {
+    const multiplierToCreateTruncatedValue = Math.pow(10, maxNumberOfDecimals)
+    const truncatedValue =
+      Math.trunc(Number(originalInputValue) * multiplierToCreateTruncatedValue) /
+      multiplierToCreateTruncatedValue
+    const modifiedInputValue = truncatedValue.toFixed(maxNumberOfDecimals)
 
     formik.setFieldValue(fieldName, modifiedInputValue)
   }
-  if (isNumericOrEmpty && !hasMoreThanTwoDecimals) {
+  if (isNumericOrEmpty && !hasMoreThanMaxDecimals) {
     formik.setFieldValue(fieldName, originalInputValue)
   }
 }


### PR DESCRIPTION
[Ticket](https://trello.com/c/3aafViyP/1367-f31-in-gfcr-webform-only-allows-2-decimals-need-more-decimals-for-area-based-sub-indicators)

Description:
- update the following form inputs to allow a maximum of 5 decimal places:
  -  F1 - F1.1
  - F2 - F2.1a, F2.1b, F2.2a, F2.2b, F2.3a, F2.3b, F2.4, F2.5
  - F3 - F 3.1
  
  Steps to test: the above GFCR form inputs should allow 5 decimal places
  
  
  Note this is a quick code change to get new requirements into a release before a workshop. Another PR will be made to make the code more intuitive and have all decimal formatting happen via the same means (we also format to 1 decimal place with an `onBlur` function and that will need to be removed for consistency and intuitiveness).
  
  The reason this change will come separately is that it involves more QA and makes no functional changes to the app, so I dont want to include it in a last minute release. 

