### PR TITLE
cdk acknowledge

### DIFF
--- a/iac/cdk.context.json
+++ b/iac/cdk.context.json
@@ -3,5 +3,8 @@
     "Id": "/hostedzone/Z057628713VX646WVHWOJ",
     "Name": "app2.datamermaid.org."
   },
-  "acknowledged-issue-numbers": [32775]
+  "acknowledged-issue-numbers": [
+    32775,
+    34892
+  ]
 }


### PR DESCRIPTION
I think something changed on the webapp which caused the deployment to fail, I had to do a rollback while skipoing certail aws resources and then redeploy from the develop branch. The lambda issue is related to that, the lambda is not a lambda we created it is one created by cdk internally for deployment which was timing out due to the failing deploy.

This pr will acknowledge:
```
❯ cdk acknowledge 34892

NOTICES         (What's this? https://github.com/aws/aws-cdk/wiki/CLI-Notices)

34892	CDK CLI will collect telemetry data on command usage starting at version 2.1100.0 (unless opted out)

	Overview: We do not collect customer content and we anonymize the
	          telemetry we do collect. See the attached issue for more
	          information on what data is collected, why, and how to
	          opt-out. Telemetry will NOT be collected for any CDK CLI
	          version prior to version 2.1100.0 - regardless of
	          opt-in/out.

	Affected versions: cli: ^2.0.0

	More information at: https://github.com/aws/aws-cdk/issues/34892


If you don’t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 34892".

```
