### PR TITLE
AWS recommends Origin Access Control (OAC)

### DIFF
--- a/iac/static-site.ts
+++ b/iac/static-site.ts
@@ -42,6 +42,7 @@ export class StaticSite extends Construct {
     const siteBucket = new s3.Bucket(this, 'Bucket', {
       publicReadAccess: false,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_ENFORCED,
       bucketName: siteDomain,
 
       /**

--- a/iac/static-site.ts
+++ b/iac/static-site.ts
@@ -8,7 +8,6 @@ import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment'
 import * as targets from 'aws-cdk-lib/aws-route53-targets'
 import * as cloudfront_origins from 'aws-cdk-lib/aws-cloudfront-origins'
 import { CfnOutput, RemovalPolicy, Stack } from 'aws-cdk-lib'
-import * as iam from 'aws-cdk-lib/aws-iam'
 import { Construct } from 'constructs'
 
 export interface StaticSiteProps {
@@ -36,9 +35,6 @@ export class StaticSite extends Construct {
     })
 
     const siteDomain = `${props.siteSubDomain}.${props.domainName}`
-    const cloudfrontOAI = new cloudfront.OriginAccessIdentity(this, 'CloudfrontOAI', {
-      comment: `OAI for ${name}`,
-    })
 
     new CfnOutput(this, 'Site', { value: `https://${siteDomain}` })
 
@@ -62,18 +58,6 @@ export class StaticSite extends Construct {
       autoDeleteObjects: props.siteSubDomain === 'dev',
     })
 
-    // Grant access to cloudfront
-    siteBucket.addToResourcePolicy(
-      new iam.PolicyStatement({
-        actions: ['s3:GetObject'],
-        resources: [siteBucket.arnForObjects('*')],
-        principals: [
-          new iam.CanonicalUserPrincipal(
-            cloudfrontOAI.cloudFrontOriginAccessIdentityS3CanonicalUserId,
-          ),
-        ],
-      }),
-    )
     new CfnOutput(this, 'BucketName', { value: siteBucket.bucketName })
 
     // TLS certificate
@@ -116,9 +100,7 @@ export class StaticSite extends Construct {
         cachePolicy: props.isPreview
           ? cloudfront.CachePolicy.CACHING_DISABLED
           : cloudfront.CachePolicy.CACHING_OPTIMIZED,
-        origin: cloudfront_origins.S3BucketOrigin.withOriginAccessIdentity(siteBucket, {
-          originAccessIdentity: cloudfrontOAI,
-        }),
+        origin: cloudfront_origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
         compress: true,
         allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,


### PR DESCRIPTION
https://trello.com/c/3MsrtCED/1894-migrate-cloudfront-from-oai-to-oac

```
❯ npx cdk diff
start: Building dev-webapp Template
success: Built dev-webapp Template
start: Publishing dev-webapp Template (554812291621-us-east-1-fab6fa13)
success: Published dev-webapp Template (554812291621-us-east-1-fab6fa13)
Hold on while we create a read-only change set to get a diff with accurate replacement information (use --method=template to use a less accurate but faster template-only diff)

Stack dev-webapp
IAM Statement Changes
┌───┬────────────────────────────┬────────┬──────────────┬────────────────────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────┐
│   │ Resource                   │ Effect │ Action       │ Principal                                                      │ Condition                                                       │
├───┼────────────────────────────┼────────┼──────────────┼────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ - │ ${StaticSite/Bucket.Arn}/* │ Allow  │ s3:GetObject │ CanonicalUser:${StaticSite/CloudfrontOAI.S3CanonicalUserId}    │                                                                 │
├───┼────────────────────────────┼────────┼──────────────┼────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ + │ ${StaticSite/Bucket.Arn}/* │ Allow  │ s3:GetObject │ Service:cloudfront.amazonaws.com                               │ "StringEquals": {                                               │
│   │                            │        │              │                                                                │   "AWS:SourceArn": "arn:${AWS::Partition}:cloudfront::${AWS::Ac │
│   │                            │        │              │                                                                │ countId}:distribution/${StaticSite/Distribution}"               │
│   │                            │        │              │                                                                │ }                                                               │
└───┴────────────────────────────┴────────┴──────────────┴────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────┘
(NOTE: There may be security-related changes not in this list. See https://github.com/aws/aws-cdk/issues/1299)

Resources
[-] AWS::CloudFront::CloudFrontOriginAccessIdentity StaticSite/CloudfrontOAI StaticSiteCloudfrontOAI422FE022 destroy
[+] AWS::CloudFront::OriginAccessControl StaticSite/Distribution/Origin1/S3OriginAccessControl StaticSiteDistributionOrigin1S3OriginAccessControlD22282A8
[~] AWS::S3::BucketPolicy StaticSite/Bucket/Policy StaticSiteBucketPolicyD6F2ED22
 └─ [~] PolicyDocument
     └─ [~] .Statement:
         └─ @@ -40,14 +40,32 @@
            [ ] },
            [ ] {
            [ ]   "Action": "s3:GetObject",
            [+]   "Condition": {
            [+]     "StringEquals": {
            [+]       "AWS:SourceArn": {
            [+]         "Fn::Join": [
            [+]           "",
            [+]           [
            [+]             "arn:",
            [+]             {
            [+]               "Ref": "AWS::Partition"
            [+]             },
            [+]             ":cloudfront::",
            [+]             {
            [+]               "Ref": "AWS::AccountId"
            [+]             },
            [+]             ":distribution/",
            [+]             {
            [+]               "Ref": "StaticSiteDistribution90D303F1"
            [+]             }
            [+]           ]
            [+]         ]
            [+]       }
            [+]     }
            [+]   },
            [ ]   "Effect": "Allow",
            [ ]   "Principal": {
            [-]     "CanonicalUser": {
            [-]       "Fn::GetAtt": [
            [-]         "StaticSiteCloudfrontOAI422FE022",
            [-]         "S3CanonicalUserId"
            [-]       ]
            [-]     }
            [+]     "Service": "cloudfront.amazonaws.com"
            [ ]   },
            [ ]   "Resource": {
            [ ]     "Fn::Join": [
[~] AWS::CloudFront::Distribution StaticSite/Distribution StaticSiteDistribution90D303F1
 └─ [~] DistributionConfig
     └─ [~] .Origins:
         └─ @@ -7,18 +7,14 @@
            [ ]       ]
            [ ]     },
            [ ]     "Id": "devwebappStaticSiteDistributionOrigin159A8878E",
            [+]     "OriginAccessControlId": {
            [+]       "Fn::GetAtt": [
            [+]         "StaticSiteDistributionOrigin1S3OriginAccessControlD22282A8",
            [+]         "Id"
            [+]       ]
            [+]     },
            [ ]     "S3OriginConfig": {
            [-]       "OriginAccessIdentity": {
            [-]         "Fn::Join": [
            [-]           "",
            [-]           [
            [-]             "origin-access-identity/cloudfront/",
            [-]             {
            [-]               "Ref": "StaticSiteCloudfrontOAI422FE022"
            [-]             }
            [-]           ]
            [-]         ]
            [-]       }
            [+]       "OriginAccessIdentity": ""
            [ ]     }
            [ ]   }
            [ ] ]
[~] Custom::CDKBucketDeployment StaticSite/DeployWithInvalidation/CustomResource-1024MiB StaticSiteDeployWithInvalidationCustomResource1024MiB4EA0C9B4 may be replaced
 └─ [~] SourceObjectKeys (may cause replacement)
     └─ @@ -1,3 +1,3 @@
        [ ] [
        [-]   "a8339196c04753b24caa65a2e8af2438da8138ec43ae5a0ee74d3c01e0be565c.zip"
        [+]   "deb1cf9ff4420c586ff03def87f41ea07f9a3134cf097f0ddc62dde57c1c63c7.zip"
        [ ] ]



✨  Number of stacks with differences: 1

```
Here's a summary of the changes to iac/static-site.ts:

1. Removed the OriginAccessIdentity construct (cloudfrontOAI) — no longer needed
2. Removed the manual addToResourcePolicy block that granted the OAI canonical user principal s3:GetObject — OAC handles the bucket policy automatically via CDK
3. Replaced S3BucketOrigin.withOriginAccessIdentity(siteBucket, { originAccessIdentity: cloudfrontOAI }) with S3BucketOrigin.withOriginAccessControl(siteBucket)
4. Removed the unused aws-cdk-lib/aws-iam import

---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] touched JS files have been updated with TypeScript
      -- Update where possible and within scope

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static site deployment infrastructure security configuration to use improved access control mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->