### PR TITLE
[M1459] Zoom to the map extent using the project’s bbox or the sample event’s lat/lng

### DIFF
--- a/src/components/ProjectName/ProjectName.jsx
+++ b/src/components/ProjectName/ProjectName.jsx
@@ -88,7 +88,7 @@ const ProjectName = () => {
       <MuiTooltip title={language.pages.gotoExplore('this project')} placement="top" arrow>
         <IconButton
           type="button"
-          aria-label="View MERMAID Explore"
+          aria-label={language.accessibilityText.viewMERMAIDExplore}
           onClick={handleExploreButtonClick}
         >
           <BiggerIconGlobe />

--- a/src/components/ProjectName/ProjectName.jsx
+++ b/src/components/ProjectName/ProjectName.jsx
@@ -1,5 +1,5 @@
-import { useParams } from 'react-router-dom'
 import React, { useState, useEffect } from 'react'
+import { useParams } from 'react-router-dom'
 import { toast } from 'react-toastify'
 import styled, { css } from 'styled-components'
 import theme from '../../theme'
@@ -10,6 +10,7 @@ import useIsMounted from '../../library/useIsMounted'
 import { useCurrentUser } from '../../App/CurrentUserContext'
 import { useExploreLaunchFeature } from '../../library/useExploreLaunchFeature'
 import { getToastArguments } from '../../library/getToastArguments'
+import { useOnlineStatus } from '../../library/onlineStatusContext'
 import { IconGlobe } from '../icons'
 import { MuiTooltip } from '../generic/MuiTooltip'
 import { IconButton } from '../generic/buttons'
@@ -47,57 +48,68 @@ const BiggerIconGlobe = styled(IconGlobe)`
 `
 
 const ProjectName = () => {
-  const [projectName, setProjectName] = useState('')
-  const [isTestProject, setIsTestProject] = useState(false)
   const isMounted = useIsMounted()
   const { projectId } = useParams()
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
+  const { isAppOnline } = useOnlineStatus()
   const { currentUser } = useCurrentUser()
   const { mermaidExploreLink, isExploreLaunchEnabledForUser } = useExploreLaunchFeature({
     currentUser,
   })
+  const [project, setProject] = useState({})
 
   const _getProjectName = useEffect(() => {
     if (databaseSwitchboardInstance) {
       databaseSwitchboardInstance.getProject(projectId).then((projectResponse) => {
         if (isMounted.current) {
-          setProjectName(projectResponse?.name)
-          setIsTestProject(projectResponse?.status < 90)
+          setProject(projectResponse)
         }
       })
     }
   }, [databaseSwitchboardInstance, isMounted, projectId])
 
   const handleExploreButtonClick = () => {
-    if (!projectName) {
-      toast.error(...getToastArguments(language.error.noProjectMermaidExplore))
-      return
+    const { name, bbox } = project
+    const queryParams = new URLSearchParams({ project: name })
+
+    if (bbox) {
+      queryParams.append('bbox', `${bbox.xmin},${bbox.ymin},${bbox.xmax},${bbox.ymax}`)
     }
 
-    window.open(`${mermaidExploreLink}/?project=${projectName}`, '_blank')
+    window.open(`${mermaidExploreLink}/?${queryParams.toString()}`, '_blank')
   }
 
-  const mermaidExploreButton = isExploreLaunchEnabledForUser ? (
-    <MuiTooltip title={language.pages.gotoExplore('this project')} placement="top" arrow>
-      <IconButton
-        type="button"
-        aria-label="View MERMAID Explore"
-        onClick={handleExploreButtonClick}
-      >
-        <BiggerIconGlobe />
-      </IconButton>
-    </MuiTooltip>
-  ) : (
-    <ProjectNameLink href={`${mermaidExploreLink}/?project=${projectName}`} target="_blank">
-      <IconGlobe />
-      <span>{language.pages.goToDashboard}</span>
-    </ProjectNameLink>
-  )
+  const renderExploreButton = () => {
+    const isTestProject = project?.status < 90
+
+    if (!isAppOnline || isTestProject) {
+      return null
+    }
+
+    const exploreButtonContent = isExploreLaunchEnabledForUser ? (
+      <MuiTooltip title={language.pages.gotoExplore('this project')} placement="top" arrow>
+        <IconButton
+          type="button"
+          aria-label="View MERMAID Explore"
+          onClick={handleExploreButtonClick}
+        >
+          <BiggerIconGlobe />
+        </IconButton>
+      </MuiTooltip>
+    ) : (
+      <ProjectNameLink href={`${mermaidExploreLink}/?project=${project?.name}`} target="_blank">
+        <IconGlobe />
+        <span>{language.pages.goToDashboard}</span>
+      </ProjectNameLink>
+    )
+
+    return exploreButtonContent
+  }
 
   return (
     <ProjectNameWrapper>
-      <ProjectNameHeader>{projectName}</ProjectNameHeader>
-      {!isTestProject ? mermaidExploreButton : null}
+      <ProjectNameHeader>{project?.name}</ProjectNameHeader>
+      {renderExploreButton()}
     </ProjectNameWrapper>
   )
 }

--- a/src/components/ProjectName/ProjectName.jsx
+++ b/src/components/ProjectName/ProjectName.jsx
@@ -12,6 +12,7 @@ import { useExploreLaunchFeature } from '../../library/useExploreLaunchFeature'
 import { getToastArguments } from '../../library/getToastArguments'
 import { useOnlineStatus } from '../../library/onlineStatusContext'
 import { openExploreLinkWithBbox } from '../../library/openExploreLinkWithBbox'
+import { PROJECT_CODES } from '../../library/constants/constants'
 import { IconGlobe } from '../icons'
 import { MuiTooltip } from '../generic/MuiTooltip'
 import { IconButton } from '../generic/buttons'
@@ -77,7 +78,7 @@ const ProjectName = () => {
   }
 
   const renderExploreButton = () => {
-    const isTestProject = project?.status < 90
+    const isTestProject = project?.status === PROJECT_CODES.status.test
 
     if (!isAppOnline || isTestProject) {
       return null

--- a/src/components/ProjectName/ProjectName.jsx
+++ b/src/components/ProjectName/ProjectName.jsx
@@ -88,7 +88,7 @@ const ProjectName = () => {
       <MuiTooltip title={language.pages.gotoExplore('this project')} placement="top" arrow>
         <IconButton
           type="button"
-          aria-label={language.accessibilityText.viewMERMAIDExplore}
+          aria-label={language.pages.gotoExplore('this project')}
           onClick={handleExploreButtonClick}
         >
           <BiggerIconGlobe />

--- a/src/components/ProjectName/ProjectName.jsx
+++ b/src/components/ProjectName/ProjectName.jsx
@@ -11,6 +11,7 @@ import { useCurrentUser } from '../../App/CurrentUserContext'
 import { useExploreLaunchFeature } from '../../library/useExploreLaunchFeature'
 import { getToastArguments } from '../../library/getToastArguments'
 import { useOnlineStatus } from '../../library/onlineStatusContext'
+import { openExploreLinkWithBbox } from '../../library/openExploreLinkWithBbox'
 import { IconGlobe } from '../icons'
 import { MuiTooltip } from '../generic/MuiTooltip'
 import { IconButton } from '../generic/buttons'
@@ -72,11 +73,7 @@ const ProjectName = () => {
     const { name, bbox } = project
     const queryParams = new URLSearchParams({ project: name })
 
-    if (bbox) {
-      queryParams.append('bbox', `${bbox.xmin},${bbox.ymin},${bbox.xmax},${bbox.ymax}`)
-    }
-
-    window.open(`${mermaidExploreLink}/?${queryParams.toString()}`, '_blank')
+    openExploreLinkWithBbox(mermaidExploreLink, queryParams, bbox)
   }
 
   const renderExploreButton = () => {

--- a/src/components/ProjectToolBarSection/ProjectToolBarSection.jsx
+++ b/src/components/ProjectToolBarSection/ProjectToolBarSection.jsx
@@ -128,7 +128,7 @@ const ProjectToolBarSection = ({
             >
               <IconButton
                 type="button"
-                aria-label={language.accessibilityText.viewMERMAIDExplore}
+                aria-label={language.pages.gotoExplore('all your projects')}
                 onClick={handleExploreButtonClick}
               >
                 <BiggerIconGlobe />

--- a/src/components/ProjectToolBarSection/ProjectToolBarSection.jsx
+++ b/src/components/ProjectToolBarSection/ProjectToolBarSection.jsx
@@ -120,7 +120,7 @@ const ProjectToolBarSection = ({
       <RowWrapper>
         <HeaderStyle>
           Projects
-          {isExploreLaunchEnabledForUser && (
+          {isExploreLaunchEnabledForUser && isAppOnline && (
             <MuiTooltip
               title={language.pages.gotoExplore('all your projects')}
               placement="top"

--- a/src/components/ProjectToolBarSection/ProjectToolBarSection.jsx
+++ b/src/components/ProjectToolBarSection/ProjectToolBarSection.jsx
@@ -128,7 +128,7 @@ const ProjectToolBarSection = ({
             >
               <IconButton
                 type="button"
-                aria-label="View MERMAID Explore"
+                aria-label={language.accessibilityText.viewMERMAIDExplore}
                 onClick={handleExploreButtonClick}
               >
                 <BiggerIconGlobe />

--- a/src/components/RecordFormTitle/RecordFormTitle.jsx
+++ b/src/components/RecordFormTitle/RecordFormTitle.jsx
@@ -121,7 +121,7 @@ const RecordFormTitle = ({
         <MuiTooltip title={language.pages.gotoExplore('this Sample Event')} placement="top" arrow>
           <IconButton
             type="button"
-            aria-label="View MERMAID Explore"
+            aria-label={language.accessibilityText.viewMERMAIDExplore}
             onClick={handleExploreButtonClick}
           >
             <BiggerIconGlobe />

--- a/src/components/RecordFormTitle/RecordFormTitle.jsx
+++ b/src/components/RecordFormTitle/RecordFormTitle.jsx
@@ -76,16 +76,16 @@ const RecordFormTitle = ({
   )
 
   const handleExploreButtonClick = () => {
-    if (!sampleEventId || siteCoordinates.length === 0) {
-      toast.error(...getToastArguments(language.error.noLocationMermaidExplore))
-      return
+    const [lng, lat] = siteCoordinates
+    const queryParams = new URLSearchParams({ sample_event_id: sampleEventId })
+
+    if (lat != null && lng != null) {
+      queryParams.append('lat', lat)
+      queryParams.append('lng', lng)
+      queryParams.append('zoom', '15')
     }
 
-    const [lng, lat] = siteCoordinates
-    window.open(
-      `${mermaidExploreLink}/?sample_event_id=${sampleEventId}&lat=${lat}&lng=${lng}&zoom=15`,
-      '_blank',
-    )
+    window.open(`${mermaidExploreLink}/?${queryParams.toString()}`, '_blank')
   }
 
   return (

--- a/src/components/RecordFormTitle/RecordFormTitle.jsx
+++ b/src/components/RecordFormTitle/RecordFormTitle.jsx
@@ -117,7 +117,7 @@ const RecordFormTitle = ({
       {label && (
         <ProjectTooltip forwardedAs="h2" text={label} tooltipText="Label" id="label-tooltip" />
       )}
-      {isExploreLaunchEnabledForUser && (
+      {isExploreLaunchEnabledForUser && sampleEventId && (
         <MuiTooltip title={language.pages.gotoExplore('this Sample Event')} placement="top" arrow>
           <IconButton
             type="button"

--- a/src/components/RecordFormTitle/RecordFormTitle.jsx
+++ b/src/components/RecordFormTitle/RecordFormTitle.jsx
@@ -121,7 +121,7 @@ const RecordFormTitle = ({
         <MuiTooltip title={language.pages.gotoExplore('this Sample Event')} placement="top" arrow>
           <IconButton
             type="button"
-            aria-label={language.accessibilityText.viewMERMAIDExplore}
+            aria-label={language.pages.gotoExplore('this Sample Event')}
             onClick={handleExploreButtonClick}
           >
             <BiggerIconGlobe />

--- a/src/components/pages/Projects/Projects.jsx
+++ b/src/components/pages/Projects/Projects.jsx
@@ -113,9 +113,17 @@ const Projects = () => {
   }
 
   const handleExploreButtonClick = () => {
-    const yourMermaidExploreProjectsLink = `${mermaidExploreLink}/?your_projects_only=true`
+    const { projects_bbox } = currentUser
+    const queryParams = new URLSearchParams({ your_projects_only: 'true' })
 
-    window.open(yourMermaidExploreProjectsLink, '_blank')
+    if (projects_bbox) {
+      queryParams.append(
+        'bbox',
+        `${projects_bbox.xmin},${projects_bbox.ymin},${projects_bbox.xmax},${projects_bbox.ymax}`,
+      )
+    }
+
+    window.open(`${mermaidExploreLink}/?${queryParams.toString()}`, '_blank')
   }
 
   const renderPageNoData = () => {

--- a/src/components/pages/Projects/Projects.jsx
+++ b/src/components/pages/Projects/Projects.jsx
@@ -20,6 +20,7 @@ import { sortArrayByObjectKey } from '../../../library/arrays/sortArrayByObjectK
 import ErrorBoundary from '../../ErrorBoundary'
 import { useHttpResponseErrorHandler } from '../../../App/HttpResponseErrorHandlerContext'
 import { useExploreLaunchFeature } from '../../../library/useExploreLaunchFeature'
+import { openExploreLinkWithBbox } from '../../../library/openExploreLinkWithBbox'
 
 /**
  * All Projects page (lists projects)
@@ -116,14 +117,7 @@ const Projects = () => {
     const { projects_bbox } = currentUser
     const queryParams = new URLSearchParams({ your_projects_only: 'true' })
 
-    if (projects_bbox) {
-      queryParams.append(
-        'bbox',
-        `${projects_bbox.xmin},${projects_bbox.ymin},${projects_bbox.xmax},${projects_bbox.ymax}`,
-      )
-    }
-
-    window.open(`${mermaidExploreLink}/?${queryParams.toString()}`, '_blank')
+    openExploreLinkWithBbox(mermaidExploreLink, queryParams, projects_bbox)
   }
 
   const renderPageNoData = () => {

--- a/src/language.jsx
+++ b/src/language.jsx
@@ -503,7 +503,7 @@ const pages = {
       setUpDataSharing: 'Set up data sharing policy',
       addOrRemoveProjectMembers: 'Add or remove project members',
       viewMemberEmail: 'View project member email',
-      delete: 'Delete a project'
+      delete: 'Delete a project',
     },
     dataCollection: {
       title: 'Data collection and management',
@@ -516,9 +516,8 @@ const pages = {
       transferSampleUnits: 'Transfer unsubmitted sample units',
       downloadSampleUnits: 'Download submitted sample units',
       viewObserversAndSampleUnits: 'View observers and sample units overview',
-      viewRegimesOverview: 'View management regimes overview'
-
-    }
+      viewRegimesOverview: 'View management regimes overview',
+    },
   },
   userDoesntHaveProjectAccess: {
     title: 'You do not have permission to access this project.',
@@ -1628,6 +1627,10 @@ const imageClassification = {
   },
 }
 
+const accessibilityText = {
+  viewMERMAIDExplore: 'View MERMAID Explore',
+}
+
 export default {
   apiDataTableNames,
   autocomplete,
@@ -1659,4 +1662,5 @@ export default {
   table,
   title,
   tooltipText,
+  accessibilityText,
 }

--- a/src/language.jsx
+++ b/src/language.jsx
@@ -1627,10 +1627,6 @@ const imageClassification = {
   },
 }
 
-const accessibilityText = {
-  viewMERMAIDExplore: 'View MERMAID Explore',
-}
-
 export default {
   apiDataTableNames,
   autocomplete,
@@ -1662,5 +1658,4 @@ export default {
   table,
   title,
   tooltipText,
-  accessibilityText,
 }

--- a/src/library/openExploreLinkWithBbox.js
+++ b/src/library/openExploreLinkWithBbox.js
@@ -1,0 +1,18 @@
+/**
+ * Opens a new browser tab with a constructed URL that includes query parameters and an optional bounding box (bbox).
+ *
+ * @param {string} baseLink - The base URL to which query parameters will be appended.
+ * @param {Object} queryParamsObject - An object containing key-value pairs to be converted into query parameters.
+ * @param {Object} [bbox] - An optional bounding box object with properties xmin, ymin, xmax, and ymax.
+ *                          If provided, it will be appended to the query parameters as "bbox".
+ *                          Example: { xmin: -75.0, ymin: 45.0, xmax: -74.0, ymax: 46.0 }
+ */
+export const openExploreLinkWithBbox = (baseLink, queryParamsObject, bbox) => {
+  const queryParams = new URLSearchParams(queryParamsObject)
+
+  if (bbox) {
+    queryParams.append('bbox', `${bbox.xmin},${bbox.ymin},${bbox.xmax},${bbox.ymax}`)
+  }
+
+  window.open(`${baseLink}/?${queryParams.toString()}`, '_blank')
+}

--- a/src/library/useExploreLaunchFeature.js
+++ b/src/library/useExploreLaunchFeature.js
@@ -1,7 +1,7 @@
 import { getCurrentUserOptionalFeature } from './getCurrentUserOptionalFeature'
 
 export const useExploreLaunchFeature = ({ currentUser }) => {
-  const { enabled: isExploreLaunchEnabledForUser = false } = getCurrentUserOptionalFeature(
+  const { enabled: isExploreLaunchEnabledForUser = true } = getCurrentUserOptionalFeature(
     currentUser,
     'explore_launch',
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Explore button and links now include bounding box parameters when available, providing more context-specific navigation.
- **Bug Fixes**
  - Explore buttons are now hidden when the app is offline, ensuring accurate button visibility.
  - Explore button rendering now requires a valid sample event ID, preventing invalid launches.
- **Refactor**
  - Improved URL construction for Explore links for greater flexibility and reliability.
  - Consolidated project-related state for cleaner component logic.
  - Extracted Explore link opening logic into a reusable utility function.
- **Chores**
  - The Explore feature is now enabled by default for users unless explicitly disabled.
  - Accessibility labels for Explore buttons updated to use localized text strings.
  - Minor syntax fixes in localization files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->