### PR TITLE
hot fix: [M1575] Limit no-results wrapper styles to paragraph items

### DIFF
--- a/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
@@ -25,7 +25,7 @@ const AutoCompleteResultsWrapper = styled.div`
     outline-offset: -2px;
     background: ${theme.color.white};
 
-    > * {
+    > p {
       margin: 0;
       padding: ${theme.spacing.buttonPadding};
     }
@@ -185,7 +185,10 @@ const InputAutocomplete = ({
                 {noResultsText && <p data-testid="noResult">{noResultsText}</p>}
                 {noResultsAction && (
                   // role="presentation" marks this as a structural wrapper, not an interactive element.
-                  <div role="presentation" onClick={() => setIsMenuOpen(false)}>
+                  <div
+                    role="presentation"
+                    onClick={() => setIsMenuOpen(false)}
+                  >
                     {noResultsAction}
                   </div>
                 )}


### PR DESCRIPTION
## What changed:
This fix the padding for this dropdown button
<img width="666" height="246" alt="Screenshot 2026-06-12 at 15 22 11" src="https://github.com/user-attachments/assets/3de07da3-e00b-4f52-bc7b-a4e3b43dfd3a" />

---Every PR---

- [x] Changes have been tested locally
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)
