### PR TITLE
M1365

### DIFF
--- a/src/components/Header/Header.styles.js
+++ b/src/components/Header/Header.styles.js
@@ -13,7 +13,7 @@ export const StyledHeader = styled('header')`
   position: fixed;
   width: 100%;
   top: 0;
-  z-index: 102;
+  z-index: ${theme.zIndex.toolbar};
   height: ${theme.spacing.headerHeight};
 `
 export const UserButton = styled('button')`

--- a/src/components/Layout/subLayouts/ContentPageLayout/ContentPageLayout.jsx
+++ b/src/components/Layout/subLayouts/ContentPageLayout/ContentPageLayout.jsx
@@ -38,7 +38,7 @@ const ContentToolbar = styled('div')`
   padding: ${theme.spacing.small} ${theme.spacing.medium};
   border-bottom: solid ${theme.spacing.borderMedium} ${theme.color.backgroundColor};
   margin-bottom: 0;
-  z-index: 10;
+  z-index: ${({ theme }) => theme.zIndex.toolbar};
   ${(props) =>
     props.isToolbarSticky &&
     css`

--- a/src/components/Layout/subLayouts/ContentPageLayout/ContentPageLayout.jsx
+++ b/src/components/Layout/subLayouts/ContentPageLayout/ContentPageLayout.jsx
@@ -38,7 +38,7 @@ const ContentToolbar = styled('div')`
   padding: ${theme.spacing.small} ${theme.spacing.medium};
   border-bottom: solid ${theme.spacing.borderMedium} ${theme.color.backgroundColor};
   margin-bottom: 0;
-  z-index: 100;
+  z-index: 10;
   ${(props) =>
     props.isToolbarSticky &&
     css`

--- a/src/components/Layout/subLayouts/ContentPageLayout/ContentPageLayout.jsx
+++ b/src/components/Layout/subLayouts/ContentPageLayout/ContentPageLayout.jsx
@@ -38,7 +38,7 @@ const ContentToolbar = styled('div')`
   padding: ${theme.spacing.small} ${theme.spacing.medium};
   border-bottom: solid ${theme.spacing.borderMedium} ${theme.color.backgroundColor};
   margin-bottom: 0;
-  z-index: ${({ theme }) => theme.zIndex.toolbar};
+  z-index: ${theme.zIndex.toolbar};
   ${(props) =>
     props.isToolbarSticky &&
     css`

--- a/src/components/NewAttributeModal/NewAttributeModal.jsx
+++ b/src/components/NewAttributeModal/NewAttributeModal.jsx
@@ -11,7 +11,7 @@ import { ButtonThatLooksLikeLink, ButtonPrimary, ButtonSecondary } from '../gene
 import { IconArrowBack, IconSend } from '../icons'
 import { Input } from '../generic/form'
 import { Row, RowSpaceBetween } from '../generic/positioning'
-import InputAutocomplete from '../generic/InputAutocomplete'
+import InputAutocomplete from '../generic/InputAutocomplete/InputAutocomplete'
 import { Table, Td, Tr } from '../generic/Table/table'
 import language from '../../language'
 import { getToastArguments } from '../../library/getToastArguments'

--- a/src/components/ObservationAutocomplete/ObservationAutocomplete.jsx
+++ b/src/components/ObservationAutocomplete/ObservationAutocomplete.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import InputAutocomplete from '../generic/InputAutocomplete'
+import InputAutocomplete from '../generic/InputAutocomplete/InputAutocomplete'
 
 export const StyledInputAutocomplete = styled(InputAutocomplete)`
   & input {

--- a/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
@@ -15,15 +15,20 @@ const AutoCompleteInput = styled(Input)`
 const AutoCompleteResultsWrapper = styled.div`
   position: relative;
 
-  & > p {
+  & > div {
+    z-index: 110;
     position: absolute;
     display: block;
     width: 100%;
-    padding: 1rem;
-    top: 2.5rem;
+    top: 4rem;
     outline: ${theme.color.outline};
     outline-offset: -2px;
     background: ${theme.color.white};
+
+    > * {
+      margin: 0;
+      padding: ${theme.spacing.buttonPadding};
+    }
   }
 
   button {
@@ -170,12 +175,10 @@ const InputAutocomplete = ({
               {isMenuOpen && getMenuContents(downshiftObject)}
             </Menu>
             {isMenuOpen && !menuItems.length && (
-              <>
-                <p data-testid="noResult" id={'noresults'}>
-                  {noResultsText}
-                </p>
+              <div>
+                <p data-testid="noResult">{noResultsText}</p>
                 {noResultsAction}
-              </>
+              </div>
             )}
           </AutoCompleteResultsWrapper>
         )

--- a/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
@@ -14,18 +14,18 @@ const AutoCompleteInput = styled(Input)`
 `
 const AutoCompleteResultsWrapper = styled.div`
   position: relative;
-`
-const NoResultSection = styled.div`
-  position: absolute;
-  top: 4rem;
-  outline: ${theme.color.outline};
-  outline-offset: -3px;
-  background: ${theme.color.white};
-  z-index: 99;
-  width: 100%;
-  p {
-    margin: ${theme.spacing.small};
+
+  & > p {
+    position: absolute;
+    display: block;
+    width: 100%;
+    padding: 1rem;
+    top: 2.5rem;
+    outline: ${theme.color.outline};
+    outline-offset: -2px;
+    background: ${theme.color.white};
   }
+
   button {
     width: 100%;
     border: none;
@@ -55,10 +55,10 @@ const InputAutocomplete = ({
 
   const [selectedValue, setSelectedValue] = useState(optionMatchingValueProp)
   const [menuItems, setMenuItems] = useState(options)
-  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const [isMenuOpen, setIsMenuOpen] = useState(true)
 
   const _updateSelectedValueWhenPropsChange = useEffect(() => {
-    setIsMenuOpen(false)
+    setIsMenuOpen(true)
     setSelectedValue(optionMatchingValueProp)
   }, [optionMatchingValueProp])
 
@@ -89,15 +89,15 @@ const InputAutocomplete = ({
 
       if (selectedItem) {
         onChange(selectedItem)
-        setIsMenuOpen(false)
+        // setIsMenuOpen(false)
       }
 
       if (!selectedItem && inputValue) {
-        setIsMenuOpen(shouldMenuBeOpen)
+        // setIsMenuOpen(shouldMenuBeOpen)
       }
 
       if (inputValue === '') {
-        setIsMenuOpen(false)
+        // setIsMenuOpen(false)
       }
     },
     [onInputValueChange, selectedValue.label, onChange],
@@ -172,14 +172,18 @@ const InputAutocomplete = ({
               />
               {helperText && <HelperText id={`aria-descp${id}`}>{helperText}</HelperText>}
             </div>
-            <Menu {...getMenuProps({ isOpen: isMenuOpen })}>
-              {isMenuOpen && getMenuContents(downshiftObject)}
-            </Menu>
+            {menuItems.length > 0 && (
+              <Menu {...getMenuProps({ isOpen: isMenuOpen })}>
+                {isMenuOpen && getMenuContents(downshiftObject)}
+              </Menu>
+            )}
             {isMenuOpen && !menuItems.length && (
-              <NoResultSection>
-                <p data-testid="noResult">{noResultsText}</p>
+              <>
+                <p data-testid="noResult" id={'noresults'}>
+                  {noResultsText}
+                </p>
                 {noResultsAction}
-              </NoResultSection>
+              </>
             )}
           </AutoCompleteResultsWrapper>
         )

--- a/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
@@ -55,10 +55,10 @@ const InputAutocomplete = ({
 
   const [selectedValue, setSelectedValue] = useState(optionMatchingValueProp)
   const [menuItems, setMenuItems] = useState(options)
-  const [isMenuOpen, setIsMenuOpen] = useState(true)
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   const _updateSelectedValueWhenPropsChange = useEffect(() => {
-    setIsMenuOpen(true)
+    setIsMenuOpen(false)
     setSelectedValue(optionMatchingValueProp)
   }, [optionMatchingValueProp])
 
@@ -89,15 +89,15 @@ const InputAutocomplete = ({
 
       if (selectedItem) {
         onChange(selectedItem)
-        // setIsMenuOpen(false)
+        setIsMenuOpen(false)
       }
 
       if (!selectedItem && inputValue) {
-        // setIsMenuOpen(shouldMenuBeOpen)
+        setIsMenuOpen(shouldMenuBeOpen)
       }
 
       if (inputValue === '') {
-        // setIsMenuOpen(false)
+        setIsMenuOpen(false)
       }
     },
     [onInputValueChange, selectedValue.label, onChange],
@@ -125,22 +125,18 @@ const InputAutocomplete = ({
     (downshiftObject) => {
       const { getItemProps, highlightedIndex } = downshiftObject
 
-      return menuItems.length
-        ? menuItems.map((item, index) => {
-            return (
-              <Item
-                {...getItemProps({
-                  item,
-                  index,
-                })}
-                key={item.value}
-                highlighted={highlightedIndex === index}
-              >
-                {item.label}
-              </Item>
-            )
-          })
-        : null
+      return menuItems.map((item, index) => (
+        <Item
+          {...getItemProps({
+            item,
+            index,
+          })}
+          key={item.value}
+          highlighted={highlightedIndex === index}
+        >
+          {item.label}
+        </Item>
+      ))
     },
     [menuItems],
   )
@@ -163,20 +159,16 @@ const InputAutocomplete = ({
             })}
             className={className}
           >
-            <div>
-              <AutoCompleteInput
-                {...getInputProps({ onKeyDown })}
-                aria-describedby={`aria-descp${id}`}
-                id={id}
-                {...restOfProps}
-              />
-              {helperText && <HelperText id={`aria-descp${id}`}>{helperText}</HelperText>}
-            </div>
-            {menuItems.length > 0 && (
-              <Menu {...getMenuProps({ isOpen: isMenuOpen })}>
-                {isMenuOpen && getMenuContents(downshiftObject)}
-              </Menu>
-            )}
+            <AutoCompleteInput
+              {...getInputProps({ onKeyDown })}
+              aria-describedby={`aria-descp${id}`}
+              id={id}
+              {...restOfProps}
+            />
+            {helperText && <HelperText id={`aria-descp${id}`}>{helperText}</HelperText>}
+            <Menu {...getMenuProps({ isOpen: isMenuOpen })}>
+              {isMenuOpen && getMenuContents(downshiftObject)}
+            </Menu>
             {isMenuOpen && !menuItems.length && (
               <>
                 <p data-testid="noResult" id={'noresults'}>

--- a/src/components/generic/InputAutocomplete/InputAutocomplete.styles.js
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.styles.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import theme from '../../../theme'
 
 export const Menu = styled('ul')`
-  z-index: ${({ theme }) => theme.zIndex.autocomplete};
+  z-index: ${theme.zIndex.autocomplete};
   position: absolute;
   top: 4rem;
   padding: 0;

--- a/src/components/generic/InputAutocomplete/InputAutocomplete.styles.js
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.styles.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import theme from '../../../theme'
 
 export const Menu = styled('ul')`
-  z-index: 15;
+  z-index: 10;
   position: absolute;
   top: 4rem;
   padding: 0;

--- a/src/components/generic/InputAutocomplete/InputAutocomplete.styles.js
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.styles.js
@@ -2,10 +2,12 @@ import styled from 'styled-components'
 import theme from '../../../theme'
 
 export const Menu = styled('ul')`
+  z-index: 15;
+  position: absolute;
+  top: 4rem;
   padding: 0;
   margin-top: 2px;
   background: ${theme.color.white};
-  position: absolute;
   width: 100%;
   max-height: 18rem;
   cursor: default;
@@ -16,8 +18,6 @@ export const Menu = styled('ul')`
   border-width: 0 1px 1px 1px;
   border-style: solid;
   color: ${theme.color.textColor};
-  z-index: 99;
-  top: 4rem;
   border: ${(props) => (props.isOpen ? null : 'none')};
   outline: ${(props) => (props.isOpen ? null : 'none')};
 `

--- a/src/components/generic/InputAutocomplete/InputAutocomplete.styles.js
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.styles.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import theme from '../../../theme'
 
 export const Menu = styled('ul')`
-  z-index: 10;
+  z-index: ${({ theme }) => theme.zIndex.autocomplete};
   position: absolute;
   top: 4rem;
   padding: 0;

--- a/src/components/generic/InputAutocomplete/index.js
+++ b/src/components/generic/InputAutocomplete/index.js
@@ -1,3 +1,0 @@
-import InputAutocomplete from './InputAutocomplete'
-
-export default InputAutocomplete

--- a/src/components/generic/Modal/Modal.jsx
+++ b/src/components/generic/Modal/Modal.jsx
@@ -19,7 +19,7 @@ const StyledDialogOverlay = styled('div')`
   position: fixed;
   display: grid;
   place-items: center;
-  z-index: ${({ theme }) => theme.zIndex.modal};
+  z-index: ${theme.zIndex.modal};
 `
 
 const StyledDialog = styled('div')`
@@ -56,7 +56,8 @@ const ModalToolbar = styled.div`
   padding: 0 ${theme.spacing.medium};
 `
 const ModalContent = styled.div`
-  overflow: visible;
+  overflow: auto;
+  display: block;
   max-height: ${MODAL_CONTENT_HEIGHT};
   padding: ${theme.spacing.medium};
 `
@@ -146,11 +147,12 @@ const Modal = ({
   isOpen,
   onDismiss,
   footerContent,
-  toolbarContent = undefined,
+  toolbarContent = null,
   maxWidth,
   padding,
   displayCloseIcon = true,
   allowCloseWithEscapeKey = true,
+  contentOverflowStyle = null,
 }) => {
   const _closeModalWithEscapeKey = useEffect(() => {
     const close = (event) => {
@@ -176,14 +178,16 @@ const Modal = ({
         >
           <ModalTitle>
             <h2 id="modal-title">{title}</h2>
-            {displayCloseIcon ? (
+            {displayCloseIcon && (
               <CloseButton type="button" className="close-button" onClick={onDismiss}>
                 <IconClose aria-label="close" />
               </CloseButton>
-            ) : null}
+            )}
           </ModalTitle>
           <ModalToolbar>{toolbarContent}</ModalToolbar>
-          <ModalContent id="modal-content">{mainContent}</ModalContent>
+          <ModalContent id="modal-content" style={{ overflow: contentOverflowStyle ?? 'auto' }}>
+            {mainContent}
+          </ModalContent>
           <ModalFooter>{footerContent}</ModalFooter>
         </StyledDialog>
       </StyledDialogOverlay>
@@ -202,6 +206,7 @@ Modal.propTypes = {
   maxWidth: PropTypes.string,
   padding: PropTypes.string,
   displayCloseIcon: PropTypes.bool,
+  contentOverflowStyle: PropTypes.string,
 }
 
 export default Modal

--- a/src/components/generic/Modal/Modal.jsx
+++ b/src/components/generic/Modal/Modal.jsx
@@ -19,7 +19,7 @@ const StyledDialogOverlay = styled('div')`
   position: fixed;
   display: grid;
   place-items: center;
-  z-index: 10;
+  z-index: ${({ theme }) => theme.zIndex.modal};
 `
 
 const StyledDialog = styled('div')`

--- a/src/components/generic/Modal/Modal.jsx
+++ b/src/components/generic/Modal/Modal.jsx
@@ -19,7 +19,7 @@ const StyledDialogOverlay = styled('div')`
   position: fixed;
   display: grid;
   place-items: center;
-  z-index: 103;
+  z-index: 10;
 `
 
 const StyledDialog = styled('div')`
@@ -39,11 +39,13 @@ const ModalTitle = styled.div`
   display: grid;
   color: ${theme.color.textColor};
   grid-template-columns: auto auto;
+
   h2 {
     justify-self: start;
     align-self: center;
     margin: 0;
   }
+
   button {
     align-self: top;
     justify-self: end;
@@ -54,7 +56,7 @@ const ModalToolbar = styled.div`
   padding: 0 ${theme.spacing.medium};
 `
 const ModalContent = styled.div`
-  overflow: auto;
+  overflow: visible;
   max-height: ${MODAL_CONTENT_HEIGHT};
   padding: ${theme.spacing.medium};
 `
@@ -63,11 +65,13 @@ const ModalFooter = styled.div`
   display: grid;
   grid-auto-columns: auto auto;
   background: ${theme.color.tableRowEven};
+
   ${mediaQueryPhoneOnly(css`
     > * {
       display: block;
       text-align: center;
     }
+
     * > button {
       margin-top: ${theme.spacing.buttonSpacing};
       margin-bottom: ${theme.spacing.buttonSpacing};
@@ -77,9 +81,11 @@ const ModalFooter = styled.div`
     svg {
       margin-right: ${theme.spacing.small};
     }
+
     &:not(:last-child) {
       margin-right: ${theme.spacing.buttonSpacing};
     }
+
     &:first-child {
       margin-left: 0;
     }
@@ -89,13 +95,16 @@ const ModalLoadingIndicatorWrapper = styled('div')`
   position: static;
   width: 100%;
   padding: 5rem 0;
+
   .loadingWrapper {
     position: static;
+
     .objectWrapper {
       div {
         background-color: ${theme.color.background};
       }
     }
+
     .loadingPrimary {
       color: ${theme.color.background};
       width: auto;
@@ -118,9 +127,11 @@ const ModalInputRow = styled(InputRow)`
   color: ${theme.color.primaryColor};
   display: block;
   border: none;
+
   h4 {
     margin: 0;
   }
+
   label {
     font-weight: bold;
   }

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.jsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.jsx
@@ -181,7 +181,6 @@ const ImageAnnotationModal = ({
         title={dataToReview?.original_image_name ?? ''}
         isOpen
         onDismiss={handleCloseModal}
-        contentOverflowIsVisible={true}
         maxWidth="fit-content"
         mainContent={
           dataToReview && !isSaving && imageScale ? (

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.tsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.tsx
@@ -171,7 +171,7 @@ export const PopupWrapperForRadio = styled.div`
 export const NewAttributeModalContentContainer = styled.div`
   display: flex;
   gap: ${theme.spacing.large};
-  min-height: 250px;
+  // min-height: 250px;
 `
 
 export const NewAttributeModalFooterContainer = styled.div`

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.tsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.tsx
@@ -82,12 +82,6 @@ export const TableWithNoMinWidth = styled(Table)`
   border-top: none;
 `
 
-export const ImageAnnotationPopupContainer = styled.div`
-  position: absolute;
-  top: 0;
-  right: 0;
-`
-
 export const TdZoom = styled(Td)`
   padding: 0;
   height: 57px; // prevents shifts to layout when the attribute is confirmed
@@ -176,10 +170,6 @@ export const NewAttributeModalContentContainer = styled.div`
 
 export const NewAttributeModalFooterContainer = styled.div`
   justify-self: right;
-`
-
-export const NewAttributeModalLabel = styled.label`
-  font-weight: bold;
 `
 
 export const ButtonZoom = styled.button<IsSelectedProps>`

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.tsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationModal.styles.tsx
@@ -5,9 +5,11 @@ import LoadingIndicator from '../../../LoadingIndicator/LoadingIndicator'
 import { Table, Td, Tr, thStyles } from '../../../generic/Table/table'
 import { ButtonPrimary, IconButton, buttonSecondaryCss } from '../../../generic/buttons'
 import { RowSpaceBetween } from '../../../generic/positioning'
+
 interface IsSelectedProps {
   $isSelected?: boolean
 }
+
 interface HasConfirmedPoint {
   $hasConfirmedPoint?: boolean
 }
@@ -91,6 +93,7 @@ export const TdZoom = styled(Td)`
   height: 57px; // prevents shifts to layout when the attribute is confirmed
   width: 48px;
   background-color: ${theme.color.white}; // stop the row hover colour from showing
+
   &:hover {
     background-color: ${theme.color.tableRowHover};
   }
@@ -99,10 +102,12 @@ export const TdZoom = styled(Td)`
 export const TrImageClassification = styled(Tr)<IsSelectedProps>`
   position: relative;
   cursor: pointer;
+
   &:hover {
     svg {
       opacity: 1; // this make the zoom icon visible on hover
     }
+
     &::after {
       // this is a non-layout impacting hack to receive the hover border
       content: '';
@@ -116,13 +121,16 @@ export const TrImageClassification = styled(Tr)<IsSelectedProps>`
       pointer-events: none;
     }
   }
+
   &:nth-child(odd),
   &:nth-child(even) {
     background-color: ${theme.color.white}; // undo default table row striping
   }
+
   &:has(${TdZoom}:hover) {
     background-color: ${theme.color.white};
   }
+
   ${({ $isSelected }) =>
     $isSelected &&
     css`
@@ -164,7 +172,6 @@ export const PopupWrapperForRadio = styled.div`
 export const NewAttributeModalContentContainer = styled.div`
   display: flex;
   gap: ${theme.spacing.large};
-  // min-height: 250px;
 `
 
 export const NewAttributeModalFooterContainer = styled.div`
@@ -180,6 +187,7 @@ export const ButtonZoom = styled.button<IsSelectedProps>`
   height: 100%;
   width: 100%;
   text-align: center;
+
   & svg {
     opacity: ${({ $isSelected }) => ($isSelected ? 1 : 0)};
   }

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
@@ -29,6 +29,7 @@ const NewAttributeModal = ({
         !!growthFormSelectOptions.length &&
         shouldDisplayModal
       }
+      contentOverflowStyle="visible"
       onDismiss={handleCloseModal}
       allowCloseWithEscapeKey={false}
       maxWidth="fit-content"

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import InputAutocomplete from '../../../../generic/InputAutocomplete/InputAutocomplete'
 import { Select } from '../../../../generic/form'
 import language from '../../../../../language'
@@ -7,20 +8,8 @@ import {
 } from '../ImageAnnotationModal.styles'
 import { ButtonPrimary, ButtonSecondary } from '../../../../generic/buttons'
 import { IconPlus } from '../../../../icons'
-import React from 'react'
 import Modal from '../../../../generic/Modal/Modal'
 import PropTypes from 'prop-types'
-
-NewAttributeModal.propTypes = {
-  benthicAttributeSelectOptions: PropTypes.array,
-  setSelectedBenthicAttr: PropTypes.func.isRequired,
-  setSelectedGrowthForm: PropTypes.func.isRequired,
-  selectedBenthicAttr: PropTypes.string.isRequired,
-  growthFormSelectOptions: PropTypes.array.isRequired,
-  shouldDisplayModal: PropTypes.bool.isRequired,
-  handleCloseModal: PropTypes.func.isRequired,
-  handleAddNewRowClick: PropTypes.func.isRequired,
-}
 
 const NewAttributeModal = ({
   benthicAttributeSelectOptions,
@@ -60,7 +49,6 @@ const NewAttributeModal = ({
           </label>
 
           <label htmlFor="growth-forms">
-            <span>{language.createNewOptionModal.growthForms}</span>
             <Select
               id="growth-forms"
               label={language.createNewOptionModal.growthForms}
@@ -95,3 +83,14 @@ const NewAttributeModal = ({
 }
 
 export default NewAttributeModal
+
+NewAttributeModal.propTypes = {
+  benthicAttributeSelectOptions: PropTypes.array,
+  setSelectedBenthicAttr: PropTypes.func.isRequired,
+  setSelectedGrowthForm: PropTypes.func.isRequired,
+  selectedBenthicAttr: PropTypes.string.isRequired,
+  growthFormSelectOptions: PropTypes.array.isRequired,
+  shouldDisplayModal: PropTypes.bool.isRequired,
+  handleCloseModal: PropTypes.func.isRequired,
+  handleAddNewRowClick: PropTypes.func.isRequired,
+}

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
@@ -1,7 +1,10 @@
 import InputAutocomplete from '../../../../generic/InputAutocomplete/InputAutocomplete'
 import { Select } from '../../../../generic/form'
 import language from '../../../../../language'
-import { NewAttributeModalFooterContainer } from '../ImageAnnotationModal.styles'
+import {
+  NewAttributeModalContentContainer,
+  NewAttributeModalFooterContainer,
+} from '../ImageAnnotationModal.styles'
 import { ButtonPrimary, ButtonSecondary } from '../../../../generic/buttons'
 import { IconPlus } from '../../../../icons'
 import React from 'react'
@@ -29,8 +32,8 @@ const NewAttributeModal = ({
       allowCloseWithEscapeKey={false}
       maxWidth="fit-content"
       mainContent={
-        <div style={{}}>
-          <label htmlFor="benthic-attribute-autocomplete" style={{ display: 'inline-block' }}>
+        <NewAttributeModalContentContainer>
+          <label htmlFor="benthic-attribute-autocomplete">
             {language.createNewOptionModal.newBenthicAttribute}
             <InputAutocomplete
               id="benthic-attribute-autocomplete"
@@ -44,7 +47,7 @@ const NewAttributeModal = ({
             />
           </label>
 
-          <label htmlFor="growth-forms" style={{ display: 'inline-block', paddingLeft: '1rem' }}>
+          <label htmlFor="growth-forms">
             <span>{language.createNewOptionModal.growthForms}</span>
             <Select
               id="growth-forms"
@@ -59,7 +62,7 @@ const NewAttributeModal = ({
               ))}
             </Select>
           </label>
-        </div>
+        </NewAttributeModalContentContainer>
       }
       footerContent={
         <NewAttributeModalFooterContainer>

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
@@ -9,6 +9,18 @@ import { ButtonPrimary, ButtonSecondary } from '../../../../generic/buttons'
 import { IconPlus } from '../../../../icons'
 import React from 'react'
 import Modal from '../../../../generic/Modal/Modal'
+import PropTypes from 'prop-types'
+
+NewAttributeModal.propTypes = {
+  benthicAttributeSelectOptions: PropTypes.array,
+  setSelectedBenthicAttr: PropTypes.func.isRequired,
+  setSelectedGrowthForm: PropTypes.func.isRequired,
+  selectedBenthicAttr: PropTypes.string.isRequired,
+  growthFormSelectOptions: PropTypes.array.isRequired,
+  shouldDisplayModal: PropTypes.bool.isRequired,
+  handleCloseModal: PropTypes.func.isRequired,
+  handleAddNewRowClick: PropTypes.func.isRequired,
+}
 
 const NewAttributeModal = ({
   benthicAttributeSelectOptions,
@@ -22,7 +34,7 @@ const NewAttributeModal = ({
 }) => {
   return (
     <Modal
-      title="Select New Attribute"
+      title={language.table.addNewRow}
       isOpen={
         !!benthicAttributeSelectOptions.length &&
         !!growthFormSelectOptions.length &&
@@ -67,14 +79,14 @@ const NewAttributeModal = ({
       footerContent={
         <NewAttributeModalFooterContainer>
           <ButtonSecondary type="button" onClick={handleCloseModal}>
-            Cancel
+            {language.buttons.cancel}
           </ButtonSecondary>
           <ButtonPrimary
             type="button"
             disabled={!selectedBenthicAttr}
             onClick={handleAddNewRowClick}
           >
-            <IconPlus /> Add Row
+            <IconPlus /> {language.buttons.addRow}
           </ButtonPrimary>
         </NewAttributeModalFooterContainer>
       }

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
@@ -49,11 +49,8 @@ const NewAttributeModal = ({
           </label>
 
           <label htmlFor="growth-forms">
-            <Select
-              id="growth-forms"
-              label={language.createNewOptionModal.growthForms}
-              onChange={(e) => setSelectedGrowthForm(e.target.value)}
-            >
+            {language.createNewOptionModal.growthForms}
+            <Select id="growth-forms" onChange={(e) => setSelectedGrowthForm(e.target.value)}>
               <option value=""></option>
               {growthFormSelectOptions.map((growthForm) => (
                 <option key={growthForm.id} value={growthForm.id}>

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
@@ -1,0 +1,47 @@
+import InputAutocomplete from '../../../../generic/InputAutocomplete/InputAutocomplete'
+import { Select } from '../../../../generic/form'
+import language from '../../../../../language'
+
+const NewAttributeModal = ({
+  benthicAttributeSelectOptions,
+  setSelectedBenthicAttr,
+  setSelectedGrowthForm,
+  selectedBenthicAttr,
+  growthFormSelectOptions,
+}) => {
+  return (
+    <>
+      <label htmlFor="benthic-attribute-autocomplete" style={{ display: 'inline-block' }}>
+        {language.createNewOptionModal.newBenthicAttribute}
+        <InputAutocomplete
+          id="benthic-attribute-autocomplete"
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus // IMPORTANT we should reconsider autofocus use. See: https://trello.com/c/4pe1zgS9/1331-accessibility-linting-issues-deferred
+          aria-labelledby="benthic-attribute-label"
+          options={benthicAttributeSelectOptions}
+          onChange={({ value }) => setSelectedBenthicAttr(value)}
+          value="t" //selectedBenthicAttr}
+          noResultsText={language.autocomplete.noResultsDefault}
+        />
+      </label>
+
+      <label htmlFor="growth-forms" style={{ display: 'inline-block', paddingLeft: '1rem' }}>
+        <span>{language.createNewOptionModal.growthForms}</span>
+        <Select
+          id="growth-forms"
+          label={language.createNewOptionModal.growthForms}
+          onChange={(e) => setSelectedGrowthForm(e.target.value)}
+        >
+          <option value=""></option>
+          {growthFormSelectOptions.map((growthForm) => (
+            <option key={growthForm.id} value={growthForm.id}>
+              {growthForm.name}
+            </option>
+          ))}
+        </Select>
+      </label>
+    </>
+  )
+}
+
+export default NewAttributeModal

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/NewAttributeModal.jsx
@@ -1,6 +1,11 @@
 import InputAutocomplete from '../../../../generic/InputAutocomplete/InputAutocomplete'
 import { Select } from '../../../../generic/form'
 import language from '../../../../../language'
+import { NewAttributeModalFooterContainer } from '../ImageAnnotationModal.styles'
+import { ButtonPrimary, ButtonSecondary } from '../../../../generic/buttons'
+import { IconPlus } from '../../../../icons'
+import React from 'react'
+import Modal from '../../../../generic/Modal/Modal'
 
 const NewAttributeModal = ({
   benthicAttributeSelectOptions,
@@ -8,39 +13,69 @@ const NewAttributeModal = ({
   setSelectedGrowthForm,
   selectedBenthicAttr,
   growthFormSelectOptions,
+  shouldDisplayModal,
+  handleCloseModal,
+  handleAddNewRowClick,
 }) => {
   return (
-    <>
-      <label htmlFor="benthic-attribute-autocomplete" style={{ display: 'inline-block' }}>
-        {language.createNewOptionModal.newBenthicAttribute}
-        <InputAutocomplete
-          id="benthic-attribute-autocomplete"
-          // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus // IMPORTANT we should reconsider autofocus use. See: https://trello.com/c/4pe1zgS9/1331-accessibility-linting-issues-deferred
-          aria-labelledby="benthic-attribute-label"
-          options={benthicAttributeSelectOptions}
-          onChange={({ value }) => setSelectedBenthicAttr(value)}
-          value="t" //selectedBenthicAttr}
-          noResultsText={language.autocomplete.noResultsDefault}
-        />
-      </label>
+    <Modal
+      title="Select New Attribute"
+      isOpen={
+        !!benthicAttributeSelectOptions.length &&
+        !!growthFormSelectOptions.length &&
+        shouldDisplayModal
+      }
+      onDismiss={handleCloseModal}
+      allowCloseWithEscapeKey={false}
+      maxWidth="fit-content"
+      mainContent={
+        <div style={{}}>
+          <label htmlFor="benthic-attribute-autocomplete" style={{ display: 'inline-block' }}>
+            {language.createNewOptionModal.newBenthicAttribute}
+            <InputAutocomplete
+              id="benthic-attribute-autocomplete"
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus // IMPORTANT we should reconsider autofocus use. See: https://trello.com/c/4pe1zgS9/1331-accessibility-linting-issues-deferred
+              aria-labelledby="benthic-attribute-label"
+              options={benthicAttributeSelectOptions}
+              onChange={({ value }) => setSelectedBenthicAttr(value)}
+              value={selectedBenthicAttr}
+              noResultsText={language.autocomplete.noResultsDefault}
+            />
+          </label>
 
-      <label htmlFor="growth-forms" style={{ display: 'inline-block', paddingLeft: '1rem' }}>
-        <span>{language.createNewOptionModal.growthForms}</span>
-        <Select
-          id="growth-forms"
-          label={language.createNewOptionModal.growthForms}
-          onChange={(e) => setSelectedGrowthForm(e.target.value)}
-        >
-          <option value=""></option>
-          {growthFormSelectOptions.map((growthForm) => (
-            <option key={growthForm.id} value={growthForm.id}>
-              {growthForm.name}
-            </option>
-          ))}
-        </Select>
-      </label>
-    </>
+          <label htmlFor="growth-forms" style={{ display: 'inline-block', paddingLeft: '1rem' }}>
+            <span>{language.createNewOptionModal.growthForms}</span>
+            <Select
+              id="growth-forms"
+              label={language.createNewOptionModal.growthForms}
+              onChange={(e) => setSelectedGrowthForm(e.target.value)}
+            >
+              <option value=""></option>
+              {growthFormSelectOptions.map((growthForm) => (
+                <option key={growthForm.id} value={growthForm.id}>
+                  {growthForm.name}
+                </option>
+              ))}
+            </Select>
+          </label>
+        </div>
+      }
+      footerContent={
+        <NewAttributeModalFooterContainer>
+          <ButtonSecondary type="button" onClick={handleCloseModal}>
+            Cancel
+          </ButtonSecondary>
+          <ButtonPrimary
+            type="button"
+            disabled={!selectedBenthicAttr}
+            onClick={handleAddNewRowClick}
+          >
+            <IconPlus /> Add Row
+          </ButtonPrimary>
+        </NewAttributeModalFooterContainer>
+      }
+    />
   )
 }
 

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/SelectAttributeFromClassifierGuesses.jsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/SelectAttributeFromClassifierGuesses.jsx
@@ -11,15 +11,12 @@ import { databaseSwitchboardPropTypes } from '../../../../../App/mermaidData/dat
 import { IconPlus } from '../../../../icons'
 import {
   LabelThatLooksLikeATh,
-  NewAttributeModalContentContainer,
   NewAttributeModalFooterContainer,
-  NewAttributeModalLabel,
   RowThatLooksLikeAnEvenTr,
 } from '../ImageAnnotationModal.styles'
 import { Select } from '../../../../generic/form'
 import { useSelectNewAttribute } from '../../useSelectNewAttribute'
-import InputAutocomplete from '../../../../generic/InputAutocomplete'
-import language from '../../../../../language'
+import NewAttributeModal from './NewAttributeModal'
 import Modal from '../../../../generic/Modal/Modal'
 
 const isClassified = ({ annotations }) => annotations.length > 0
@@ -157,6 +154,7 @@ const SelectAttributeFromClassifierGuesses = ({
         </Select>
       </RowThatLooksLikeAnEvenTr>
       {createPortal(
+        //modal will otherwise populate within the map container
         <Modal
           title="Select New Attribute"
           isOpen={
@@ -169,37 +167,13 @@ const SelectAttributeFromClassifierGuesses = ({
           maxWidth="fit-content"
           contentOverflowIsVisible
           mainContent={
-            <NewAttributeModalContentContainer>
-              <NewAttributeModalLabel htmlFor="benthic-attribute-autocomplete">
-                Benthic Attribute
-                <InputAutocomplete
-                  id="benthic-attribute-autocomplete"
-                  // eslint-disable-next-line jsx-a11y/no-autofocus
-                  autoFocus // IMPORTANT we should reconsider autofocus use. See: https://trello.com/c/4pe1zgS9/1331-accessibility-linting-issues-deferred
-                  aria-labelledby="benthic-attribute-label"
-                  options={benthicAttributeSelectOptions}
-                  onChange={({ value }) => setSelectedBenthicAttr(value)}
-                  value={selectedBenthicAttr}
-                  noResultsText={language.autocomplete.noResultsDefault}
-                />
-              </NewAttributeModalLabel>
-
-              <NewAttributeModalLabel htmlFor="growth-forms">
-                <span>Growth forms</span>
-                <Select
-                  id="growth-forms"
-                  label="Growth forms"
-                  onChange={(e) => setSelectedGrowthForm(e.target.value)}
-                >
-                  <option value=""></option>
-                  {growthFormSelectOptions.map((growthForm) => (
-                    <option key={growthForm.id} value={growthForm.id}>
-                      {growthForm.name}
-                    </option>
-                  ))}
-                </Select>
-              </NewAttributeModalLabel>
-            </NewAttributeModalContentContainer>
+            <NewAttributeModal
+              benthicAttributeSelectOptions={benthicAttributeSelectOptions}
+              setSelectedBenthicAttr={setSelectedBenthicAttr}
+              setSelectedGrowthForm={setSelectedGrowthForm}
+              selectedBenthicAttr={selectedBenthicAttr}
+              growthFormSelectOptions={growthFormSelectOptions}
+            />
           }
           footerContent={
             <NewAttributeModalFooterContainer>

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/SelectAttributeFromClassifierGuesses.jsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/SelectAttributeFromClassifierGuesses.jsx
@@ -11,6 +11,7 @@ import { LabelThatLooksLikeATh, RowThatLooksLikeAnEvenTr } from '../ImageAnnotat
 import { Select } from '../../../../generic/form'
 import { useSelectNewAttribute } from '../../useSelectNewAttribute'
 import NewAttributeModal from './NewAttributeModal'
+import language from '../../../../../language'
 
 const isClassified = ({ annotations }) => annotations.length > 0
 

--- a/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/SelectAttributeFromClassifierGuesses.jsx
+++ b/src/components/pages/ImageClassification/ImageAnnotationModal/ImageAnnotationPopup/SelectAttributeFromClassifierGuesses.jsx
@@ -5,19 +5,12 @@ import {
   imageClassificationPointPropType,
   imageClassificationResponsePropType,
 } from '../../../../../App/mermaidData/mermaidDataProptypes'
-import { ButtonPrimary, ButtonSecondary } from '../../../../generic/buttons'
 import { createPortal } from 'react-dom'
 import { databaseSwitchboardPropTypes } from '../../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboard'
-import { IconPlus } from '../../../../icons'
-import {
-  LabelThatLooksLikeATh,
-  NewAttributeModalFooterContainer,
-  RowThatLooksLikeAnEvenTr,
-} from '../ImageAnnotationModal.styles'
+import { LabelThatLooksLikeATh, RowThatLooksLikeAnEvenTr } from '../ImageAnnotationModal.styles'
 import { Select } from '../../../../generic/form'
 import { useSelectNewAttribute } from '../../useSelectNewAttribute'
 import NewAttributeModal from './NewAttributeModal'
-import Modal from '../../../../generic/Modal/Modal'
 
 const isClassified = ({ annotations }) => annotations.length > 0
 
@@ -155,40 +148,15 @@ const SelectAttributeFromClassifierGuesses = ({
       </RowThatLooksLikeAnEvenTr>
       {createPortal(
         //modal will otherwise populate within the map container
-        <Modal
-          title="Select New Attribute"
-          isOpen={
-            !!benthicAttributeSelectOptions.length &&
-            !!growthFormSelectOptions.length &&
-            shouldDisplayModal
-          }
-          onDismiss={handleCloseModal}
-          allowCloseWithEscapeKey={false}
-          maxWidth="fit-content"
-          contentOverflowIsVisible
-          mainContent={
-            <NewAttributeModal
-              benthicAttributeSelectOptions={benthicAttributeSelectOptions}
-              setSelectedBenthicAttr={setSelectedBenthicAttr}
-              setSelectedGrowthForm={setSelectedGrowthForm}
-              selectedBenthicAttr={selectedBenthicAttr}
-              growthFormSelectOptions={growthFormSelectOptions}
-            />
-          }
-          footerContent={
-            <NewAttributeModalFooterContainer>
-              <ButtonSecondary type="button" onClick={handleCloseModal}>
-                Cancel
-              </ButtonSecondary>
-              <ButtonPrimary
-                type="button"
-                disabled={!selectedBenthicAttr}
-                onClick={handleAddNewRowClick}
-              >
-                <IconPlus /> Add Row
-              </ButtonPrimary>
-            </NewAttributeModalFooterContainer>
-          }
+        <NewAttributeModal
+          benthicAttributeSelectOptions={benthicAttributeSelectOptions}
+          growthFormSelectOptions={growthFormSelectOptions}
+          shouldDisplayModal={shouldDisplayModal}
+          handleCloseModal={handleCloseModal}
+          selectedBenthicAttr={selectedBenthicAttr}
+          setSelectedBenthicAttr={setSelectedBenthicAttr}
+          handleAddNewRowClick={handleAddNewRowClick}
+          setSelectedGrowthForm={setSelectedGrowthForm}
         />,
         document.body,
       )}

--- a/src/components/pages/ProjectInfo/ProjectInfo.jsx
+++ b/src/components/pages/ProjectInfo/ProjectInfo.jsx
@@ -16,7 +16,7 @@ import { useDatabaseSwitchboardInstance } from '../../../App/mermaidData/databas
 import { useOnlineStatus } from '../../../library/onlineStatusContext'
 import EnhancedPrompt from '../../generic/EnhancedPrompt'
 import IdsNotFound from '../IdsNotFound/IdsNotFound'
-import InputAutocomplete from '../../generic/InputAutocomplete'
+import InputAutocomplete from '../../generic/InputAutocomplete/InputAutocomplete'
 import InputWithLabelAndValidation from '../../mermaidInputs/InputWithLabelAndValidation'
 import language from '../../../language'
 import { getToastArguments } from '../../../library/getToastArguments'

--- a/src/components/pages/Site/Site.jsx
+++ b/src/components/pages/Site/Site.jsx
@@ -31,7 +31,7 @@ import { useUnsavedDirtyFormDataUtilities } from '../../../library/useUnsavedDir
 import DeleteRecordButton from '../../DeleteRecordButton'
 import EnhancedPrompt from '../../generic/EnhancedPrompt'
 import IdsNotFound from '../IdsNotFound/IdsNotFound'
-import InputAutocomplete from '../../generic/InputAutocomplete'
+import InputAutocomplete from '../../generic/InputAutocomplete/InputAutocomplete'
 import InputValidationInfo from '../../mermaidInputs/InputValidationInfo/InputValidationInfo'
 import InputWithLabelAndValidation from '../../mermaidInputs/InputWithLabelAndValidation'
 import language from '../../../language'

--- a/src/language.jsx
+++ b/src/language.jsx
@@ -274,6 +274,7 @@ const createNewOptionModal = {
   contactForHelp: 'Contact us for help',
   species: 'Species',
   newBenthicAttribute: 'Benthic Attribute',
+  growthForms: 'Growth Forms',
   benthicAttributeParent: 'Parent',
   newBenthicAttributeName: 'Name',
   goToNextPage: 'Next',

--- a/src/language.jsx
+++ b/src/language.jsx
@@ -65,6 +65,7 @@ const buttons = {
   close: 'Close',
   confirm: 'Confirm',
   saveChanges: 'Save Changes',
+  addRow: 'Add row',
 }
 
 const error = {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -209,9 +209,10 @@ const typography = {
 }
 
 const zIndex = {
-  toolbar: 10,
   autocomplete: 15,
+  header: 10,
   modal: 20,
+  toolbar: 10,
 }
 
 const theme = { color, timing, spacing, typography, zIndex }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -208,6 +208,12 @@ const typography = {
   `,
 }
 
-const theme = { color, timing, spacing, typography }
+const zIndex = {
+  toolbar: 10,
+  autocomplete: 15,
+  modal: 20,
+}
+
+const theme = { color, timing, spacing, typography, zIndex }
 
 export default theme


### PR DESCRIPTION
Adjust the size of the New Attribute modal for Image Classification
https://trello.com/c/sUWfZ6P9/1365-select-new-attribute-modal-unnecessarily-big

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated modal for adding new attribute rows in image classification annotations, featuring autocomplete and dropdown selection.
  - Added new UI text labels for "Add row" and "Growth Forms".

- **Refactor**
  - Simplified modal rendering in attribute selection by encapsulating logic in a new component.
  - Streamlined autocomplete component structure and unified styling.

- **Style**
  - Adjusted z-index and spacing for various UI elements, including toolbars, modals, headers, and autocomplete menus, to improve layering and layout consistency.
  - Removed unused styled components and cleaned up formatting for better maintainability.

- **Chores**
  - Updated import paths for the autocomplete component to ensure consistent module resolution.
  - Removed redundant index file for the autocomplete component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->