### PR TITLE
M1579 Tighten data flow for PIT / LITI records

### DIFF
--- a/src/App/unitTests/BenthicPitLitObservationSummaryStats.test.tsx
+++ b/src/App/unitTests/BenthicPitLitObservationSummaryStats.test.tsx
@@ -20,7 +20,7 @@ describe('BenthicPitLitObservationSummaryStats', () => {
       <BenthicPitLitObservationSummaryStats
         benthicAttributeSelectOptions={benthicAttributeSelectOptions}
         observations={observations}
-        transectLengthSurveyed={60}
+        recordType={'lit'}
       />,
     )
     expect(screen.getByText('% Category 1')).toBeInTheDocument()
@@ -41,6 +41,7 @@ describe('BenthicPitLitObservationSummaryStats', () => {
       <BenthicPitLitObservationSummaryStats
         benthicAttributeSelectOptions={benthicAttributeSelectOptions}
         observations={observations}
+        recordType={'pit'}
       />,
     )
     expect(screen.getByText('% Category 1')).toBeInTheDocument()
@@ -49,11 +50,23 @@ describe('BenthicPitLitObservationSummaryStats', () => {
     expect(screen.getByText('33.3')).toBeInTheDocument() // 1/3*100 = 33.3
   })
 
-  it('will show "missing attribute" of 100.0 percent if no observations with attributes are present', () => {
+  it('will show "missing attribute" of 100.0 percent if no observations with attributes are present on a PIT record', () => {
     render(
       <BenthicPitLitObservationSummaryStats
         benthicAttributeSelectOptions={benthicAttributeSelectOptions}
         observations={[{ attribute: '', growth_form: '', id: '1' }]}
+        recordType={'pit'}
+      />,
+    )
+    expect(screen.getByText('100.0')).toBeInTheDocument() // Missing category will be 100.0%
+  })
+
+  it('will show "missing attribute" of 100.0 percent if no observations with attributes are present on a LIT record', () => {
+    render(
+      <BenthicPitLitObservationSummaryStats
+        benthicAttributeSelectOptions={benthicAttributeSelectOptions}
+        observations={[{ attribute: '', growth_form: '', id: '1', length: 10 }]}
+        recordType={'lit'}
       />,
     )
     expect(screen.getByText('100.0')).toBeInTheDocument() // Missing category will be 100.0%

--- a/src/components/BenthicPitLitObservationSummaryStats.tsx
+++ b/src/components/BenthicPitLitObservationSummaryStats.tsx
@@ -28,7 +28,7 @@ interface CategoryStat {
 interface BenthicPitLitObservationSummaryStatsProps {
   benthicAttributeSelectOptions: BenthicAttribute[]
   observations: Observation[]
-  transectLengthSurveyed?: number
+  recordType: 'pit' | 'lit'
 }
 
 // TopLevelCategory = TLC
@@ -38,7 +38,7 @@ interface BenthicPitLitObservationSummaryStatsProps {
 const BenthicPitLitObservationSummaryStats = ({
   benthicAttributeSelectOptions,
   observations,
-  transectLengthSurveyed,
+  recordType,
 }: BenthicPitLitObservationSummaryStatsProps) => {
   const { t } = useTranslation()
 
@@ -77,7 +77,7 @@ const BenthicPitLitObservationSummaryStats = ({
       let totalObservationsSum: number
 
       //LIT
-      if (transectLengthSurveyed) {
+      if (recordType === 'lit') {
         totalObservationsSum = observations.reduce((total, observation) => {
           return total + Number(observation.length)
         }, 0)
@@ -102,12 +102,7 @@ const BenthicPitLitObservationSummaryStats = ({
     })
 
     return sortArrayByObjectKey(topLevelCategoryStats, 'topLevelCategory')
-  }, [
-    observations,
-    benthicAttributeSelectOptions,
-    transectLengthSurveyed,
-    missingBenthicAttributeLabel,
-  ])
+  }, [observations, benthicAttributeSelectOptions, recordType, missingBenthicAttributeLabel])
 
   return (
     <ObservationsSummaryStats>

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.jsx
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitObservationTable.jsx
@@ -49,7 +49,6 @@ const BenthicLitObservationsTable = ({
   benthicAttributeSelectOptions,
   choices,
   collectRecord = undefined,
-  formik,
   ignoreObservationValidations,
   observationsReducer = [],
   resetObservationValidations,
@@ -58,7 +57,6 @@ const BenthicLitObservationsTable = ({
   setObservationIdToAddNewBenthicAttributeTo,
   testId,
 }) => {
-  const transectLengthSurveyed = Number(formik?.values?.len_surveyed) || null
   const [observationsState, observationsDispatch] = observationsReducer
   const [autoFocusAllowed, setAutoFocusAllowed] = useState(false)
   const [isHelperTextShowing, setIsHelperTextShowing] = useState(false)
@@ -372,7 +370,7 @@ const BenthicLitObservationsTable = ({
             <BenthicPitLitObservationSummaryStats
               benthicAttributeSelectOptions={benthicAttributeSelectOptions}
               observations={observationsState}
-              transectLengthSurveyed={transectLengthSurveyed}
+              recordType={'lit'}
             />
           </UnderTableRow>
         </>
@@ -390,13 +388,6 @@ BenthicLitObservationsTable.propTypes = {
   observationsReducer: observationsReducerPropType,
   resetObservationValidations: PropTypes.func.isRequired,
   setAreObservationsInputsDirty: PropTypes.func.isRequired,
-  formik: PropTypes.shape({
-    values: PropTypes.shape({
-      interval_start: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-      interval_size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-      len_surveyed: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    }),
-  }).isRequired,
   setObservationIdToAddNewBenthicAttributeTo: PropTypes.func.isRequired,
   setIsNewBenthicAttributeModalOpen: PropTypes.func.isRequired,
   testId: PropTypes.string.isRequired,

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.jsx
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitObservationTable.jsx
@@ -372,6 +372,7 @@ const BenthicPitObservationsTable = ({
             <BenthicPitLitObservationSummaryStats
               benthicAttributeSelectOptions={benthicAttributeSelectOptions}
               observations={observationsState}
+              recordType={'pit'}
             />
           </UnderTableRow>
         </>

--- a/src/components/pages/submittedRecordPages/SubmittedBenthicLit/SubmittedBenthicLitObservationTable.jsx
+++ b/src/components/pages/submittedRecordPages/SubmittedBenthicLit/SubmittedBenthicLitObservationTable.jsx
@@ -49,6 +49,7 @@ const SubmittedBenthicLitObservationTable = ({
         <BenthicPitLitObservationSummaryStats
           benthicAttributeSelectOptions={benthicAttributeOptions}
           observations={obs_benthic_lits}
+          recordType={'lit'}
         />
       </UnderTableRow>
     </InputWrapper>

--- a/src/components/pages/submittedRecordPages/SubmittedBenthicPit/SubmittedBenthicPitObservationTable.jsx
+++ b/src/components/pages/submittedRecordPages/SubmittedBenthicPit/SubmittedBenthicPitObservationTable.jsx
@@ -49,6 +49,7 @@ const SubmittedBenthicPitObservationTable = ({
         <BenthicPitLitObservationSummaryStats
           benthicAttributeSelectOptions={benthicAttributeOptions}
           observations={obs_benthic_pits}
+          recordType={'pit'}
         />
       </UnderTableRow>
     </InputWrapper>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Observation summary statistics now explicitly distinguish between 'pit' and 'lit' record types, improving clarity in data presentation.

* **Bug Fixes**
  * Enhanced handling and display of missing attribute percentages for both 'pit' and 'lit' observation records.

* **Refactor**
  * Updated components to use a new 'recordType' property instead of the previous approach, streamlining record type identification and usage.
  * Removed unused form-related properties for cleaner component interfaces.

* **Tests**
  * Expanded and clarified test coverage for missing attribute scenarios across both record types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->