### PR TITLE
fix: [M1510] GFCR title text alignment

### DIFF
--- a/src/components/generic/form.js
+++ b/src/components/generic/form.js
@@ -127,7 +127,7 @@ export const Input = styled.input`
   ${inputTextareaSelectStyles}
   &[type='number'],
   &[type='text'] {
-    text-align: right;
+    text-align: ${(props) => props.textAlign || 'right'};
   }
   &:disabled {
     background: ${theme.color.disabledInputBackground};

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/ReportTitleAndDateForm.jsx
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/ReportTitleAndDateForm.jsx
@@ -60,6 +60,7 @@ const ReportTitleAndDateForm = ({ formik, isNewIndicatorSet, displayHelp }) => {
         label={language.pages.gfcrIndicatorSet.indicatorSetTitle}
         id="gfcr-title"
         type="text"
+        textAlign="left"
         {...formik.getFieldProps('title')}
         validationType={formik.errors.title && formik.touched.title ? 'error' : null}
         validationMessages={formik.errors.title}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text and number inputs now support configurable text alignment via a new setting, improving flexibility across forms. If not specified, fields default to right alignment.

* **Style**
  * The Report Title field in the Report Title and Date form is now left-aligned for better readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->