### PR TITLE
fix: [M1783] Always show demo project callout on no-data projects screen

### DIFF
--- a/src/components/pages/Projects.tsx
+++ b/src/components/pages/Projects.tsx
@@ -110,7 +110,10 @@ const Projects = () => {
     'demo_project',
   )
   const shouldShowDemoCallout =
-    !userHasDemoProject && !hasUserDismissedDemo && isAppOnline && isDemoProjectEnabledForUser
+    !userHasDemoProject &&
+    (!hasUserDismissedDemo || !userHasProjects) &&
+    isAppOnline &&
+    isDemoProjectEnabledForUser
   const [isDemoCalloutVisible, setIsDemoCalloutVisible] = useState(shouldShowDemoCallout)
 
   // Keep callout visibility in sync with current eligibility state


### PR DESCRIPTION
When a user added then removed the demo project, the callout was hidden because creating the demo sets hasUserDismissedDemo to true. Now the dismissed state is ignored when the user has no projects, so the callout always appears on the empty projects page.

https://github.com/user-attachments/assets/c05eae42-bb29-4b8b-8b95-b8fcf70fde77



---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] touched JS files have been updated with TypeScript
      -- Update where possible and within scope

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated demo project callout visibility logic: the callout now re-appears when users have no projects, even if previously dismissed, while remaining hidden for users with existing projects who have dismissed it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->