### PR TITLE
feat [1958] address qa comments

### DIFF
--- a/src/components/generic/Table/table.d.ts
+++ b/src/components/generic/Table/table.d.ts
@@ -51,4 +51,7 @@ export const OverviewTd: React.ComponentType<TdProps>
 export const ObservationsSummaryStats: React.ComponentType<
   React.TableHTMLAttributes<HTMLTableElement>
 >
+export const MacroinvertebrateObservationsSummaryStats: React.ComponentType<
+  React.TableHTMLAttributes<HTMLTableElement>
+>
 export const thStyles: (props: ThProps) => ReturnType<typeof import('styled-components').css>

--- a/src/components/generic/Table/table.js
+++ b/src/components/generic/Table/table.js
@@ -257,6 +257,14 @@ export const ObservationsSummaryStats = styled(Table)`
     font-size: smaller;
   `)}
 `
+
+export const MacroinvertebrateObservationsSummaryStats = styled(ObservationsSummaryStats)`
+  width: 45%;
+
+  th.goi-density {
+    padding-left: ${theme.spacing.xlarge};
+  }
+`
 export const HeaderCenter = styled.p`
   text-align: center;
   white-space: nowrap;

--- a/src/components/pages/submittedRecordPages/SubmittedBeltInvert/SubmittedBeltInvertObservationTable.jsx
+++ b/src/components/pages/submittedRecordPages/SubmittedBeltInvert/SubmittedBeltInvertObservationTable.jsx
@@ -6,7 +6,7 @@ import {
   submittedBeltInvertPropType,
 } from '../../../../App/mermaidData/mermaidDataProptypes'
 import {
-  ObservationsSummaryStats,
+  MacroinvertebrateObservationsSummaryStats,
   SubmittedObservationStickyTable,
   Tr,
   Td,
@@ -58,7 +58,9 @@ const SubmittedBeltInvertObservationTable = ({
     <Tr key={item.id}>
       <Td $align="center">{index + 1}</Td>
       <Td $align="left">{getInvertName(item.invert_attribute)}</Td>
+      <Td $align="left">{item.size}</Td>
       <Td $align="right">{item.count}</Td>
+      <Td $align="right">{item.notes}</Td>
       <Td $align="right">{getInvertDensity(item)}</Td>
     </Tr>
   ))
@@ -71,8 +73,10 @@ const SubmittedBeltInvertObservationTable = ({
           <thead>
             <Tr>
               <TheadItem> </TheadItem>
-              <TheadItem $align="left">{t('taxonomies.species')}</TheadItem>
+              <TheadItem $align="left">{t('observations.macroinvertebrate_name')}</TheadItem>
+              <TheadItem $align="left">{t('size_cm')}</TheadItem>
               <TheadItem $align="right">{t('count')}</TheadItem>
+              <TheadItem $align="right">{t('notes')}</TheadItem>
               <TheadItem $align="right">{`${t('density')} (${t(
                 'measurements.individuals_per_hectare_short',
               )})`}</TheadItem>
@@ -82,12 +86,19 @@ const SubmittedBeltInvertObservationTable = ({
         </SubmittedObservationStickyTable>
       </StyledOverflowWrapper>
       <UnderTableRow>
-        <ObservationsSummaryStats>
+        <MacroinvertebrateObservationsSummaryStats>
+          <thead>
+            <Tr>
+              <Th colSpan={2}>
+                {t('macroinvertebrate_observations.density_by_group_of_interest_units')}
+              </Th>
+            </Tr>
+          </thead>
           <tbody>
             {Object.entries(densityByGoi).map(([groupName, groupDensity]) => {
               return (
                 <Tr key={groupName}>
-                  <Th>{`${t('density')} - ${groupName}`}</Th>
+                  <Th className="goi-density">{groupName}</Th>
                   <Td>{formatDensityToTwoDecimals(groupDensity)}</Td>
                 </Tr>
               )
@@ -101,7 +112,7 @@ const SubmittedBeltInvertObservationTable = ({
               <Td>{abundance}</Td>
             </Tr>
           </tbody>
-        </ObservationsSummaryStats>
+        </MacroinvertebrateObservationsSummaryStats>
       </UnderTableRow>
     </InputWrapper>
   )

--- a/src/library/macroinvertebrates/calculateGroupOfInterestDensity.ts
+++ b/src/library/macroinvertebrates/calculateGroupOfInterestDensity.ts
@@ -302,12 +302,11 @@ export const calculateDensityByGroupOfInterest = (
   widthM: number,
   options: GoiDensityOptions = {},
 ): GoiDensityResult => {
-  // Phase 1: Setup
   const goiChoices = options.goiChoices ?? getGoiChoices(options.choices, invertAttributes)
   const goiWeightMaps = options.goiWeightMaps ?? buildGoiWeightMaps(invertAttributes)
   const attributeById = new Map(invertAttributes.map((attribute) => [attribute.id, attribute]))
 
-  // Phase 2: Attribution — accumulate per-GoI count totals from included observations
+  // Accumulate per-GoI count totals from included observations
   const includedObservations = observations.filter((observation) => observation.include !== false)
   const totalIncludedCount = includedObservations.reduce(
     (sum, observation) => sum + Number(observation.count ?? 0),
@@ -335,7 +334,7 @@ export const calculateDensityByGroupOfInterest = (
     attributeObservationToGoi(attribute, count, goiWeightMaps, goiCountTotals)
   })
 
-  // Phase 3: Density conversion — (count / area_m2) * 10000 to get ind/ha
+  // Density conversion — (count / area_m2) * 10000 to get ind/ha
   const areaM2 = Number(lenSurveyed) * Number(widthM)
   const totalDensity = areaM2 > 0 ? roundToTwoDecimals((totalIncludedCount / areaM2) * 10000) : 0
   const densityByGoi = buildDensityByGoi(goiCountTotals, goiChoices, areaM2)

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -529,6 +529,7 @@
   "macroinvertebrate_observations": {
     "add_notes": "Add notes...",
     "add_macroinvertebrate": "Add macroinvertebrate species",
+    "density_by_group_of_interest_units": "Density by group of interest (ind/ha)",
     "edit_notes": "Edit Notes",
     "macroinvertebrate_species": "Macroinvertebrate species",
     "must_select_size_bin_warning": "You must select a macroinvertebrate size bin before adding any observations",


### PR DESCRIPTION
Ref: https://trello.com/c/d2Wkqk29/1958-idea-macroinvertebrate-submitted-record-view-calculated-metrics-phase-41

Updated as per QA comments
- ‘Species' header should be replaced by 'Macroinvertebrate name’
- ‘Size’ and ‘Notes’ column missing
- "The word  'Density' is repeated for all groups of interest listed, which makes the list quite cluttered. It'd be cleaner to have one title at the top of the list, such as 'Density by group of interest (ind/ha)' with unit included, as it's also missing for each group of interest density. Then have each group listed, such as 'Sea cucumbers', and its density. Example below:

Density by group of interest (ind/ha)
      Sea cucumbers       1000.00
      Sea urchins             2000.00
      Giant clams             50.00

<img width="528" height="290" alt="image" src="https://github.com/user-attachments/assets/36c1d3f2-69e3-43b0-8e17-c4c6c0f7b245" />


---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)
