### PR TITLE
fix: [M1575] propose button overlap modal

### DIFF
--- a/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
@@ -185,12 +185,7 @@ const InputAutocomplete = ({
                 {noResultsText && <p data-testid="noResult">{noResultsText}</p>}
                 {noResultsAction && (
                   // role="presentation" marks this as a structural wrapper, not an interactive element.
-                  // onKeyDown satisfies the a11y linter — real keyboard interaction is handled by the button inside.
-                  <div
-                    role="presentation"
-                    onClick={() => setIsMenuOpen(false)}
-                    onKeyDown={() => setIsMenuOpen(false)}
-                  >
+                  <div role="presentation" onClick={() => setIsMenuOpen(false)}>
                     {noResultsAction}
                   </div>
                 )}

--- a/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
@@ -184,6 +184,8 @@ const InputAutocomplete = ({
               <div>
                 {noResultsText && <p data-testid="noResult">{noResultsText}</p>}
                 {noResultsAction && (
+                  // role="presentation" marks this as a structural wrapper, not an interactive element.
+                  // onKeyDown satisfies the a11y linter — real keyboard interaction is handled by the button inside.
                   <div
                     role="presentation"
                     onClick={() => setIsMenuOpen(false)}

--- a/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
@@ -183,7 +183,15 @@ const InputAutocomplete = ({
             {isMenuOpen && !menuItems.length && (
               <div>
                 {noResultsText && <p data-testid="noResult">{noResultsText}</p>}
-                {noResultsAction}
+                {noResultsAction && (
+                  <div
+                    role="presentation"
+                    onClick={() => setIsMenuOpen(false)}
+                    onKeyDown={() => setIsMenuOpen(false)}
+                  >
+                    {noResultsAction}
+                  </div>
+                )}
               </div>
             )}
           </AutoCompleteResultsWrapper>


### PR DESCRIPTION
## What changed

`InputAutocomplete` now closes the dropdown when the `noResultsAction` button is clicked. Previously, clicking "Propose New Fish Species / Benthic Attribute" or "Suggest a new organization" opened the modal but left the dropdown open, visually overlapping the modal. A structural wrapper div around `noResultsAction` intercepts the click and calls `setIsMenuOpen(false)` before the action's own handler fires.

Single change in `InputAutocomplete.jsx` — fixes all 7 affected places at once with no caller updates required.

---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed autocomplete menu dismissal when interacting with the no-results action. The menu now properly closes whether activated via mouse click or keyboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->