### PR TITLE
fix: [M1585] Validations don't clear after updating confirmed points in BPQ

### DIFF
--- a/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.tsx
+++ b/src/components/pages/ImageClassification/ImageClassificationTable/ImageClassificationObservationTable.tsx
@@ -541,6 +541,11 @@ const ImageClassificationObservationTable = ({
                 } else if (hasObservationWarningValidation) {
                   trMessageType = 'warning'
                 }
+
+                const shouldDisplayObservationValidation = Boolean(
+                  hasObservationErrorValidation && annotation?.unconfirmedCount,
+                )
+                
                 return (
                   <StyledTr
                     key={`${file.id}-${subIndex}`}
@@ -581,7 +586,7 @@ const ImageClassificationObservationTable = ({
                       <>
                         {areValidationsShowing && (
                           <StyledTd>
-                            {hasObservationErrorValidation && annotation?.unconfirmedCount && (
+                            {shouldDisplayObservationValidation && (
                               <ObservationValidationInfo
                                 hasObservationErrorValidation={hasObservationErrorValidation}
                                 hasObservationIgnoredValidation={hasObservationIgnoredValidation}
@@ -631,7 +636,7 @@ const ImageClassificationObservationTable = ({
                     )}
                     {areValidationsShowing && subIndex >= 1 && (
                       <StyledTd>
-                        {hasObservationErrorValidation && annotation?.unconfirmedCount && (
+                        {shouldDisplayObservationValidation && (
                           <ObservationValidationInfo
                             hasObservationErrorValidation={hasObservationErrorValidation}
                             hasObservationIgnoredValidation={hasObservationIgnoredValidation}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized the logic for when to display observation validation info in the Image Classification observation table. This simplifies the code and ensures consistent rendering across scenarios.
  - No changes to user-facing behavior are expected; the table should continue to show validation indicators exactly as before.
  - Improves maintainability and reduces the chance of future inconsistencies in how validation states are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->