### PR TITLE
fix: [M1927] Enable save button on project info page 

### DIFF
--- a/src/components/pages/ProjectInfo/ProjectInfo.tsx
+++ b/src/components/pages/ProjectInfo/ProjectInfo.tsx
@@ -201,9 +201,7 @@ const ProjectInfo = ({ isNewDemoProject }: ProjectInfoProps) => {
         })
     },
     validate: (values) => {
-      const errors = {
-        name: undefined,
-      }
+      const errors: { name?: { code: string; id: string }[] } = {}
 
       if (!values.name) {
         errors.name = [{ code: requiredFieldErrorText, id: 'Required' }]


### PR DESCRIPTION
Initializing the validate errors object with `{ name: undefined }` caused `Object.keys(formik.errors)` to always have length 1, making `formHasErrors` permanently true.
Use an empty object with a correct type annotation instead.

Regression from [`ed3ba408`](https://github.com/data-mermaid/mermaid-webapp/commit/ed3ba408) (M1806).


---Every PR---

- [x] Changes have been tested locally
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] touched JS files have been updated with TypeScript
      -- Update where possible and within scope

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved form validation logic structure for enhanced maintainability and code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->