### PR TITLE
IC zooming refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@iconify/react": "^1.1.4",
     "@mui/material": "^5.13.6",
     "@turf/bbox": "^7.2.0",
+    "@turf/bbox-polygon": "^7.2.0",
+    "@turf/boolean-contains": "^7.2.0",
     "@turf/buffer": "^7.2.0",
     "@turf/centroid": "^7.2.0",
     "axios": "^0.21.1",

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.js
@@ -23,6 +23,7 @@ import { usePointsGeoJson } from './usePointsGeoJson'
 import { useZoomToPointsByAttributeId } from './useZoomToPointsByAttributeId'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import { useHttpResponseErrorHandler } from '../../../../App/HttpResponseErrorHandlerContext'
+import { DEFAULT_MAP_ANIMATION_DURATION } from '../imageClassificationConstants'
 
 const EXCLUDE_PARAMS =
   'classification_status,collect_record_id,comments,created_by,created_on,data,id,location,name,num_confirmed,num_unclassified,num_unconfirmed,photo_timestamp,thumbnail,updated_by,updated_on'
@@ -52,9 +53,25 @@ const ImageAnnotationModal = ({
   const [hasMapLoaded, setHasMapLoaded] = useState(false)
   const [isTableShowing, setIsTableShowing] = useState(true)
   const map = useRef(null)
+  const [patchesGeoJson, setPatchesGeoJson] = useState()
 
   const { imageScale } = useImageScale({ hasMapLoaded, dataToReview })
   const handleHttpResponseError = useHttpResponseErrorHandler()
+
+  const zoomToPaddedBounds = useCallback(
+    (bounds) => {
+      if (!bounds || !map.current) {
+        return
+      }
+
+      map.current.fitBounds(bounds, {
+        padding: 250,
+        duration: DEFAULT_MAP_ANIMATION_DURATION,
+        linear: true,
+      })
+    },
+    [map],
+  )
 
   const { getPointsGeojson, getPointsLabelAnchorsGeoJson } = usePointsGeoJson({
     dataToReview,
@@ -63,8 +80,8 @@ const ImageAnnotationModal = ({
   })
 
   const { zoomToPointsByAttributeId } = useZoomToPointsByAttributeId({
-    getPointsGeojson,
-    mapRef: map,
+    zoomToPaddedBounds,
+    patchesGeoJson,
   })
 
   const getBenthicAttributeLabel = useCallback(
@@ -185,20 +202,23 @@ const ImageAnnotationModal = ({
                 isTableShowing={isTableShowing}
               />
               <ImageAnnotationModalMap
-                dataToReview={dataToReview}
-                setDataToReview={setDataToReview}
-                selectedAttributeId={selectedAttributeId}
-                hoveredAttributeId={hoveredAttributeId}
                 databaseSwitchboardInstance={databaseSwitchboardInstance}
-                setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
+                dataToReview={dataToReview}
                 getPointsGeojson={getPointsGeojson}
                 getPointsLabelAnchorsGeoJson={getPointsLabelAnchorsGeoJson}
                 hasMapLoaded={hasMapLoaded}
+                hoveredAttributeId={hoveredAttributeId}
                 imageScale={imageScale}
-                map={map}
-                setHasMapLoaded={setHasMapLoaded}
-                setIsTableShowing={setIsTableShowing}
                 isTableShowing={isTableShowing}
+                map={map}
+                patchesGeoJson={patchesGeoJson}
+                selectedAttributeId={selectedAttributeId}
+                setDataToReview={setDataToReview}
+                setHasMapLoaded={setHasMapLoaded}
+                setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
+                setIsTableShowing={setIsTableShowing}
+                setPatchesGeoJson={setPatchesGeoJson}
+                zoomToPaddedBounds={zoomToPaddedBounds}
               />
             </ImageAnnotationModalContainer>
           ) : (

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModalMap.js
@@ -3,6 +3,9 @@ import ReactDOM from 'react-dom/client'
 import PropTypes from 'prop-types'
 import maplibregl from 'maplibre-gl'
 import getBounds from '@turf/bbox'
+import buffer from '@turf/buffer'
+import bboxPolygon from '@turf/bbox-polygon'
+import booleanContains from '@turf/boolean-contains'
 
 import {
   IMAGE_CLASSIFICATION_COLORS as COLORS,
@@ -22,9 +25,11 @@ import {
 import ImageAnnotationPopup from './ImageAnnotationPopup/ImageAnnotationPopup'
 import EditPointPopupWrapper from './ImageAnnotationPopup/EditPointPopupWrapper'
 import { getPatchesCenters } from './getPatchesCenters'
-
-const DEFAULT_CENTER = [0, 0] // this value doesn't matter, default to null island
-const DEFAULT_ZOOM = 2 // needs to be > 1 otherwise bounds become > 180 and > 85
+import {
+  DEFAULT_MAP_ANIMATION_DURATION,
+  DEFAULT_MAP_CENTER,
+  DEFAULT_MAP_ZOOM,
+} from '../imageClassificationConstants'
 
 const IMAGE_CLASSIFICATION_COLOR_EXP = [
   'case',
@@ -45,15 +50,20 @@ const pointLabelPopup = new maplibregl.Popup({
 })
 
 const easeToDefaultView = (map) =>
-  map.current.easeTo({ center: DEFAULT_CENTER, zoom: DEFAULT_ZOOM, duration: 500 })
+  map.current.easeTo({
+    center: DEFAULT_MAP_CENTER,
+    zoom: DEFAULT_MAP_ZOOM,
+    duration: DEFAULT_MAP_ANIMATION_DURATION,
+    linear: true,
+  })
 
 // HACK: MapLibre's unproject() (used to get pixel coords) doesn't let you pass zoom as parameter.
 // So to ensure that our points remain in the same position we:
 // 1. store current lnglat/zoom, 2. reset map lnglat/zoom to default,
 // 3. call unproject (to get pixel coords) 4. set back to current lnglat/zoom
 const hackTemporarilySetMapToDefaultPosition = (map) => {
-  map.current.setZoom(DEFAULT_ZOOM)
-  map.current.setCenter(DEFAULT_CENTER)
+  map.current.setZoom(DEFAULT_MAP_ZOOM)
+  map.current.setCenter(DEFAULT_MAP_CENTER)
 }
 const hackResetMapToCurrentPosition = (map, currentZoom, currentCenter) => {
   map.current.setZoom(currentZoom)
@@ -61,20 +71,23 @@ const hackResetMapToCurrentPosition = (map, currentZoom, currentCenter) => {
 }
 
 const ImageAnnotationModalMap = ({
-  dataToReview,
-  setDataToReview,
-  selectedAttributeId,
-  hoveredAttributeId,
   databaseSwitchboardInstance,
-  setIsDataUpdatedSinceLastSave,
+  dataToReview,
   getPointsGeojson,
   getPointsLabelAnchorsGeoJson,
   hasMapLoaded,
+  hoveredAttributeId,
   imageScale,
-  map,
-  setHasMapLoaded,
-  setIsTableShowing,
   isTableShowing,
+  map,
+  patchesGeoJson,
+  selectedAttributeId,
+  setDataToReview,
+  setHasMapLoaded,
+  setIsDataUpdatedSinceLastSave,
+  setIsTableShowing,
+  setPatchesGeoJson,
+  zoomToPaddedBounds,
 }) => {
   const [areLabelsShowing, setAreLabelsShowing] = useState(false)
   const [hoveredPointId, setHoveredPointId] = useState(null)
@@ -131,19 +144,20 @@ const ImageAnnotationModalMap = ({
   }
 
   const updatePointsOnMap = useCallback(() => {
-    const currentZoom = map.current.getZoom()
-    const currentCenter = map.current.getCenter()
+    const currentZoom = map.current?.getZoom()
+    const currentCenter = map.current?.getCenter()
 
     hackTemporarilySetMapToDefaultPosition(map)
-    const patchesGeoJson = getPointsGeojson()
-    const patchesCenters = getPatchesCenters(patchesGeoJson)
+    const patches = getPointsGeojson()
+    const patchesCenters = getPatchesCenters(patches)
+    setPatchesGeoJson(patches)
 
-    map.current?.getSource('patches')?.setData(patchesGeoJson)
+    map.current?.getSource('patches')?.setData(patches)
     map.current?.getSource('patches-center')?.setData(patchesCenters)
     map.current?.getSource('patches-labels')?.setData(getPointsLabelAnchorsGeoJson())
 
     hackResetMapToCurrentPosition(map, currentZoom, currentCenter)
-  }, [getPointsGeojson, getPointsLabelAnchorsGeoJson, map])
+  }, [getPointsGeojson, getPointsLabelAnchorsGeoJson, map, setPatchesGeoJson])
 
   const updateImageSizeOnMap = () => {
     const bounds = map.current.getBounds()
@@ -163,16 +177,16 @@ const ImageAnnotationModalMap = ({
     ])
   }
 
-  const _renderImageMapOnLoad = useEffect(() => {
+  const _initializeMapAndData = useEffect(() => {
     if (hasMapLoaded) {
       return
     }
 
     map.current = new maplibregl.Map({
       container: mapContainer.current,
-      center: DEFAULT_CENTER,
-      zoom: DEFAULT_ZOOM,
-      minZoom: DEFAULT_ZOOM,
+      center: DEFAULT_MAP_CENTER,
+      zoom: DEFAULT_MAP_ZOOM,
+      minZoom: DEFAULT_MAP_ZOOM,
       renderWorldCopies: false, // prevents the image from repeating
       dragRotate: false,
       touchPitch: false,
@@ -182,8 +196,9 @@ const ImageAnnotationModalMap = ({
     map.current.addControl(zoomControl, 'top-left')
 
     const bounds = map.current.getBounds()
-    const pointsGeoJson = getPointsGeojson()
-    const patchesCenters = getPatchesCenters(pointsGeoJson)
+    const patches = getPointsGeojson()
+    const patchesCenters = getPatchesCenters(patches)
+    setPatchesGeoJson(patches)
 
     map.current.setStyle({
       version: 8,
@@ -203,7 +218,7 @@ const ImageAnnotationModalMap = ({
         },
         patches: {
           type: 'geojson',
-          data: pointsGeoJson,
+          data: patches,
         },
         'patches-center': {
           type: 'geojson',
@@ -363,18 +378,8 @@ const ImageAnnotationModalMap = ({
       return
     }
 
-    map.current.fitBounds(selectedPoint.bounds, { padding: 250 })
-  }, [map, selectedPoint.bounds])
-
-  const zoomToBounds = useCallback(
-    (bounds) => {
-      if (!bounds || !map.current) {
-        return
-      }
-      map.current.fitBounds(bounds, { padding: 250, duration: 0 })
-    },
-    [map],
-  )
+    zoomToPaddedBounds(selectedPoint.bounds)
+  }, [map, selectedPoint.bounds, zoomToPaddedBounds])
 
   const selectFeature = useCallback((feature) => {
     const { properties } = feature
@@ -395,25 +400,29 @@ const ImageAnnotationModalMap = ({
       'bottom-left': topRight,
       'bottom-right': topLeft,
     }
-
-    setSelectedPoint({
+    const selectedPointToUse = {
       id: properties.id,
       popupAnchorLngLat: latLngLookupByAnchorPosition[popupAnchorPosition],
       popupAnchorPosition,
       bounds,
-    })
+    }
+    setSelectedPoint(selectedPointToUse)
+
+    return selectedPointToUse
   }, [])
 
   const selectNextUnconfirmedPoint = useCallback(() => {
-    map.current.setZoom(DEFAULT_ZOOM)
-    const { features } = getPointsGeojson()
+    const patchesFeatures = patchesGeoJson?.features
+    if (!patchesFeatures?.length) {
+      return
+    }
 
-    const selectedPointFeaturesIndex = features.findIndex(
+    const selectedPointFeaturesIndex = patchesFeatures.findIndex(
       (feature) => feature.properties.id === selectedPoint.id,
     )
-    const backSectionOfFeaturesArray = features.slice(selectedPointFeaturesIndex + 1)
+    const backSectionOfFeaturesArray = patchesFeatures.slice(selectedPointFeaturesIndex + 1)
 
-    const frontSectionOfFeaturesArray = features.slice(0, selectedPointFeaturesIndex)
+    const frontSectionOfFeaturesArray = patchesFeatures.slice(0, selectedPointFeaturesIndex)
     const featuresArrayOrderedForSearching = [
       ...backSectionOfFeaturesArray,
       ...frontSectionOfFeaturesArray,
@@ -422,11 +431,10 @@ const ImageAnnotationModalMap = ({
       (feature) => !feature.properties.isConfirmed,
     )
 
-    zoomToBounds(getBounds(nextUnconfirmedFeature))
-    map.current.once('idle', () => {
-      selectFeature(nextUnconfirmedFeature)
-    })
-  }, [getPointsGeojson, map, selectFeature, selectedPoint.id, zoomToBounds])
+    zoomToPaddedBounds(getBounds(nextUnconfirmedFeature))
+
+    selectFeature(nextUnconfirmedFeature)
+  }, [patchesGeoJson, selectFeature, selectedPoint.id, zoomToPaddedBounds])
 
   const _displayEditPointPopupOnPointClick = useEffect(() => {
     if (!hasMapLoaded) {
@@ -435,7 +443,29 @@ const ImageAnnotationModalMap = ({
 
     const showFeaturePopupOnClick = ({ features }) => {
       const feature = features[0]
-      selectFeature(feature)
+      const { popupAnchorLngLat } = selectFeature(feature)
+
+      const bufferedFeature = buffer(feature, 1500) // the buffer unit is set by feel for laptop sized screens, it may need to be tweaked as we go
+      const mapBoundsFeature = bboxPolygon(map.current.getBounds().toArray().flat())
+      const isBufferedFeatureCompletelyWithinMapBounds = booleanContains(
+        mapBoundsFeature,
+        bufferedFeature,
+      )
+      const shouldAlsoZoom = map.current.getZoom() > 4.5
+      const easeToOptions = {
+        center: popupAnchorLngLat,
+        duration: DEFAULT_MAP_ANIMATION_DURATION,
+      }
+      if (shouldAlsoZoom) {
+        // Setting null zoom on easeTo will zoom all the way out;
+        // setting undefined will cause errors, so we need to make
+        // the zoom setting conditional.
+        easeToOptions.zoom = 4.5
+      }
+
+      if (!isBufferedFeatureCompletelyWithinMapBounds) {
+        map.current.easeTo(easeToOptions)
+      }
     }
 
     const hideFeaturePopup = ({ point }) => {
@@ -453,7 +483,7 @@ const ImageAnnotationModalMap = ({
       map.current.off('click', 'patches-fill-layer', showFeaturePopupOnClick)
       map.current.off('click', hideFeaturePopup)
     }
-  }, [dataToReview, hasMapLoaded, map, selectFeature])
+  }, [hasMapLoaded, map, selectFeature, zoomToPaddedBounds])
 
   const _updateStyleOnPointHover = useEffect(() => {
     if (!hasMapLoaded) {
@@ -606,20 +636,23 @@ const ImageAnnotationModalMap = ({
 }
 
 ImageAnnotationModalMap.propTypes = {
-  dataToReview: imageClassificationResponsePropType.isRequired,
-  setDataToReview: PropTypes.func.isRequired,
-  selectedAttributeId: PropTypes.string.isRequired,
-  hoveredAttributeId: PropTypes.string.isRequired,
   databaseSwitchboardInstance: PropTypes.object.isRequired,
-  setIsDataUpdatedSinceLastSave: PropTypes.func.isRequired,
+  dataToReview: imageClassificationResponsePropType.isRequired,
   getPointsGeojson: PropTypes.func.isRequired,
   getPointsLabelAnchorsGeoJson: PropTypes.func.isRequired,
   hasMapLoaded: PropTypes.bool.isRequired,
+  hoveredAttributeId: PropTypes.string.isRequired,
   imageScale: PropTypes.number.isRequired,
-  map: PropTypes.object.isRequired,
-  setHasMapLoaded: PropTypes.func.isRequired,
   isTableShowing: PropTypes.bool.isRequired,
+  map: PropTypes.object.isRequired,
+  patchesGeoJson: PropTypes.object.isRequired,
+  selectedAttributeId: PropTypes.string.isRequired,
+  setDataToReview: PropTypes.func.isRequired,
+  setHasMapLoaded: PropTypes.func.isRequired,
+  setIsDataUpdatedSinceLastSave: PropTypes.func.isRequired,
   setIsTableShowing: PropTypes.func.isRequired,
+  setPatchesGeoJson: PropTypes.func.isRequired,
+  zoomToPaddedBounds: PropTypes.func.isRequired,
 }
 
 export default ImageAnnotationModalMap

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/ImageAnnotationPopup.js
@@ -62,30 +62,29 @@ const ImageAnnotationPopup = ({
 
   return (
     <>
-      <form>
-        {areAnyClassifierGuesses ? (
-          <EditPointPopupWrapper aria-labelledby="table-label">
-            <PointPopupSectionHeader>
-              <span>Classifier Guesses</span>
-              <span>Confidence</span>
-            </PointPopupSectionHeader>
+      {areAnyClassifierGuesses ? (
+        <EditPointPopupWrapper aria-labelledby="table-label">
+          <PointPopupSectionHeader>
+            <span>Classifier Guesses</span>
+            <span>Confidence</span>
+          </PointPopupSectionHeader>
 
-            <ClassifierGuesses
-              selectedPoint={selectedPoint}
-              dataToReview={dataToReview}
-              setDataToReview={setDataToReview}
-              setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
-            />
-          </EditPointPopupWrapper>
-        ) : null}
-        <SelectAttributeFromClassifierGuesses
-          selectedPoint={selectedPoint}
-          dataToReview={dataToReview}
-          setDataToReview={setDataToReview}
-          setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
-          databaseSwitchboardInstance={databaseSwitchboardInstance}
-        />
-      </form>
+          <ClassifierGuesses
+            selectedPoint={selectedPoint}
+            dataToReview={dataToReview}
+            setDataToReview={setDataToReview}
+            setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
+          />
+        </EditPointPopupWrapper>
+      ) : null}
+      <SelectAttributeFromClassifierGuesses
+        selectedPoint={selectedPoint}
+        dataToReview={dataToReview}
+        setDataToReview={setDataToReview}
+        setIsDataUpdatedSinceLastSave={setIsDataUpdatedSinceLastSave}
+        databaseSwitchboardInstance={databaseSwitchboardInstance}
+      />
+
       <PopupBottomRow>
         <PopupZoomButtonContainer>
           <PopupIconButton type="button" onClick={resetZoom}>

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/useZoomToPointsByAttributeId.js
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/useZoomToPointsByAttributeId.js
@@ -1,28 +1,21 @@
 // importing from @turf/turf causes issues with tests, so import each utility individually
 import bbox from '@turf/bbox'
-import buffer from '@turf/buffer'
 
-export const useZoomToPointsByAttributeId = ({ getPointsGeojson, mapRef }) => {
+export const useZoomToPointsByAttributeId = ({ patchesGeoJson, zoomToPaddedBounds }) => {
   const zoomToPointsByAttributeId = (attributeId) => {
-    // we need to zoom out first to reset the bounds so that zooming in works properly
-    // since the points geojson is created using the maps current bounds
-    mapRef.current.setZoom(0)
+    if (!patchesGeoJson.features.length) {
+      return
+    }
 
-    const pointsGeoJson = getPointsGeojson()
-    const featuresAssociatedWithAttribute = pointsGeoJson.features.filter(
+    const featuresAssociatedWithAttribute = patchesGeoJson.features.filter(
       (feature) => feature.properties.ba_gr === attributeId,
     )
-    const zoomInBounds = bbox(
-      buffer(
-        {
-          type: 'FeatureCollection',
-          features: featuresAssociatedWithAttribute,
-        },
-        500,
-      ),
-    )
 
-    mapRef.current.fitBounds(zoomInBounds, { duration: 0 })
+    const pointsBounds = bbox({
+      type: 'FeatureCollection',
+      features: featuresAssociatedWithAttribute,
+    })
+    zoomToPaddedBounds(pointsBounds)
   }
 
   return { zoomToPointsByAttributeId }

--- a/src/components/pages/ImageClassification/imageClassificationConstants.js
+++ b/src/components/pages/ImageClassification/imageClassificationConstants.js
@@ -1,2 +1,5 @@
 export const EXCLUDE_PARAMS_FOR_GET_ALL_IMAGES_IN_COLLECT_RECORD =
   'data,created_by,updated_by,updated_on,original_image_width,original_image_height,location,comments,image,photo_timestamp'
+export const DEFAULT_MAP_CENTER = [0, 0] // this value doesn't matter, default to null island
+export const DEFAULT_MAP_ZOOM = 2 // needs to be > 1 otherwise bounds become > 180 and > 85
+export const DEFAULT_MAP_ANIMATION_DURATION = 1000

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,6 +3265,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@turf/bbox-polygon@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@turf/bbox-polygon@npm:7.2.0"
+  dependencies:
+    "@turf/helpers": "npm:^7.2.0"
+    "@types/geojson": "npm:^7946.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/c0b35639fdefae3fddd6345a44ece35f7d411faf07c274731a2ec6fa2e94bce9be7864d86f7618594161ac12dcf3ae7c7f978225a7baeabe1f82d1211ff99c40
+  languageName: node
+  linkType: hard
+
 "@turf/bbox@npm:^7.2.0":
   version: 7.2.0
   resolution: "@turf/bbox@npm:7.2.0"
@@ -3274,6 +3285,46 @@ __metadata:
     "@types/geojson": "npm:^7946.0.10"
     tslib: "npm:^2.8.1"
   checksum: 10c0/766d59d5f75c272481e971cd4004e139962607e8f34391b2abfb15bb34f9544a0479ceb14772565e005e4a12fdd82adf0d440ab1c9e0decbde6de50a5706db43
+  languageName: node
+  linkType: hard
+
+"@turf/boolean-contains@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@turf/boolean-contains@npm:7.2.0"
+  dependencies:
+    "@turf/bbox": "npm:^7.2.0"
+    "@turf/boolean-point-in-polygon": "npm:^7.2.0"
+    "@turf/boolean-point-on-line": "npm:^7.2.0"
+    "@turf/helpers": "npm:^7.2.0"
+    "@turf/invariant": "npm:^7.2.0"
+    "@types/geojson": "npm:^7946.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/ae3ac8e4d3607b9700b4a5ab622ece503baaeb5ab08987fab6e7c626e50a42555cddc653f6608bc266306c33f92bf6eeeb05a4839abb2cc486275105567c9bf7
+  languageName: node
+  linkType: hard
+
+"@turf/boolean-point-in-polygon@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@turf/boolean-point-in-polygon@npm:7.2.0"
+  dependencies:
+    "@turf/helpers": "npm:^7.2.0"
+    "@turf/invariant": "npm:^7.2.0"
+    "@types/geojson": "npm:^7946.0.10"
+    point-in-polygon-hao: "npm:^1.1.0"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/eeb431f70175e466205b27076dbc331b862d3e6867d43730ac4099ecd7e6d6f0fed9e3301fd29f6375f340e379f477489f09060e6aec9fc0f7afa01ac58d5c09
+  languageName: node
+  linkType: hard
+
+"@turf/boolean-point-on-line@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@turf/boolean-point-on-line@npm:7.2.0"
+  dependencies:
+    "@turf/helpers": "npm:^7.2.0"
+    "@turf/invariant": "npm:^7.2.0"
+    "@types/geojson": "npm:^7946.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/a7f81170ff795025f209602559a289330304adf046340133e1b18f950aca386e8f2d4f1f91b85c2456306d95359fdd19b8323c13f88327491dbf2f196fa1e635
   languageName: node
   linkType: hard
 
@@ -3335,6 +3386,17 @@ __metadata:
     "@types/geojson": "npm:^7946.0.10"
     tslib: "npm:^2.8.1"
   checksum: 10c0/4d6f57164cca00ec7a18e2d3c0200d0274e4ab2b6b3201c6a867b867d899f3f618a82ae242617d467efb04f32740cec150ae06a0e07ee39318397ebc34914687
+  languageName: node
+  linkType: hard
+
+"@turf/invariant@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@turf/invariant@npm:7.2.0"
+  dependencies:
+    "@turf/helpers": "npm:^7.2.0"
+    "@types/geojson": "npm:^7946.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/6968b766d5522488bb2b149a72f863e3f0d4bb0342b14f3992e3e920d9e32c252e1e07e84213732cb51609aef7a82833a8fe76b1c7d0db4cd384954cfedaa4e5
   languageName: node
   linkType: hard
 
@@ -11745,6 +11807,8 @@ __metadata:
     "@testing-library/react": "npm:^16.2.0"
     "@testing-library/user-event": "npm:^14.6.1"
     "@turf/bbox": "npm:^7.2.0"
+    "@turf/bbox-polygon": "npm:^7.2.0"
+    "@turf/boolean-contains": "npm:^7.2.0"
     "@turf/buffer": "npm:^7.2.0"
     "@turf/centroid": "npm:^7.2.0"
     axios: "npm:^0.21.1"
@@ -13119,6 +13183,15 @@ __metadata:
   bin:
     plop: bin/plop.js
   checksum: 10c0/eeb8b352a3f82d3d825d9152b36f302c2384ac1b3fd66e7dea2f16f21955c3d836c59e24e3f366fe72536fc0f16b78be80ad9fa55e116d8c35ce7e8c80cc3cd1
+  languageName: node
+  linkType: hard
+
+"point-in-polygon-hao@npm:^1.1.0":
+  version: 1.2.4
+  resolution: "point-in-polygon-hao@npm:1.2.4"
+  dependencies:
+    robust-predicates: "npm:^3.0.2"
+  checksum: 10c0/12badef8b15216acdae7d609a8aca1b916d6a9cac2f53ace2928e3b521bee57224489ea8fba41d001c0c05c50e64152c175e3d6583d8cad6fe7af929f082b49a
   languageName: node
   linkType: hard
 
@@ -15061,6 +15134,13 @@ __metadata:
   bin:
     rimraf: dist/esm/bin.mjs
   checksum: 10c0/7da4fd0e15118ee05b918359462cfa1e7fe4b1228c7765195a45b55576e8c15b95db513b8466ec89129666f4af45ad978a3057a02139afba1a63512a2d9644cc
+  languageName: node
+  linkType: hard
+
+"robust-predicates@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "robust-predicates@npm:3.0.2"
+  checksum: 10c0/4ecd53649f1c2d49529c85518f2fa69ffb2f7a4453f7fd19c042421c7b4d76c3efb48bc1c740c8f7049346d7cb58cf08ee0c9adaae595cc23564d360adb1fde4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[Ticket](https://trello.com/c/X2Y93X1g/1385-look-into-adding-more-buffer-to-zoom-when-ic-popover-opened)

Description of work: refactored some of the base code for image classification so that we dont need weird zoom hacks to create a sub par at best zooming experience (we previously needed to zoom out before other zooming). This included updating the zoom behaviour for:
- table zoom button
- reset zoom
- next unconfirmed point button
- popup zoom in and out buttons
- clicking a point/patch when its slightly offscreen will now attempt to ensure popup is visible (this isnt perfect but it should be an improvement. Its also tuned for small laptop screensizes and fairly useless on phone screen sizes)


Steps to test:
- play with the above zoom features ensuring they work to an acceptable level.
- since this refactored some code stuff, if _anything_ in the IC feature seems off, please mention it (we are going to merge this and use it in an upcoming workshop)