### PR TITLE
fix [1997]

### DIFF
--- a/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertValidationDisplay1.test.jsx
+++ b/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertValidationDisplay1.test.jsx
@@ -251,9 +251,6 @@ test('Validating an empty collect record, and then editing an input with errors 
     within(screen.getByTestId('width')).getByText('validation_messages.required'),
   ).toBeInTheDocument()
   expect(
-    within(screen.getByTestId('size-bin')).getByText('validation_messages.required'),
-  ).toBeInTheDocument()
-  expect(
     within(screen.getByTestId('reef-slope')).getByText('validation_messages.required'),
   ).toBeInTheDocument()
   expect(
@@ -301,9 +298,6 @@ test('Validating an empty collect record, and then editing an input with errors 
     within(screen.getByTestId('width')).queryByText('validation_messages.required'),
   ).not.toBeInTheDocument()
   expect(
-    within(screen.getByTestId('size-bin')).queryByText('validation_messages.required'),
-  ).not.toBeInTheDocument()
-  expect(
     within(screen.getByTestId('reef-slope')).queryByText('validation_messages.required'),
   ).not.toBeInTheDocument()
   expect(
@@ -348,9 +342,6 @@ test('Validating an empty collect record, and then editing an input with errors 
   ).toBeInTheDocument()
   expect(
     within(screen.getByTestId('width')).getByText('validation_messages.required'),
-  ).toBeInTheDocument()
-  expect(
-    within(screen.getByTestId('size-bin')).getByText('validation_messages.required'),
   ).toBeInTheDocument()
   expect(
     within(screen.getByTestId('reef-slope')).getByText('validation_messages.required'),

--- a/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertValidationDisplay2.test.jsx
+++ b/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertValidationDisplay2.test.jsx
@@ -152,9 +152,6 @@ test('Validating an empty collect record shows validations (proof of wire-up)', 
     within(screen.getByTestId('width')).getByText('validation_messages.required'),
   ).toBeInTheDocument()
   expect(
-    within(screen.getByTestId('size-bin')).getByText('validation_messages.required'),
-  ).toBeInTheDocument()
-  expect(
     within(screen.getByTestId('reef-slope')).getByText('validation_messages.required'),
   ).toBeInTheDocument()
   expect(

--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertObservationTable.tsx
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertObservationTable.tsx
@@ -30,15 +30,7 @@ import {
   useBeltInvertDensityMetrics,
 } from '../../../../library/macroinvertebrates/useBeltInvertDensityMetrics'
 import ObservationSizeSelect from '../ObservationSizeSelect'
-
-interface ObservationRecord {
-  id: string
-  count?: number | null
-  size?: number | string | null
-  invert_attribute?: string | null
-  notes?: string | null
-  include?: boolean
-}
+import { ObservationRecord } from './BeltInvertTypes'
 
 interface SizeBinChoice {
   id: string | number
@@ -108,6 +100,22 @@ const buildSizeOptionsFromBinLabel = (sizeBinLabel: string | number | undefined)
   return sizeOptions
 }
 
+const sanitizeOneDecimalInput = (value: string) => {
+  const digitsAndDotOnly = value.replace(/[^\d.]/g, '')
+  const [integerPart = '', ...decimalParts] = digitsAndDotOnly.split('.')
+  const decimalPart = decimalParts.join('').slice(0, 1)
+  return digitsAndDotOnly.includes('.') ? `${integerPart}.${decimalPart}` : integerPart
+}
+
+const formatOneDecimalDisplayValue = (size: number | string | null | undefined) => {
+  if (size === null || typeof size === 'undefined' || size === '') {
+    return ''
+  }
+
+  const parsed = Number.parseFloat(String(size))
+  return Number.isNaN(parsed) ? '' : parsed.toFixed(1)
+}
+
 interface BeltInvertObservationTableProps {
   areValidationsShowing: boolean
   choices: ChoicesWithSizeBins
@@ -173,6 +181,8 @@ const BeltInvertObservationRow = ({
   const { t } = useTranslation()
   const { id: observationId, count, size, invert_attribute: invertAttributeId } = observation
   const rowNumber = index + 1
+  const [isSizeInputFocused, setIsSizeInputFocused] = useState(false)
+  const [sizeInputDraft, setSizeInputDraft] = useState('')
 
   const showNumericSizeInput =
     sizeBinSelectedLabel?.toString() === '1' || typeof sizeBinSelectedLabel === 'undefined'
@@ -192,9 +202,21 @@ const BeltInvertObservationRow = ({
   }
 
   const handleUpdateSizeFromInput = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const regExNumbers = new RegExp(/\D/g)
-    const newValue = event.target.value.replace(regExNumbers, '')
+    const newValue = sanitizeOneDecimalInput(event.target.value)
+    setSizeInputDraft(newValue)
     handleUpdateSize(newValue)
+  }
+
+  const handleSizeInputFocus = () => {
+    setIsSizeInputFocused(true)
+    setSizeInputDraft(
+      size === null || typeof size === 'undefined' || size === '' ? '' : String(size),
+    )
+  }
+
+  const handleSizeInputBlur = () => {
+    setSizeInputDraft(formatOneDecimalDisplayValue(size))
+    setIsSizeInputFocused(false)
   }
 
   const handleUpdateCount = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -244,12 +266,13 @@ const BeltInvertObservationRow = ({
 
   const sizeInput = showNumericSizeInput ? (
     <InputNumberNumericCharactersOnly
-      value={size ?? ''}
+      value={isSizeInputFocused ? sizeInputDraft : formatOneDecimalDisplayValue(size)}
       step="any"
-      disabled={!sizeBinSelectedLabel}
       aria-labelledby="invert-size-label"
       data-testid="invert-size-input"
       onChange={handleUpdateSizeFromInput}
+      onFocus={handleSizeInputFocus}
+      onBlur={handleSizeInputBlur}
       onKeyDown={(event: React.KeyboardEvent) =>
         onObservationKeyDown({ event, index, observation })
       }
@@ -265,7 +288,6 @@ const BeltInvertObservationRow = ({
       labelledBy="invert-size-label"
       testid="invert-size-select"
       plusInputTestId="invert-size-50-input"
-      disabled={!sizeBinSelectedLabel}
     />
   )
 
@@ -277,7 +299,6 @@ const BeltInvertObservationRow = ({
           <ObservationAutocomplete
             id={`observation-${observationId}`}
             data-testid="species-name-autocomplete"
-            disabled={!sizeBinSelectedLabel}
             // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus={autoFocusAllowed}
             isLastRow={isLastRow}
@@ -305,7 +326,7 @@ const BeltInvertObservationRow = ({
           step="any"
           aria-labelledby="invert-count-label"
           onChange={handleUpdateCount}
-          disabled={!sizeBinSelectedLabel}
+          // disabled={!sizeBinSelectedLabel}
           data-testid="invert-count-input"
           onKeyDown={(event: React.KeyboardEvent) => {
             onObservationKeyDown({ event, index, observation })
@@ -596,14 +617,11 @@ const BeltInvertObservationTable = ({
           <ButtonPrimary
             type="button"
             onClick={handleAddObservation}
-            disabled={!sizeBinSelectedLabel || invertAttributesLoadError}
+            disabled={invertAttributesLoadError}
             data-testid="add-observation-row"
           >
             <IconPlus /> {t('buttons.add_row')}
           </ButtonPrimary>
-          {!sizeBinSelectedLabel ? (
-            <p>{t('macroinvertebrate_observations.must_select_size_bin_warning')}</p>
-          ) : null}
           {invertAttributesLoadError ? (
             <p>{t('macroinvertebrate_observations.species_taxonomy_unavailable')}</p>
           ) : null}

--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertObservationTable.tsx
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertObservationTable.tsx
@@ -25,6 +25,7 @@ import InputNumberNumericCharactersOnly from '../../../generic/InputNumberNumeri
 import ObservationValidationInfo from '../ObservationValidationInfo'
 import ObservationAutocomplete from '../../../ObservationAutocomplete/ObservationAutocomplete'
 import { roundToOneDecimal } from '../../../../library/numbers/roundToOneDecimal'
+import { formatOneDecimalDisplayValue } from '../../../../library/numbers/formatOneDecimalDisplayValue'
 import {
   formatDensityToTwoDecimals,
   useBeltInvertDensityMetrics,
@@ -105,15 +106,6 @@ const sanitizeOneDecimalInput = (value: string) => {
   const [integerPart = '', ...decimalParts] = digitsAndDotOnly.split('.')
   const decimalPart = decimalParts.join('').slice(0, 1)
   return digitsAndDotOnly.includes('.') ? `${integerPart}.${decimalPart}` : integerPart
-}
-
-const formatOneDecimalDisplayValue = (size: number | string | null | undefined) => {
-  if (size === null || typeof size === 'undefined' || size === '') {
-    return ''
-  }
-
-  const parsed = Number.parseFloat(String(size))
-  return Number.isNaN(parsed) ? '' : parsed.toFixed(1)
 }
 
 interface BeltInvertObservationTableProps {

--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertObservationTable.tsx
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertObservationTable.tsx
@@ -319,14 +319,13 @@ const BeltInvertObservationRow = ({
           />
         </InputAutocompleteContainer>
       </Td>
-      <Td $align="right">{sizeInput}</Td>
+      {sizeBinSelectedLabel && <Td $align="right">{sizeInput}</Td>}
       <Td $align="right">
         <InputNumberNumericCharactersOnly
           value={count ?? ''}
           step="any"
           aria-labelledby="invert-count-label"
           onChange={handleUpdateCount}
-          // disabled={!sizeBinSelectedLabel}
           data-testid="invert-count-input"
           onKeyDown={(event: React.KeyboardEvent) => {
             onObservationKeyDown({ event, index, observation })
@@ -541,7 +540,7 @@ const BeltInvertObservationTable = ({
           <colgroup>
             <col className={tableStyles.colNumber} />
             <col className={tableStyles.colInvertName} />
-            <col className={tableStyles.colSize} />
+            {sizeBinSelectedLabel && <col className={tableStyles.colSize} />}
             <col className={tableStyles.colCount} />
             <col className={tableStyles.colNotes} />
             {areValidationsShowing ? <col className={tableStyles.colValidations} /> : null}
@@ -556,11 +555,13 @@ const BeltInvertObservationTable = ({
                   {t('observations.macroinvertebrate_name')} <RequiredIndicator />
                 </LabelContainer>
               </Th>
-              <Th $align="right" id="invert-size-label">
-                <LabelContainer>
-                  {`${t('sample_units.size')} (${t('measurements.centimeter_short')})`}
-                </LabelContainer>
-              </Th>
+              {sizeBinSelectedLabel && (
+                <Th $align="right" id="invert-size-label">
+                  <LabelContainer>
+                    {`${t('sample_units.size')} (${t('measurements.centimeter_short')})`}
+                  </LabelContainer>
+                </Th>
+              )}
               <Th $align="right" id="invert-count-label">
                 <LabelContainer>
                   {t('count')} <RequiredIndicator />

--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useTranslation, Trans } from 'react-i18next'
 
 import { getOptions } from '../../../../library/getOptions'
@@ -11,6 +11,8 @@ import TextareaWithLabelAndValidation from '../../../mermaidInputs/TextareaWithL
 import InputSelectWithLabelAndValidation from '../../../mermaidInputs/InputSelectWithLabelAndValidation'
 import { HelperTextLink } from '../../../generic/links'
 import { links } from '../../../../link_constants'
+import ClearSizeValuesModal from '../FishBeltForm/ClearSizeValueModal'
+import { ObservationRecord } from './BeltInvertTypes'
 
 const CURRENT_VALIDATION_PATH = 'data.beltinvert_transect.current'
 const DEPTH_VALIDATION_PATH = 'data.beltinvert_transect.depth'
@@ -28,13 +30,14 @@ const WIDTH_VALIDATION_PATH = 'data.beltinvert_transect.width'
 
 interface BeltInvertTransectInputsProps {
   observationsDispatch: (action: { type: string; payload?: unknown }) => void
-  observationsState: { invert_attribute?: string | null }[]
+  observationsState: ObservationRecord[]
   areValidationsShowing: boolean
   choices: Record<string, { data: unknown[] }>
   formik: {
     values: Record<string, unknown>
     handleBlur: (event: React.FocusEvent<HTMLElement>) => void
     handleChange: (event: React.ChangeEvent<HTMLElement>) => void
+    setFieldValue: (field: string, value: unknown) => void
   }
   ignoreNonObservationFieldValidations: (args: { validationPath: string }) => void
   resetNonObservationFieldValidations: (args: {
@@ -74,9 +77,8 @@ const BeltInvertTransectInputs = ({
   const tideOptions = getOptions(choices.tides?.data ?? [])
 
   const beltinvert_transect = validationsApiData?.beltinvert_transect
-  // Account for an empty starter row before real observation values exist.
-  const hasBeltInvertObservations =
-    observationsState?.length > 0 && !!observationsState[0]?.invert_attribute
+  const [isClearSizeValueModalOpen, setIsClearSizeValueModalOpen] = useState(false)
+  const [pendingSizeBinValue, setPendingSizeBinValue] = useState('')
 
   const transectNumberValidationProperties = getValidationPropertiesForInput(
     beltinvert_transect?.number,
@@ -138,321 +140,370 @@ const BeltInvertTransectInputs = ({
   ) => {
     formik.handleChange(event)
 
-    if (inputName === 'size_bin' && hasBeltInvertObservations) {
-      observationsDispatch({ type: 'resetObservationSizes' })
-    }
-
     resetNonObservationFieldValidations({ inputName, validationPath })
   }
 
+  const openClearSizeValuesModal = () => {
+    setIsClearSizeValueModalOpen(true)
+  }
+
+  const closeClearSizeValuesModal = () => {
+    setIsClearSizeValueModalOpen(false)
+    setPendingSizeBinValue('')
+  }
+
+  const applySizeBinChange = (sizeBinValue: string) => {
+    formik.setFieldValue('size_bin', sizeBinValue)
+    resetNonObservationFieldValidations({
+      inputName: 'size_bin',
+      validationPath: SIZE_BIN_VALIDATION_PATH,
+    })
+  }
+
+  const handleSizeBinChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const sizeBinValue = event.target.value
+    const hasBeltInvertObservations = observationsState.some(
+      (obs) => obs.size !== null && obs.size !== undefined && obs.size !== '',
+    )
+
+    if (hasBeltInvertObservations) {
+      setPendingSizeBinValue(sizeBinValue)
+      openClearSizeValuesModal()
+      return
+    }
+
+    applySizeBinChange(sizeBinValue)
+  }
+
+  const handleResetSizeValues = () => {
+    if (pendingSizeBinValue) {
+      applySizeBinChange(pendingSizeBinValue)
+    }
+
+    observationsDispatch({ type: 'resetObservationSizes' })
+    closeClearSizeValuesModal()
+  }
+
   return (
-    <InputWrapper>
-      <H2>{t('transect')}</H2>
-      <InputWithLabelAndValidation
-        label={t('transect_number')}
-        required={true}
-        id="number"
-        testId="transect-number"
-        type="number"
-        ignoreNonObservationFieldValidations={() => {
-          ignoreNonObservationFieldValidations({ validationPath: TRANSECT_NUMBER_VALIDATION_PATH })
-        }}
-        resetNonObservationFieldValidations={() => {
-          resetNonObservationFieldValidations({ validationPath: TRANSECT_NUMBER_VALIDATION_PATH })
-        }}
-        {...validationPropertiesWithDirtyResetOnInputChange(
-          transectNumberValidationProperties,
-          'number',
-        )}
-        onBlur={formik.handleBlur}
-        value={formik.values.number as string | number}
-        onChange={(event: React.ChangeEvent<HTMLElement>) =>
-          handleInputChange(event, 'number', TRANSECT_NUMBER_VALIDATION_PATH)
-        }
-        helperText={t('transect_number_info')}
+    <>
+      <InputWrapper>
+        <H2>{t('transect')}</H2>
+        <InputWithLabelAndValidation
+          label={t('transect_number')}
+          required={true}
+          id="number"
+          testId="transect-number"
+          type="number"
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({
+              validationPath: TRANSECT_NUMBER_VALIDATION_PATH,
+            })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: TRANSECT_NUMBER_VALIDATION_PATH })
+          }}
+          {...validationPropertiesWithDirtyResetOnInputChange(
+            transectNumberValidationProperties,
+            'number',
+          )}
+          onBlur={formik.handleBlur}
+          value={formik.values.number as string | number}
+          onChange={(event: React.ChangeEvent<HTMLElement>) =>
+            handleInputChange(event, 'number', TRANSECT_NUMBER_VALIDATION_PATH)
+          }
+          helperText={t('transect_number_info')}
+        />
+        <InputWithLabelAndValidation
+          label={t('label')}
+          id="label"
+          testId="label"
+          type="text"
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({ validationPath: LABEL_VALIDATION_PATH })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: LABEL_VALIDATION_PATH })
+          }}
+          {...labelValidationProperties}
+          onBlur={formik.handleBlur}
+          value={formik.values.label as string}
+          onChange={(event: React.ChangeEvent<HTMLElement>) =>
+            handleInputChange(event, 'label', LABEL_VALIDATION_PATH)
+          }
+          helperText={t('label_info')}
+        />
+        <InputWithLabelAndValidation
+          label={t('sample_units.sample_time')}
+          id="sample_time"
+          testId="sample-time"
+          type="time"
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({ validationPath: SAMPLE_TIME_VALIDATION_PATH })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: SAMPLE_TIME_VALIDATION_PATH })
+          }}
+          {...validationPropertiesWithDirtyResetOnInputChange(
+            sampleTimeValidationProperties,
+            'sample_time',
+          )}
+          onBlur={formik.handleBlur}
+          value={formik.values.sample_time as string}
+          onChange={(event: React.ChangeEvent<HTMLElement>) =>
+            handleInputChange(event, 'sample_time', SAMPLE_TIME_VALIDATION_PATH)
+          }
+          helperText={t('sample_units.sample_time_info')}
+        />
+        <InputWithLabelAndValidation
+          label={t('sample_units.depth')}
+          required={true}
+          id="depth"
+          unit="m"
+          testId="depth"
+          type="number"
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({ validationPath: DEPTH_VALIDATION_PATH })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: DEPTH_VALIDATION_PATH })
+          }}
+          {...validationPropertiesWithDirtyResetOnInputChange(depthValidationProperties, 'depth')}
+          onBlur={formik.handleBlur}
+          value={formik.values.depth as string | number}
+          onChange={(event: React.ChangeEvent<HTMLElement>) =>
+            handleInputChange(event, 'depth', DEPTH_VALIDATION_PATH)
+          }
+          helperText={t('sample_units.depth_info')}
+        />
+        <InputWithLabelAndValidation
+          label={t('sample_units.transect_length_surveyed')}
+          required={true}
+          id="len_surveyed"
+          testId="len-surveyed"
+          type="number"
+          unit="m"
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({
+              validationPath: LENGTH_SURVEYED_VALIDATION_PATH,
+            })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: LENGTH_SURVEYED_VALIDATION_PATH })
+          }}
+          {...validationPropertiesWithDirtyResetOnInputChange(
+            lengthSurveyedValidationProperties,
+            'len_surveyed',
+          )}
+          onBlur={formik.handleBlur}
+          value={formik.values.len_surveyed as string | number}
+          onChange={(event: React.ChangeEvent<HTMLElement>) =>
+            handleInputChange(event, 'len_surveyed', LENGTH_SURVEYED_VALIDATION_PATH)
+          }
+          helperText={t('sample_units.transect_length_surveyed_info')}
+        />
+        <InputSelectWithLabelAndValidation
+          label={t('width')}
+          required={true}
+          id="width"
+          testId="width"
+          options={transectWidthOptions}
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({ validationPath: WIDTH_VALIDATION_PATH })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: WIDTH_VALIDATION_PATH })
+          }}
+          {...validationPropertiesWithDirtyResetOnInputChange(widthValidationProperties, 'width')}
+          onBlur={formik.handleBlur}
+          value={formik.values.width as string}
+          onChange={(event: React.ChangeEvent<HTMLElement>) =>
+            handleInputChange(event, 'width', WIDTH_VALIDATION_PATH)
+          }
+          helperText={t('width_info')}
+        />
+        <InputSelectWithLabelAndValidation
+          label={t('macroinvertebrate_observations.size_bin')}
+          required={false}
+          id="size_bin"
+          testId="size-bin"
+          options={invertSizeBinOptions}
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({ validationPath: SIZE_BIN_VALIDATION_PATH })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: SIZE_BIN_VALIDATION_PATH })
+          }}
+          {...validationPropertiesWithDirtyResetOnInputChange(
+            sizeBinValidationProperties,
+            'size_bin',
+          )}
+          onBlur={formik.handleBlur}
+          value={formik.values.size_bin as string}
+          onChange={handleSizeBinChange}
+          helperText={t('macroinvertebrate_observations.size_bin_info')}
+        />
+        <InputSelectWithLabelAndValidation
+          label={t('reef_slope')}
+          required={false}
+          id="reef_slope"
+          testId="reef-slope"
+          options={reefSlopeOptions}
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({ validationPath: REEF_SLOPE_VALIDATION_PATH })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: REEF_SLOPE_VALIDATION_PATH })
+          }}
+          {...validationPropertiesWithDirtyResetOnInputChange(
+            reefSlopeValidationProperties,
+            'reef_slope',
+          )}
+          onBlur={formik.handleBlur}
+          value={formik.values.reef_slope as string}
+          onChange={(event: React.ChangeEvent<HTMLElement>) =>
+            handleInputChange(event, 'reef_slope', REEF_SLOPE_VALIDATION_PATH)
+          }
+          helperText={
+            <Trans
+              i18nKey="reef_slope_info"
+              components={{
+                a: (
+                  <HelperTextLink
+                    href={links.reefCoverClassDefinitions}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
+                ),
+              }}
+            />
+          }
+        />
+        <InputSelectWithLabelAndValidation
+          label={t('visibility')}
+          required={false}
+          id="visibility"
+          testId="visibility"
+          options={visibilityOptions}
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({ validationPath: VISIBILITY_VALIDATION_PATH })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: VISIBILITY_VALIDATION_PATH })
+          }}
+          {...validationPropertiesWithDirtyResetOnInputChange(
+            visibilityValidationProperties,
+            'visibility',
+          )}
+          onBlur={formik.handleBlur}
+          value={formik.values.visibility as string}
+          onChange={(event: React.ChangeEvent<HTMLElement>) =>
+            handleInputChange(event, 'visibility', VISIBILITY_VALIDATION_PATH)
+          }
+          helperText={t('visibility_info')}
+        />
+        <InputSelectWithLabelAndValidation
+          label={t('current')}
+          required={false}
+          id="current"
+          testId="current"
+          options={currentOptions}
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({ validationPath: CURRENT_VALIDATION_PATH })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: CURRENT_VALIDATION_PATH })
+          }}
+          {...validationPropertiesWithDirtyResetOnInputChange(
+            currentValidationProperties,
+            'current',
+          )}
+          onBlur={formik.handleBlur}
+          value={formik.values.current as string}
+          onChange={(event: React.ChangeEvent<HTMLElement>) =>
+            handleInputChange(event, 'current', CURRENT_VALIDATION_PATH)
+          }
+          helperText={t('current_info')}
+        />
+        <InputSelectWithLabelAndValidation
+          label={t('relative_depth')}
+          required={false}
+          id="relative_depth"
+          testId="relative-depth"
+          options={relativeDepthOptions}
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({ validationPath: RELATIVE_DEPTH_VALIDATION_PATH })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: RELATIVE_DEPTH_VALIDATION_PATH })
+          }}
+          {...validationPropertiesWithDirtyResetOnInputChange(
+            relativeDepthValidationProperties,
+            'relative_depth',
+          )}
+          onBlur={formik.handleBlur}
+          value={formik.values.relative_depth as string}
+          onChange={(event: React.ChangeEvent<HTMLElement>) =>
+            handleInputChange(event, 'relative_depth', RELATIVE_DEPTH_VALIDATION_PATH)
+          }
+          helperText={t('relative_depth_info')}
+        />
+        <InputSelectWithLabelAndValidation
+          label={t('tide')}
+          required={false}
+          id="tide"
+          testId="tide"
+          options={tideOptions}
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({ validationPath: TIDE_VALIDATION_PATH })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: TIDE_VALIDATION_PATH })
+          }}
+          {...validationPropertiesWithDirtyResetOnInputChange(tideValidationProperties, 'tide')}
+          onBlur={formik.handleBlur}
+          value={formik.values.tide as string}
+          onChange={(event: React.ChangeEvent<HTMLElement>) =>
+            handleInputChange(event, 'tide', TIDE_VALIDATION_PATH)
+          }
+          helperText={
+            <Trans
+              i18nKey="tide_info"
+              components={{
+                a: (
+                  <HelperTextLink
+                    href={links.tideIntroduction}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
+                ),
+              }}
+            />
+          }
+        />
+        <TextareaWithLabelAndValidation
+          label={t('notes')}
+          id="notes"
+          testId="notes"
+          ignoreNonObservationFieldValidations={() => {
+            ignoreNonObservationFieldValidations({ validationPath: NOTES_VALIDATION_PATH })
+          }}
+          resetNonObservationFieldValidations={() => {
+            resetNonObservationFieldValidations({ validationPath: NOTES_VALIDATION_PATH })
+          }}
+          {...notesValidationProperties}
+          onBlur={formik.handleBlur}
+          value={(formik.values.notes ?? '') as string}
+          onChange={(event: React.ChangeEvent<HTMLElement>) =>
+            handleInputChange(event, 'notes', NOTES_VALIDATION_PATH)
+          }
+        />
+      </InputWrapper>
+      <ClearSizeValuesModal
+        isOpen={isClearSizeValueModalOpen}
+        handleResetSizeValues={handleResetSizeValues}
+        onDismiss={closeClearSizeValuesModal}
       />
-      <InputWithLabelAndValidation
-        label={t('label')}
-        id="label"
-        testId="label"
-        type="text"
-        ignoreNonObservationFieldValidations={() => {
-          ignoreNonObservationFieldValidations({ validationPath: LABEL_VALIDATION_PATH })
-        }}
-        resetNonObservationFieldValidations={() => {
-          resetNonObservationFieldValidations({ validationPath: LABEL_VALIDATION_PATH })
-        }}
-        {...labelValidationProperties}
-        onBlur={formik.handleBlur}
-        value={formik.values.label as string}
-        onChange={(event: React.ChangeEvent<HTMLElement>) =>
-          handleInputChange(event, 'label', LABEL_VALIDATION_PATH)
-        }
-        helperText={t('label_info')}
-      />
-      <InputWithLabelAndValidation
-        label={t('sample_units.sample_time')}
-        id="sample_time"
-        testId="sample-time"
-        type="time"
-        ignoreNonObservationFieldValidations={() => {
-          ignoreNonObservationFieldValidations({ validationPath: SAMPLE_TIME_VALIDATION_PATH })
-        }}
-        resetNonObservationFieldValidations={() => {
-          resetNonObservationFieldValidations({ validationPath: SAMPLE_TIME_VALIDATION_PATH })
-        }}
-        {...validationPropertiesWithDirtyResetOnInputChange(
-          sampleTimeValidationProperties,
-          'sample_time',
-        )}
-        onBlur={formik.handleBlur}
-        value={formik.values.sample_time as string}
-        onChange={(event: React.ChangeEvent<HTMLElement>) =>
-          handleInputChange(event, 'sample_time', SAMPLE_TIME_VALIDATION_PATH)
-        }
-        helperText={t('sample_units.sample_time_info')}
-      />
-      <InputWithLabelAndValidation
-        label={t('sample_units.depth')}
-        required={true}
-        id="depth"
-        unit="m"
-        testId="depth"
-        type="number"
-        ignoreNonObservationFieldValidations={() => {
-          ignoreNonObservationFieldValidations({ validationPath: DEPTH_VALIDATION_PATH })
-        }}
-        resetNonObservationFieldValidations={() => {
-          resetNonObservationFieldValidations({ validationPath: DEPTH_VALIDATION_PATH })
-        }}
-        {...validationPropertiesWithDirtyResetOnInputChange(depthValidationProperties, 'depth')}
-        onBlur={formik.handleBlur}
-        value={formik.values.depth as string | number}
-        onChange={(event: React.ChangeEvent<HTMLElement>) =>
-          handleInputChange(event, 'depth', DEPTH_VALIDATION_PATH)
-        }
-        helperText={t('sample_units.depth_info')}
-      />
-      <InputWithLabelAndValidation
-        label={t('sample_units.transect_length_surveyed')}
-        required={true}
-        id="len_surveyed"
-        testId="len-surveyed"
-        type="number"
-        unit="m"
-        ignoreNonObservationFieldValidations={() => {
-          ignoreNonObservationFieldValidations({ validationPath: LENGTH_SURVEYED_VALIDATION_PATH })
-        }}
-        resetNonObservationFieldValidations={() => {
-          resetNonObservationFieldValidations({ validationPath: LENGTH_SURVEYED_VALIDATION_PATH })
-        }}
-        {...validationPropertiesWithDirtyResetOnInputChange(
-          lengthSurveyedValidationProperties,
-          'len_surveyed',
-        )}
-        onBlur={formik.handleBlur}
-        value={formik.values.len_surveyed as string | number}
-        onChange={(event: React.ChangeEvent<HTMLElement>) =>
-          handleInputChange(event, 'len_surveyed', LENGTH_SURVEYED_VALIDATION_PATH)
-        }
-        helperText={t('sample_units.transect_length_surveyed_info')}
-      />
-      <InputSelectWithLabelAndValidation
-        label={t('width')}
-        required={true}
-        id="width"
-        testId="width"
-        options={transectWidthOptions}
-        ignoreNonObservationFieldValidations={() => {
-          ignoreNonObservationFieldValidations({ validationPath: WIDTH_VALIDATION_PATH })
-        }}
-        resetNonObservationFieldValidations={() => {
-          resetNonObservationFieldValidations({ validationPath: WIDTH_VALIDATION_PATH })
-        }}
-        {...validationPropertiesWithDirtyResetOnInputChange(widthValidationProperties, 'width')}
-        onBlur={formik.handleBlur}
-        value={formik.values.width as string}
-        onChange={(event: React.ChangeEvent<HTMLElement>) =>
-          handleInputChange(event, 'width', WIDTH_VALIDATION_PATH)
-        }
-        helperText={t('width_info')}
-      />
-      <InputSelectWithLabelAndValidation
-        label={t('macroinvertebrate_observations.size_bin')}
-        required={true}
-        id="size_bin"
-        testId="size-bin"
-        options={invertSizeBinOptions}
-        ignoreNonObservationFieldValidations={() => {
-          ignoreNonObservationFieldValidations({ validationPath: SIZE_BIN_VALIDATION_PATH })
-        }}
-        resetNonObservationFieldValidations={() => {
-          resetNonObservationFieldValidations({ validationPath: SIZE_BIN_VALIDATION_PATH })
-        }}
-        {...validationPropertiesWithDirtyResetOnInputChange(
-          sizeBinValidationProperties,
-          'size_bin',
-        )}
-        onBlur={formik.handleBlur}
-        value={formik.values.size_bin as string}
-        onChange={(event: React.ChangeEvent<HTMLElement>) =>
-          handleInputChange(event, 'size_bin', SIZE_BIN_VALIDATION_PATH)
-        }
-        helperText={t('macroinvertebrate_observations.size_bin_info')}
-      />
-      <InputSelectWithLabelAndValidation
-        label={t('reef_slope')}
-        required={false}
-        id="reef_slope"
-        testId="reef-slope"
-        options={reefSlopeOptions}
-        ignoreNonObservationFieldValidations={() => {
-          ignoreNonObservationFieldValidations({ validationPath: REEF_SLOPE_VALIDATION_PATH })
-        }}
-        resetNonObservationFieldValidations={() => {
-          resetNonObservationFieldValidations({ validationPath: REEF_SLOPE_VALIDATION_PATH })
-        }}
-        {...validationPropertiesWithDirtyResetOnInputChange(
-          reefSlopeValidationProperties,
-          'reef_slope',
-        )}
-        onBlur={formik.handleBlur}
-        value={formik.values.reef_slope as string}
-        onChange={(event: React.ChangeEvent<HTMLElement>) =>
-          handleInputChange(event, 'reef_slope', REEF_SLOPE_VALIDATION_PATH)
-        }
-        helperText={
-          <Trans
-            i18nKey="reef_slope_info"
-            components={{
-              a: (
-                <HelperTextLink
-                  href={links.reefCoverClassDefinitions}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                />
-              ),
-            }}
-          />
-        }
-      />
-      <InputSelectWithLabelAndValidation
-        label={t('visibility')}
-        required={false}
-        id="visibility"
-        testId="visibility"
-        options={visibilityOptions}
-        ignoreNonObservationFieldValidations={() => {
-          ignoreNonObservationFieldValidations({ validationPath: VISIBILITY_VALIDATION_PATH })
-        }}
-        resetNonObservationFieldValidations={() => {
-          resetNonObservationFieldValidations({ validationPath: VISIBILITY_VALIDATION_PATH })
-        }}
-        {...validationPropertiesWithDirtyResetOnInputChange(
-          visibilityValidationProperties,
-          'visibility',
-        )}
-        onBlur={formik.handleBlur}
-        value={formik.values.visibility as string}
-        onChange={(event: React.ChangeEvent<HTMLElement>) =>
-          handleInputChange(event, 'visibility', VISIBILITY_VALIDATION_PATH)
-        }
-        helperText={t('visibility_info')}
-      />
-      <InputSelectWithLabelAndValidation
-        label={t('current')}
-        required={false}
-        id="current"
-        testId="current"
-        options={currentOptions}
-        ignoreNonObservationFieldValidations={() => {
-          ignoreNonObservationFieldValidations({ validationPath: CURRENT_VALIDATION_PATH })
-        }}
-        resetNonObservationFieldValidations={() => {
-          resetNonObservationFieldValidations({ validationPath: CURRENT_VALIDATION_PATH })
-        }}
-        {...validationPropertiesWithDirtyResetOnInputChange(currentValidationProperties, 'current')}
-        onBlur={formik.handleBlur}
-        value={formik.values.current as string}
-        onChange={(event: React.ChangeEvent<HTMLElement>) =>
-          handleInputChange(event, 'current', CURRENT_VALIDATION_PATH)
-        }
-        helperText={t('current_info')}
-      />
-      <InputSelectWithLabelAndValidation
-        label={t('relative_depth')}
-        required={false}
-        id="relative_depth"
-        testId="relative-depth"
-        options={relativeDepthOptions}
-        ignoreNonObservationFieldValidations={() => {
-          ignoreNonObservationFieldValidations({ validationPath: RELATIVE_DEPTH_VALIDATION_PATH })
-        }}
-        resetNonObservationFieldValidations={() => {
-          resetNonObservationFieldValidations({ validationPath: RELATIVE_DEPTH_VALIDATION_PATH })
-        }}
-        {...validationPropertiesWithDirtyResetOnInputChange(
-          relativeDepthValidationProperties,
-          'relative_depth',
-        )}
-        onBlur={formik.handleBlur}
-        value={formik.values.relative_depth as string}
-        onChange={(event: React.ChangeEvent<HTMLElement>) =>
-          handleInputChange(event, 'relative_depth', RELATIVE_DEPTH_VALIDATION_PATH)
-        }
-        helperText={t('relative_depth_info')}
-      />
-      <InputSelectWithLabelAndValidation
-        label={t('tide')}
-        required={false}
-        id="tide"
-        testId="tide"
-        options={tideOptions}
-        ignoreNonObservationFieldValidations={() => {
-          ignoreNonObservationFieldValidations({ validationPath: TIDE_VALIDATION_PATH })
-        }}
-        resetNonObservationFieldValidations={() => {
-          resetNonObservationFieldValidations({ validationPath: TIDE_VALIDATION_PATH })
-        }}
-        {...validationPropertiesWithDirtyResetOnInputChange(tideValidationProperties, 'tide')}
-        onBlur={formik.handleBlur}
-        value={formik.values.tide as string}
-        onChange={(event: React.ChangeEvent<HTMLElement>) =>
-          handleInputChange(event, 'tide', TIDE_VALIDATION_PATH)
-        }
-        helperText={
-          <Trans
-            i18nKey="tide_info"
-            components={{
-              a: (
-                <HelperTextLink
-                  href={links.tideIntroduction}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                />
-              ),
-            }}
-          />
-        }
-      />
-      <TextareaWithLabelAndValidation
-        label={t('notes')}
-        id="notes"
-        testId="notes"
-        ignoreNonObservationFieldValidations={() => {
-          ignoreNonObservationFieldValidations({ validationPath: NOTES_VALIDATION_PATH })
-        }}
-        resetNonObservationFieldValidations={() => {
-          resetNonObservationFieldValidations({ validationPath: NOTES_VALIDATION_PATH })
-        }}
-        {...notesValidationProperties}
-        onBlur={formik.handleBlur}
-        value={(formik.values.notes ?? '') as string}
-        onChange={(event: React.ChangeEvent<HTMLElement>) =>
-          handleInputChange(event, 'notes', NOTES_VALIDATION_PATH)
-        }
-      />
-    </InputWrapper>
+    </>
   )
 }
 

--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
@@ -78,7 +78,7 @@ const BeltInvertTransectInputs = ({
 
   const beltinvert_transect = validationsApiData?.beltinvert_transect
   const [isClearSizeValueModalOpen, setIsClearSizeValueModalOpen] = useState(false)
-  const [pendingSizeBinValue, setPendingSizeBinValue] = useState('')
+  const [pendingSizeBinValue, setPendingSizeBinValue] = useState<string | null>(null)
 
   const transectNumberValidationProperties = getValidationPropertiesForInput(
     beltinvert_transect?.number,
@@ -149,7 +149,7 @@ const BeltInvertTransectInputs = ({
 
   const closeClearSizeValuesModal = () => {
     setIsClearSizeValueModalOpen(false)
-    setPendingSizeBinValue('')
+    setPendingSizeBinValue(null)
   }
 
   const applySizeBinChange = (sizeBinValue: string) => {
@@ -176,7 +176,7 @@ const BeltInvertTransectInputs = ({
   }
 
   const handleResetSizeValues = () => {
-    if (pendingSizeBinValue) {
+    if (pendingSizeBinValue !== null) {
       applySizeBinChange(pendingSizeBinValue)
     }
 

--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTypes.ts
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTypes.ts
@@ -1,0 +1,8 @@
+export interface ObservationRecord {
+  id: string
+  count?: number | null
+  size?: number | string | null
+  invert_attribute?: string | null
+  notes?: string | null
+  include?: boolean
+}

--- a/src/components/pages/submittedRecordPages/SubmittedBeltInvert/SubmittedBeltInvertObservationTable.jsx
+++ b/src/components/pages/submittedRecordPages/SubmittedBeltInvert/SubmittedBeltInvertObservationTable.jsx
@@ -54,11 +54,13 @@ const SubmittedBeltInvertObservationTable = ({
     return roundToOneDecimal(observationDensities.get(item.id))
   }
 
+  const hasSizeData = obs_belt_inverts.some((item) => item.size)
+
   const observationBeltInverts = obs_belt_inverts.map((item, index) => (
     <Tr key={item.id}>
       <Td $align="center">{index + 1}</Td>
       <Td $align="left">{getInvertName(item.invert_attribute)}</Td>
-      <Td $align="left">{item.size}</Td>
+      {hasSizeData && <Td $align="left">{item.size}</Td>}
       <Td $align="right">{item.count}</Td>
       <Td $align="right">{item.notes}</Td>
       <Td $align="right">{getInvertDensity(item)}</Td>
@@ -74,7 +76,7 @@ const SubmittedBeltInvertObservationTable = ({
             <Tr>
               <TheadItem> </TheadItem>
               <TheadItem $align="left">{t('observations.macroinvertebrate_name')}</TheadItem>
-              <TheadItem $align="left">{t('size_cm')}</TheadItem>
+              {hasSizeData && <TheadItem $align="left">{t('size_cm')}</TheadItem>}
               <TheadItem $align="right">{t('count')}</TheadItem>
               <TheadItem $align="right">{t('notes')}</TheadItem>
               <TheadItem $align="right">{`${t('density')} (${t(

--- a/src/components/pages/submittedRecordPages/SubmittedBeltInvert/SubmittedBeltInvertObservationTable.jsx
+++ b/src/components/pages/submittedRecordPages/SubmittedBeltInvert/SubmittedBeltInvertObservationTable.jsx
@@ -20,6 +20,7 @@ import {
   formatDensityToTwoDecimals,
   useBeltInvertDensityMetrics,
 } from '../../../../library/macroinvertebrates/useBeltInvertDensityMetrics'
+import { formatOneDecimalDisplayValue } from '../../../../library/numbers/formatOneDecimalDisplayValue'
 
 const SubmittedBeltInvertObservationTable = ({
   choices,
@@ -60,7 +61,7 @@ const SubmittedBeltInvertObservationTable = ({
     <Tr key={item.id}>
       <Td $align="center">{index + 1}</Td>
       <Td $align="left">{getInvertName(item.invert_attribute)}</Td>
-      {hasSizeData && <Td $align="left">{item.size}</Td>}
+      {hasSizeData && <Td $align="left">{formatOneDecimalDisplayValue(item.size)}</Td>}
       <Td $align="right">{item.count}</Td>
       <Td $align="right">{item.notes}</Td>
       <Td $align="right">{getInvertDensity(item)}</Td>

--- a/src/library/numbers/formatOneDecimalDisplayValue.ts
+++ b/src/library/numbers/formatOneDecimalDisplayValue.ts
@@ -1,0 +1,10 @@
+export const formatOneDecimalDisplayValue = (
+  value: number | string | null | undefined,
+): string => {
+  if (value === null || typeof value === 'undefined' || value === '') {
+    return ''
+  }
+
+  const parsed = Number.parseFloat(String(value))
+  return Number.isNaN(parsed) ? '' : parsed.toFixed(1)
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -532,7 +532,6 @@
     "density_by_group_of_interest_units": "Density by group of interest (ind/ha)",
     "edit_notes": "Edit Notes",
     "macroinvertebrate_species": "Macroinvertebrate species",
-    "must_select_size_bin_warning": "You must select a macroinvertebrate size bin before adding any observations",
     "size_bin": "Macroinvertebrate size bin (cm)",
     "size_bin_info": "Name of bin scheme used to estimate macroinvertebrate size for the transect.",
     "proposed_species_already_exists": "Proposed macroinvertebrate species {{attributeName}} already exists",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -534,7 +534,7 @@
     "macroinvertebrate_species": "Macroinvertebrate species",
     "must_select_size_bin_warning": "You must select a macroinvertebrate size bin before adding any observations",
     "size_bin": "Macroinvertebrate size bin (cm)",
-    "size_bin_info": "Name of bin scheme used to estimate macroinvertebrate size for the transect. Choose 1 cm if macroinvertebrate size does not use bins.",
+    "size_bin_info": "Name of bin scheme used to estimate macroinvertebrate size for the transect.",
     "proposed_species_already_exists": "Proposed macroinvertebrate species {{attributeName}} already exists",
     "proposed_species_saved": "Proposed macroinvertebrate species {{attributeName}} saved. Observation has been updated with this species.",
     "row": "Row",

--- a/src/testUtilities/mockBeltInvertValidationsObject.js
+++ b/src/testUtilities/mockBeltInvertValidationsObject.js
@@ -163,15 +163,6 @@ export default {
             validation_id: 'b0781708804d47a9816741c010587f88',
           },
         ],
-        size_bin: [
-          {
-            code: 'required',
-            fields: ['data.beltinvert_transect.size_bin'],
-            status: 'error',
-            context: null,
-            validation_id: '7ef514ed41d46f3e6e3f2e70a8fa6a68',
-          },
-        ],
         sample_time: [
           {
             validation_id: Math.random(),


### PR DESCRIPTION
update form size behavior to clear observation size values when the user changes the macroinvertebrate size bin with a modal confirmation. ensure observation table is always enabled, remove warning text, remove requirement for macroinvertebrate size field

---Every PR---

- [x] Changes have been tested locally
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Unit tests have run and passed

---Transitional Changes---

- [x] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [x] Any language.js tokens no longer used are removed
- [x] Any necessary updates to the documentation have been made
- [x] Unit tests have been added or updated, where possible, to prevent future regressions
- [x] styled-components code in changed files has been updated to CSS modules in the styles folder
- [x] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog for clearing/applying belt invert size values when changing the size bin while size data already exists.

* **Improvements**
  * Improved one-decimal formatting and sanitization for belt invert size input, including clearer focused-vs-finalized input behavior.

* **Bug Fixes**
  * Adjusted when the “add row” button becomes disabled to rely only on loading error state.

* **Tests**
  * Updated belt invert validation display integration tests to match the refined validation visibility behavior.

* **Documentation**
  * Updated the size-bin tooltip text to reflect the active bin scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->