### PR TITLE
hotfix: [M1409] add missing semicolon in ProjectCardHeader styles

### DIFF
--- a/src/components/ProjectCard/ProjectCard.styles.js
+++ b/src/components/ProjectCard/ProjectCard.styles.js
@@ -33,7 +33,7 @@ export const ProjectCardHeader = styled('div')`
   justify-content: space-between;
   background: ${theme.color.primaryColor};
   color: ${theme.color.white};
-   gap: ${theme.spacing.large}
+  gap: ${theme.spacing.large};
   ${theme.typography.noWordBreak};
   ${mediaQueryPhoneOnly(css`
     font-size: ${theme.typography.defaultFontSize};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected CSS syntax by adding a missing semicolon to improve style consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->