### PR TITLE
feat [1979] Remove asterisk from size

### DIFF
--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertObservationTable.tsx
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertObservationTable.tsx
@@ -521,7 +521,6 @@ const BeltInvertObservationTable = ({
               <Th $align="right" id="invert-size-label">
                 <LabelContainer>
                   {`${t('sample_units.size')} (${t('measurements.centimeter_short')})`}
-                  <RequiredIndicator />
                 </LabelContainer>
               </Th>
               <Th $align="right" id="invert-count-label">


### PR DESCRIPTION
Remove the asterisk from the size column header as it is not required on the api side

Updated screenshot without asterisk
<img width="1181" height="276" alt="image" src="https://github.com/user-attachments/assets/d5b730a6-59c1-4a06-8d91-a2f9d2da8cf0" />


---Every PR---

- [x] Changes have been tested locally
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Unit tests have run and passed

---Transitional Changes---

- [x] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [x] Any language.js tokens no longer used are removed
- [x] Any necessary updates to the documentation have been made
- [x] Unit tests have been added or updated, where possible, to prevent future regressions
- [x] styled-components code in changed files has been updated to CSS modules in the styles folder
- [x] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)
