### PR TITLE
fix: [M1500] add missing props for Mobile View GlobalLinks.

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -173,7 +173,11 @@ const Header = ({ logout = () => {}, currentUser = undefined }) => {
               }
               contents={
                 <UserMenu>
-                  <GlobalLinks />
+                  <GlobalLinks
+                    isAppOnline={isAppOnline}
+                    isExploreLaunchEnabledForUser={isExploreLaunchEnabledForUser}
+                    mermaidExploreLink={mermaidExploreLink}
+                  />
                   {currentUser && <LoggedInAs>Logged in as {userDisplayName}</LoggedInAs>}
                   <UserMenuDropDownContent />
                 </UserMenu>


### PR DESCRIPTION
<img width="1441" alt="Screenshot 2025-05-21 at 12 54 50" src="https://github.com/user-attachments/assets/1ce6232c-3e22-4aad-9314-9eae490d21ae" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved consistency between desktop and mobile menus by ensuring the mobile user menu displays links based on app online status, feature flags, and explore link availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->