### PR TITLE
fix: [M1409] Admin label truncated in project card 

### DIFF
--- a/src/components/ProjectCard/ProjectCard.styles.js
+++ b/src/components/ProjectCard/ProjectCard.styles.js
@@ -33,6 +33,7 @@ export const ProjectCardHeader = styled('div')`
   justify-content: space-between;
   background: ${theme.color.primaryColor};
   color: ${theme.color.white};
+  gap: 20px;
   ${theme.typography.noWordBreak};
   ${mediaQueryPhoneOnly(css`
     font-size: ${theme.typography.defaultFontSize};

--- a/src/components/ProjectCard/ProjectCard.styles.js
+++ b/src/components/ProjectCard/ProjectCard.styles.js
@@ -33,7 +33,7 @@ export const ProjectCardHeader = styled('div')`
   justify-content: space-between;
   background: ${theme.color.primaryColor};
   color: ${theme.color.white};
-  gap: 20px;
+   gap: ${theme.spacing.large}
   ${theme.typography.noWordBreak};
   ${mediaQueryPhoneOnly(css`
     font-size: ${theme.typography.defaultFontSize};


### PR DESCRIPTION
add gap to ProjectCardHeader for improved layout

**old:**
<img width="1245" alt="Screenshot 2025-05-09 at 11 34 54" src="https://github.com/user-attachments/assets/4180e958-3b61-49c0-a134-795509aa518f" />
**new:**
<img width="1236" alt="Screenshot 2025-05-09 at 11 34 45" src="https://github.com/user-attachments/assets/0a5b4646-5ad5-4861-a873-9e8cb7de396f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Improved spacing between items in the project card header for a cleaner layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->