### PR TITLE
fix: [M1862] Hide demo project callout when offline

### DIFF
--- a/src/components/pages/Projects.tsx
+++ b/src/components/pages/Projects.tsx
@@ -109,18 +109,14 @@ const Projects = () => {
     currentUser,
     'demo_project',
   )
-  const [isDemoCalloutVisible, setIsDemoCalloutVisible] = useState(
-    !userHasDemoProject && !hasUserDismissedDemo && isAppOnline && isDemoProjectEnabledForUser,
-  )
+  const shouldShowDemoCallout =
+    !userHasDemoProject && !hasUserDismissedDemo && isAppOnline && isDemoProjectEnabledForUser
+  const [isDemoCalloutVisible, setIsDemoCalloutVisible] = useState(shouldShowDemoCallout)
 
-  // Hide demo callout when projects load and contain a demo project, or when offline
+  // Keep callout visibility in sync with current eligibility state
   useEffect(() => {
-    if (userHasDemoProject || !isAppOnline) {
-      setIsDemoCalloutVisible(false)
-    } else if (isAppOnline && !hasUserDismissedDemo && isDemoProjectEnabledForUser) {
-      setIsDemoCalloutVisible(true)
-    }
-  }, [userHasDemoProject, isAppOnline, hasUserDismissedDemo, isDemoProjectEnabledForUser])
+    setIsDemoCalloutVisible(shouldShowDemoCallout)
+  }, [shouldShowDemoCallout])
 
   useEffect(() => {
     if (databaseSwitchboardInstance && !isSyncInProgress) {

--- a/src/components/pages/Projects.tsx
+++ b/src/components/pages/Projects.tsx
@@ -113,12 +113,14 @@ const Projects = () => {
     !userHasDemoProject && !hasUserDismissedDemo && isAppOnline && isDemoProjectEnabledForUser,
   )
 
-  // Hide demo callout when projects load and contain a demo project
+  // Hide demo callout when projects load and contain a demo project, or when offline
   useEffect(() => {
-    if (userHasDemoProject) {
+    if (userHasDemoProject || !isAppOnline) {
       setIsDemoCalloutVisible(false)
+    } else if (isAppOnline && !hasUserDismissedDemo && isDemoProjectEnabledForUser) {
+      setIsDemoCalloutVisible(true)
     }
-  }, [userHasDemoProject])
+  }, [userHasDemoProject, isAppOnline, hasUserDismissedDemo, isDemoProjectEnabledForUser])
 
   useEffect(() => {
     if (databaseSwitchboardInstance && !isSyncInProgress) {


### PR DESCRIPTION
---Every PR---

- [x] Changes have been tested locally
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] touched JS files have been updated with TypeScript
      -- Update where possible and within scope

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Demo callout visibility now updates correctly when connectivity, demo-feature enablement, demo-project presence, or dismissal state change, ensuring the callout appears only when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->