### PR TITLE
fix [2007] add padding to dropdown

### DIFF
--- a/src/components/NewAttributeModal.tsx
+++ b/src/components/NewAttributeModal.tsx
@@ -44,7 +44,7 @@ interface NewAttributeModalProps {
 }
 
 const NoResults = (
-  <div className={style['styled-not-found-dropdown']}>
+  <div className={style['no-results-dropdown']}>
     <Trans
       i18nKey="taxonomies.genus_not_found"
       components={{

--- a/src/components/NewAttributeModal.tsx
+++ b/src/components/NewAttributeModal.tsx
@@ -44,13 +44,15 @@ interface NewAttributeModalProps {
 }
 
 const NoResults = (
-  <Trans
-    i18nKey="taxonomies.genus_not_found"
-    components={{
-      // eslint-disable-next-line jsx-a11y/anchor-has-content
-      a: <a href={links.contactUs} target="_blank" rel="noopener noreferrer" />,
-    }}
-  />
+  <div className={style['styled-not-found-dropdown']}>
+    <Trans
+      i18nKey="taxonomies.genus_not_found"
+      components={{
+        // eslint-disable-next-line jsx-a11y/anchor-has-content
+        a: <a href={links.contactUs} target="_blank" rel="noopener noreferrer" />,
+      }}
+    />
+  </div>
 )
 
 const NewAttributeModal = ({

--- a/src/style/NewAttributeModal.module.scss
+++ b/src/style/NewAttributeModal.module.scss
@@ -17,7 +17,7 @@ tr td:first-child {
   width: 100%;
 }
 
-.styled-not-found-dropdown {
+.no-results-dropdown {
   padding-left: 0.5rem;
   padding-bottom: 1rem;
 }

--- a/src/style/NewAttributeModal.module.scss
+++ b/src/style/NewAttributeModal.module.scss
@@ -16,3 +16,8 @@ tr td:first-child {
 .input-container {
   width: 100%;
 }
+
+.styled-not-found-dropdown {
+  padding-left: 0.5rem;
+  padding-bottom: 1rem;
+}


### PR DESCRIPTION
Ref: https://trello.com/c/NA7EB6Ss/2007-add-padding-to-the-genus-dropdown-when-proposing-a-new-species

Add padding to the dropdown

Before:
<img width="481" height="253" alt="image" src="https://github.com/user-attachments/assets/8e3b4ac6-6fcf-4fdf-8ea1-803f8a6c5d1c" />


After:
<img width="541" height="285" alt="image" src="https://github.com/user-attachments/assets/04986374-4513-46f6-83dc-7509978de009" />


---Every PR---

- [x] Changes have been tested locally
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Unit tests have run and passed

---Transitional Changes---

- [x] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [x] Any language.js tokens no longer used are removed
- [x] Any necessary updates to the documentation have been made
- [x] Unit tests have been added or updated, where possible, to prevent future regressions
- [x] styled-components code in changed files has been updated to CSS modules in the styles folder
- [x] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “not found” state in the New Attribute modal by refining spacing and layout for the genus-not-found message.
  * Updated the “no results” dropdown presentation to appear cleaner, with better alignment and padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->