### PR TITLE
hot fix: [M1511] tooltip not closing when clicking on table inputs

### DIFF
--- a/src/components/ColumnHeaderToolTip/LabelWithTooltip.tsx
+++ b/src/components/ColumnHeaderToolTip/LabelWithTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import Tooltip from '@mui/material/Tooltip'
 import { LabelContainer } from '../generic/form'
 import { IconInfo } from '../icons'
@@ -17,6 +17,8 @@ interface LabelWithTooltipProps {
 
 const LabelWithTooltip = ({ label, tooltipText, groupRef, maxWidth }: LabelWithTooltipProps) => {
   const [isOpen, setIsOpen] = useState(false)
+  const iconRef = useRef<HTMLButtonElement>(null)
+  const popperRef = useRef<HTMLDivElement>(null)
 
   const handleClose = () => {
     setIsOpen(false)
@@ -38,42 +40,56 @@ const LabelWithTooltip = ({ label, tooltipText, groupRef, maxWidth }: LabelWithT
     }
   }
 
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node
+      const isOnIcon = iconRef.current?.contains(target)
+      const isOnPopper = popperRef.current?.contains(target)
+      if (!isOnIcon && !isOnPopper) {
+        handleClose()
+      }
+    }
+
+    // window capture fires before Downshift's document capture listener, so
+    // stopImmediatePropagation from Downshift cannot block this handler.
+    // The event continues to its target normally — no DOM overlay needed.
+    window.addEventListener('pointerdown', handlePointerDown, { capture: true })
+
+    return () => window.removeEventListener('pointerdown', handlePointerDown, { capture: true })
+  }, [isOpen]) // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
-    <>
-      {isOpen && (
-        // Transparent backdrop sits below the MUI tooltip (z-index 1500) but above everything
-        // else. Any mousedown outside the tooltip hits this and closes it, bypassing any
-        // stopPropagation calls from table inputs or autocompletes.
-        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-        <div style={{ position: 'fixed', inset: 0, zIndex: 1499 }} onMouseDown={handleClose} />
-      )}
-      <LabelContainer>
-        {label}
-        <Tooltip
-          title={tooltipText}
-          placement="top"
-          arrow
-          open={isOpen}
-          disableFocusListener
-          disableHoverListener
-          disableTouchListener
-          classes={{
-            tooltip: tooltipStyles['MuiTooltip-tooltip'],
-            arrow: tooltipStyles['MuiTooltip-arrow'],
-          }}
-          slotProps={{
-            popper: {
-              modifiers: [{ name: 'offset', options: { offset: [0, -10] } }],
-            },
-            tooltip: maxWidth ? { style: { maxWidth } } : undefined,
-          }}
-        >
-          <IconButton type="button" onClick={handleIconClick}>
-            <IconInfo aria-label="info" />
-          </IconButton>
-        </Tooltip>
-      </LabelContainer>
-    </>
+    <LabelContainer>
+      {label}
+      <Tooltip
+        title={tooltipText}
+        placement="top"
+        arrow
+        open={isOpen}
+        disableFocusListener
+        disableHoverListener
+        disableTouchListener
+        classes={{
+          tooltip: tooltipStyles['MuiTooltip-tooltip'],
+          arrow: tooltipStyles['MuiTooltip-arrow'],
+        }}
+        slotProps={{
+          popper: {
+            ref: popperRef,
+            modifiers: [{ name: 'offset', options: { offset: [0, -10] } }],
+          },
+          tooltip: maxWidth ? { style: { maxWidth } } : undefined,
+        }}
+      >
+        <IconButton ref={iconRef} type="button" onClick={handleIconClick}>
+          <IconInfo aria-label="info" />
+        </IconButton>
+      </Tooltip>
+    </LabelContainer>
   )
 }
 

--- a/src/components/ColumnHeaderToolTip/LabelWithTooltip.tsx
+++ b/src/components/ColumnHeaderToolTip/LabelWithTooltip.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import Tooltip from '@mui/material/Tooltip'
-import ClickAwayListener from '@mui/material/ClickAwayListener'
 import { LabelContainer } from '../generic/form'
 import { IconInfo } from '../icons'
 import { IconButton } from '../generic/buttons'
@@ -40,7 +39,14 @@ const LabelWithTooltip = ({ label, tooltipText, groupRef, maxWidth }: LabelWithT
   }
 
   return (
-    <ClickAwayListener mouseEvent="onMouseDown" onClickAway={handleClose}>
+    <>
+      {isOpen && (
+        // Transparent backdrop sits below the MUI tooltip (z-index 1500) but above everything
+        // else. Any mousedown outside the tooltip hits this and closes it, bypassing any
+        // stopPropagation calls from table inputs or autocompletes.
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div style={{ position: 'fixed', inset: 0, zIndex: 1499 }} onMouseDown={handleClose} />
+      )}
       <LabelContainer>
         {label}
         <Tooltip
@@ -67,7 +73,7 @@ const LabelWithTooltip = ({ label, tooltipText, groupRef, maxWidth }: LabelWithT
           </IconButton>
         </Tooltip>
       </LabelContainer>
-    </ClickAwayListener>
+    </>
   )
 }
 


### PR DESCRIPTION
## What changed

- Tooltips on observation table column headers (Fish Belt, Benthic, etc.) would not close when clicking anywhere in the table body — inputs, autocompletes, or empty header space
- Root cause: Downshift (the autocomplete library) registers a capture-phase `mousedown` listener on `document` and calls `stopImmediatePropagation()`, which blocked `ClickAwayListener` from ever firing
- Fix: replace `ClickAwayListener` with a transparent `position: fixed` backdrop rendered at z-index 1499 (just below MUI Tooltip at 1500) — any click outside the tooltip lands directly on the backdrop, bypassing event propagation entirely

## Test plan

- [ ] Open a tooltip on any observation table column header (Fish Belt, Benthic LIT, Benthic PIT, etc.)
- [ ] Click on an autocomplete input in the table body — tooltip should close
- [ ] Click on a count/size input in the table body — tooltip should close
- [ ] Click in the empty space of a wide column header — tooltip should close
- [ ] Click the info icon again — tooltip should toggle closed
- [ ] Open two tooltips in sequence — only one should be visible at a time (groupRef behavior unchanged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip dismissal behavior to be more responsive and reliable when clicking outside the tooltip area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->