### PR TITLE
HOTFIX - fix: [M1773] persist 'not reported' compliance selection

### DIFF
--- a/src/components/pages/ManagementRegime/ManagementRegime.jsx
+++ b/src/components/pages/ManagementRegime/ManagementRegime.jsx
@@ -14,7 +14,7 @@ import {
   getIsUserReadOnlyForProject,
   getIsUserAdminForProject,
 } from '../../../App/currentUserProfileHelpers'
-import { getManagementRegimeInitialValues } from './managementRegimeFormInitialValues'
+import { getManagementRegimeInitialValues, NOT_REPORTED_COMPLIANCE_VALUE } from './managementRegimeFormInitialValues'
 import { getOptions } from '../../../library/getOptions'
 import { getToastArguments } from '../../../library/getToastArguments'
 import { H2, ItalicizedInfo } from '../../generic/text'
@@ -208,10 +208,14 @@ const ManagementRegimeForm = ({ formik, managementComplianceOptions, managementP
         <InputSelectWithLabelAndValidation
           label={t('management_regimes.compliance')}
           id="compliance"
-          required={false}
+          required
           testId="compliance"
           options={managementComplianceOptions}
           {...formik.getFieldProps('compliance')}
+          validationType={
+            formik.errors.compliance && formik.touched.compliance ? 'error' : null
+          }
+          validationMessages={formik.errors.compliance}
           helperText={t('management_regimes.rules_effectiveness')}
         />
         <TextareaWithLabelAndValidation
@@ -303,7 +307,8 @@ const ManagementRegime = ({ isNewManagementRegime }) => {
 
             const sortedManagementComplianceOptions = sortManagementComplianceChoices([
               ...getOptions(choicesResponse.managementcompliances.data),
-              { label: notReportedCompliance, value: '' },
+              // UI-only option - converted to null on save, so it never reaches the database.
+              { label: notReportedCompliance, value: NOT_REPORTED_COMPLIANCE_VALUE },
             ])
 
             setManagementPartyOptions(getOptions(choicesResponse.managementparties.data))
@@ -342,9 +347,9 @@ const ManagementRegime = ({ isNewManagementRegime }) => {
   const initialFormValues = useMemo(() => {
     return (
       getPersistedUnsavedFormikData() ??
-      getManagementRegimeInitialValues(managementRegimeBeingEdited)
+      getManagementRegimeInitialValues(managementRegimeBeingEdited, isNewManagementRegime)
     )
-  }, [getPersistedUnsavedFormikData, managementRegimeBeingEdited])
+  }, [getPersistedUnsavedFormikData, managementRegimeBeingEdited, isNewManagementRegime])
 
   const formik = useFormik({
     initialValues: initialFormValues,
@@ -381,7 +386,9 @@ const ManagementRegime = ({ isNewManagementRegime }) => {
         gear_restriction,
         species_restriction,
         access_restriction,
-        compliance,
+        // Convert the "not reported" placeholder to null here - this is the only point
+        // where it leaves the form, so the placeholder never reaches the database.
+        compliance: compliance && compliance !== NOT_REPORTED_COMPLIANCE_VALUE ? compliance : null,
         notes,
       }
 
@@ -462,6 +469,11 @@ const ManagementRegime = ({ isNewManagementRegime }) => {
 
       if (!values.name) {
         errors.name = [{ code: t('forms.required_field'), id: 'Required' }]
+      }
+
+      // "Not reported" is truthy and passes - only "Choose..." (empty string) blocks save.
+      if (!values.compliance) {
+        errors.compliance = [{ code: t('forms.required_field'), id: 'Required' }]
       }
 
       if (noPartialRestrictionRulesSelected) {

--- a/src/components/pages/ManagementRegime/ManagementRegime.test.jsx
+++ b/src/components/pages/ManagementRegime/ManagementRegime.test.jsx
@@ -155,3 +155,118 @@ test('Management Regime component - form inputs are initialized with the correct
   expect(screen.getByTestId('compliance-select')).toHaveDisplayValue('none')
   expect(screen.getByTestId('notes-textarea')).toHaveValue('Some notes')
 })
+
+test('New Management Regime - compliance defaults to "Choose..."', async () => {
+  const { dexiePerUserDataInstance } = getMockDexieInstancesAllSuccess()
+
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
+  renderAuthenticatedOnline(
+    <Routes>
+      <Route
+        path="/projects/:projectId/management-regimes/new"
+        element={<ManagementRegime isNewManagementRegime={true} />}
+      />
+    </Routes>,
+    {
+      initialEntries: ['/projects/5/management-regimes/new'],
+      dexiePerUserDataInstance,
+      isSyncInProgressOverride: true,
+    },
+  )
+
+  await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'))
+
+  // empty value = "Choose..." placeholder option
+  expect(await screen.findByTestId('compliance-select')).toHaveValue('')
+})
+
+test('Edit Management Regime - null compliance is shown as "not reported"', async () => {
+  const { dexiePerUserDataInstance } = getMockDexieInstancesAllSuccess()
+
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
+  // Management Regime id "1" has compliance: null in the mock data
+  renderAuthenticatedOnline(
+    <Routes>
+      <Route
+        path="/projects/:projectId/management-regimes/:managementRegimeId"
+        element={<ManagementRegime isNewManagementRegime={false} />}
+      />
+    </Routes>,
+    {
+      initialEntries: ['/projects/5/management-regimes/1'],
+      dexiePerUserDataInstance,
+      isSyncInProgressOverride: true,
+    },
+  )
+
+  await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'))
+
+  await waitFor(() =>
+    expect(screen.getByTestId('compliance-select')).toHaveValue('not-reported'),
+  )
+})
+
+test('Selecting "not reported" updates the compliance display (bug regression)', async () => {
+  const { dexiePerUserDataInstance } = getMockDexieInstancesAllSuccess()
+
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
+  const { user } = renderAuthenticatedOnline(
+    <Routes>
+      <Route
+        path="/projects/:projectId/management-regimes/new"
+        element={<ManagementRegime isNewManagementRegime={true} />}
+      />
+    </Routes>,
+    {
+      initialEntries: ['/projects/5/management-regimes/new'],
+      dexiePerUserDataInstance,
+      isSyncInProgressOverride: true,
+    },
+  )
+
+  await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'))
+  const select = await screen.findByTestId('compliance-select')
+  expect(select).toHaveValue('')
+
+  await user.selectOptions(select, 'not-reported')
+
+  expect(select).toHaveValue('not-reported')
+})
+
+test('New Management Regime - "Choose..." blocks save; "not reported" unblocks it', async () => {
+  const { dexiePerUserDataInstance } = getMockDexieInstancesAllSuccess()
+
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
+  const { user } = renderAuthenticatedOnline(
+    <Routes>
+      <Route
+        path="/projects/:projectId/management-regimes/new"
+        element={<ManagementRegime isNewManagementRegime={true} />}
+      />
+    </Routes>,
+    {
+      initialEntries: ['/projects/5/management-regimes/new'],
+      dexiePerUserDataInstance,
+      isSyncInProgressOverride: true,
+    },
+  )
+
+  await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'))
+
+  // dirty the form by filling name, leaving compliance on "Choose..."
+  await user.type(await screen.findByTestId('name-input'), 'New MR')
+
+  await waitFor(() =>
+    expect(screen.getByTestId('save-button-management-regime-form')).toBeDisabled(),
+  )
+
+  await user.selectOptions(screen.getByTestId('compliance-select'), 'not-reported')
+
+  await waitFor(() =>
+    expect(screen.getByTestId('save-button-management-regime-form')).toBeEnabled(),
+  )
+})

--- a/src/components/pages/ManagementRegime/managementRegimeFormInitialValues.js
+++ b/src/components/pages/ManagementRegime/managementRegimeFormInitialValues.js
@@ -1,8 +1,8 @@
-// All boolean fields default to false and all string fields default to '' to ensure
-// controlled inputs are always controlled from the first render (avoiding React's
-// "uncontrolled to controlled" warning). The compliance field intentionally defaults
-// to '' rather than a specific value so no compliance option is pre-selected.
-const getManagementRegimeInitialValues = (managementRegimeRecord) => {
+// Booleans default to false and strings to '' so React inputs stay controlled from first render.
+// Compliance is the exception: on edit, null becomes "not reported" so the user's prior blank choice persists.
+const NOT_REPORTED_COMPLIANCE_VALUE = 'not-reported'
+
+const getManagementRegimeInitialValues = (managementRegimeRecord, isNewManagementRegime) => {
   return {
     name: managementRegimeRecord?.name ?? '',
     name_secondary: managementRegimeRecord?.name_secondary ?? '',
@@ -16,9 +16,11 @@ const getManagementRegimeInitialValues = (managementRegimeRecord) => {
     size_limits: managementRegimeRecord?.size_limits ?? false,
     gear_restriction: managementRegimeRecord?.gear_restriction ?? false,
     species_restriction: managementRegimeRecord?.species_restriction ?? false,
-    compliance: managementRegimeRecord?.compliance ?? '',
+    compliance:
+      managementRegimeRecord?.compliance ??
+      (isNewManagementRegime ? '' : NOT_REPORTED_COMPLIANCE_VALUE),
     notes: managementRegimeRecord?.notes ?? '',
   }
 }
 
-export { getManagementRegimeInitialValues }
+export { getManagementRegimeInitialValues, NOT_REPORTED_COMPLIANCE_VALUE }


### PR DESCRIPTION
Currently on hold until we determine the required behaviour (see associated trello card)

The compliance select had two options sharing an empty-string value (the hardcoded 'Choose...' placeholder and 'not reported'), so picking 'not reported' rendered as 'Choose...'.

Give 'not reported' a UI-only value, converted to null in onSubmit so the placeholder never reaches the API.

On edit, default null compliance to 'not reported' so the user's prior blank choice persists across sessions. On create, keep 'Choose...'.

Make compliance required so 'Choose...' now blocks save.

Add tests for each of the above.

---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] touched JS files have been updated with TypeScript
      -- Update where possible and within scope

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)
