### PR TITLE
Reenable pinch zoom for image classification

### DIFF
--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
@@ -176,7 +176,6 @@ const ImageAnnotationModalMap = ({
       minZoom: DEFAULT_ZOOM,
       renderWorldCopies: false, // prevents the image from repeating
       dragRotate: false,
-      touchZoomRotate: false,
       touchPitch: false,
       accessToken: process.env.REACT_APP_MAPBOX_ACCESS_TOKEN,
     })
@@ -553,7 +552,10 @@ const ImageAnnotationModalMap = ({
     map.current.setPaintProperty('patches-outline-layer', 'line-color', lineColor)
   }, [selectedAttributeId, hoveredAttributeId, hoveredPointId, hasMapLoaded, selectedPoint, map])
 
-  const resetZoom = () => easeToDefaultView(map)
+  const resetZoom = () => {
+    map.current.setBearing(0) // If on a touch device, reset the rotation before calling the easeTo function to avoid any potential issues.
+    easeToDefaultView(map)
+  }
   return (
     <ImageAnnotationMapWrapper>
       {!hasMapLoaded ? <LoadingIndicatorImageClassificationImage /> : null}


### PR DESCRIPTION
[Ticket](https://trello.com/c/fgV3EzJE/1352-disable-tilt-on-image)

This is a redo of the oabove ticket to ensure that we can still pinch zoom on touch devices. Unfortunately Mapbox has coupled the toggle to enable zoom to the togle that enables rotate so we have to enable rotate too 👎 

