### PR TITLE
fix [m2006] fix format of width dropdown values

### DIFF
--- a/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertCreateOffline.test.jsx
+++ b/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertCreateOffline.test.jsx
@@ -24,7 +24,7 @@ const saveBeltInvertRecord = async (user) => {
   await user.type(await screen.findByTestId('len-surveyed-input'), '2')
   await user.selectOptions(
     await screen.findByTestId('width-select'),
-    '228c932d-b5da-4464-b0df-d15a05c05c02',
+    '18fc5c30-1786-4fe1-9536-4ee41ef3c08a',
   )
   await user.selectOptions(
     await screen.findByTestId('size-bin-select'),
@@ -86,7 +86,7 @@ describe('Offline', () => {
       expect(screen.getByTestId('transect-number-input')).toHaveValue(56)
       expect(screen.getByTestId('label-input')).toHaveValue('some label')
       expect(screen.getByTestId('len-surveyed-input')).toHaveValue(2)
-      expect(screen.getByTestId('width-select')).toHaveDisplayValue('10m')
+      expect(screen.getByTestId('width-select')).toHaveDisplayValue('4 m')
       expect(screen.getByTestId('size-bin-select')).toHaveDisplayValue('1')
       expect(screen.getByTestId('reef-slope-select')).toHaveDisplayValue('flat')
       expect(screen.getByTestId('visibility-select')).toHaveDisplayValue('1-5m - poor')
@@ -171,7 +171,7 @@ describe('Offline', () => {
       expect(screen.getByTestId('transect-number-input')).toHaveValue(56)
       expect(screen.getByTestId('label-input')).toHaveValue('some label')
       expect(screen.getByTestId('len-surveyed-input')).toHaveValue(2)
-      expect(screen.getByTestId('width-select')).toHaveDisplayValue('10m')
+      expect(screen.getByTestId('width-select')).toHaveDisplayValue('4 m')
       expect(screen.getByTestId('size-bin-select')).toHaveDisplayValue('1')
       expect(screen.getByTestId('reef-slope-select')).toHaveDisplayValue('flat')
       expect(screen.getByTestId('visibility-select')).toHaveDisplayValue('1-5m - poor')

--- a/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertCreateOffline.test.jsx
+++ b/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertCreateOffline.test.jsx
@@ -28,7 +28,7 @@ const saveBeltInvertRecord = async (user) => {
   )
   await user.selectOptions(
     await screen.findByTestId('size-bin-select'),
-    '67c1356f-e0a7-4383-8034-77b2f36e1a49',
+    'ab91e41a-c0d5-477f-baf3-f0571d7c0dcf',
   )
   await user.selectOptions(
     await screen.findByTestId('reef-slope-select'),

--- a/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertCreateOffline.test.jsx
+++ b/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertCreateOffline.test.jsx
@@ -24,7 +24,7 @@ const saveBeltInvertRecord = async (user) => {
   await user.type(await screen.findByTestId('len-surveyed-input'), '2')
   await user.selectOptions(
     await screen.findByTestId('width-select'),
-    '18fc5c30-1786-4fe1-9536-4ee41ef3c08a',
+    'e1a133d3-70fe-403c-aed2-a70d630ef910',
   )
   await user.selectOptions(
     await screen.findByTestId('size-bin-select'),
@@ -86,7 +86,7 @@ describe('Offline', () => {
       expect(screen.getByTestId('transect-number-input')).toHaveValue(56)
       expect(screen.getByTestId('label-input')).toHaveValue('some label')
       expect(screen.getByTestId('len-surveyed-input')).toHaveValue(2)
-      expect(screen.getByTestId('width-select')).toHaveDisplayValue('4 m')
+      expect(screen.getByTestId('width-select')).toHaveDisplayValue('2 m')
       expect(screen.getByTestId('size-bin-select')).toHaveDisplayValue('1')
       expect(screen.getByTestId('reef-slope-select')).toHaveDisplayValue('flat')
       expect(screen.getByTestId('visibility-select')).toHaveDisplayValue('1-5m - poor')
@@ -171,7 +171,7 @@ describe('Offline', () => {
       expect(screen.getByTestId('transect-number-input')).toHaveValue(56)
       expect(screen.getByTestId('label-input')).toHaveValue('some label')
       expect(screen.getByTestId('len-surveyed-input')).toHaveValue(2)
-      expect(screen.getByTestId('width-select')).toHaveDisplayValue('4 m')
+      expect(screen.getByTestId('width-select')).toHaveDisplayValue('2 m')
       expect(screen.getByTestId('size-bin-select')).toHaveDisplayValue('1')
       expect(screen.getByTestId('reef-slope-select')).toHaveDisplayValue('flat')
       expect(screen.getByTestId('visibility-select')).toHaveDisplayValue('1-5m - poor')

--- a/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertCreateOnline.test.jsx
+++ b/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertCreateOnline.test.jsx
@@ -24,7 +24,7 @@ const saveBeltInvertRecord = async (user) => {
   await user.type(await screen.findByTestId('len-surveyed-input'), '2')
   await user.selectOptions(
     await screen.findByTestId('width-select'),
-    '18fc5c30-1786-4fe1-9536-4ee41ef3c08a',
+    'e1a133d3-70fe-403c-aed2-a70d630ef910',
   )
   await user.selectOptions(
     await screen.findByTestId('size-bin-select'),
@@ -90,7 +90,7 @@ describe('Online', () => {
       expect(screen.getByTestId('transect-number-input')).toHaveValue(56)
       expect(screen.getByTestId('label-input')).toHaveValue('some label')
       expect(screen.getByTestId('len-surveyed-input')).toHaveValue(2)
-      expect(screen.getByTestId('width-select')).toHaveDisplayValue('4 m')
+      expect(screen.getByTestId('width-select')).toHaveDisplayValue('2 m')
       expect(screen.getByTestId('size-bin-select')).toHaveDisplayValue('1')
       expect(screen.getByTestId('reef-slope-select')).toHaveDisplayValue('flat')
       expect(screen.getByTestId('visibility-select')).toHaveDisplayValue('1-5m - poor')
@@ -173,7 +173,7 @@ describe('Online', () => {
       expect(screen.getByTestId('transect-number-input')).toHaveValue(56)
       expect(screen.getByTestId('label-input')).toHaveValue('some label')
       expect(screen.getByTestId('len-surveyed-input')).toHaveValue(2)
-      expect(screen.getByTestId('width-select')).toHaveDisplayValue('4 m')
+      expect(screen.getByTestId('width-select')).toHaveDisplayValue('2 m')
       expect(screen.getByTestId('size-bin-select')).toHaveDisplayValue('1')
       expect(screen.getByTestId('reef-slope-select')).toHaveDisplayValue('flat')
       expect(screen.getByTestId('visibility-select')).toHaveDisplayValue('1-5m - poor')

--- a/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertCreateOnline.test.jsx
+++ b/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertCreateOnline.test.jsx
@@ -24,7 +24,7 @@ const saveBeltInvertRecord = async (user) => {
   await user.type(await screen.findByTestId('len-surveyed-input'), '2')
   await user.selectOptions(
     await screen.findByTestId('width-select'),
-    '228c932d-b5da-4464-b0df-d15a05c05c02',
+    '18fc5c30-1786-4fe1-9536-4ee41ef3c08a',
   )
   await user.selectOptions(
     await screen.findByTestId('size-bin-select'),
@@ -90,7 +90,7 @@ describe('Online', () => {
       expect(screen.getByTestId('transect-number-input')).toHaveValue(56)
       expect(screen.getByTestId('label-input')).toHaveValue('some label')
       expect(screen.getByTestId('len-surveyed-input')).toHaveValue(2)
-      expect(screen.getByTestId('width-select')).toHaveDisplayValue('10m')
+      expect(screen.getByTestId('width-select')).toHaveDisplayValue('4 m')
       expect(screen.getByTestId('size-bin-select')).toHaveDisplayValue('1')
       expect(screen.getByTestId('reef-slope-select')).toHaveDisplayValue('flat')
       expect(screen.getByTestId('visibility-select')).toHaveDisplayValue('1-5m - poor')
@@ -173,7 +173,7 @@ describe('Online', () => {
       expect(screen.getByTestId('transect-number-input')).toHaveValue(56)
       expect(screen.getByTestId('label-input')).toHaveValue('some label')
       expect(screen.getByTestId('len-surveyed-input')).toHaveValue(2)
-      expect(screen.getByTestId('width-select')).toHaveDisplayValue('10m')
+      expect(screen.getByTestId('width-select')).toHaveDisplayValue('4 m')
       expect(screen.getByTestId('size-bin-select')).toHaveDisplayValue('1')
       expect(screen.getByTestId('reef-slope-select')).toHaveDisplayValue('flat')
       expect(screen.getByTestId('visibility-select')).toHaveDisplayValue('1-5m - poor')

--- a/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertCreateOnline.test.jsx
+++ b/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertCreateOnline.test.jsx
@@ -28,7 +28,7 @@ const saveBeltInvertRecord = async (user) => {
   )
   await user.selectOptions(
     await screen.findByTestId('size-bin-select'),
-    '67c1356f-e0a7-4383-8034-77b2f36e1a49',
+    'ab91e41a-c0d5-477f-baf3-f0571d7c0dcf',
   )
   await user.selectOptions(
     await screen.findByTestId('reef-slope-select'),

--- a/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertUpdate.test.jsx
+++ b/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertUpdate.test.jsx
@@ -49,7 +49,7 @@ describe('Offline', () => {
     expect(screen.getByTestId('transect-number-input')).toHaveValue(2)
     expect(screen.getByTestId('label-input')).toHaveValue('FB-2')
     expect(screen.getByTestId('len-surveyed-input')).toHaveValue(6)
-    expect(screen.getByTestId('width-select')).toHaveDisplayValue('2m')
+    expect(screen.getByTestId('width-select')).toHaveDisplayValue('2 m')
     expect(screen.getByTestId('size-bin-select')).toHaveDisplayValue('5')
     expect(screen.getByTestId('reef-slope-select')).toHaveDisplayValue('flat')
     expect(screen.getByTestId('visibility-select')).toHaveDisplayValue('<1m - bad')

--- a/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertValidationIgnoring2.test.jsx
+++ b/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertValidationIgnoring2.test.jsx
@@ -478,10 +478,10 @@ test('Validation: user edits non-observation input with ignored validation reset
   )
   await waitFor(() => expect(within(widthRow).queryByText('Ignored')).not.toBeInTheDocument())
 
-  // Fish Size Bin selection AGRRA
+  // Macroinvertebrate Size Bin selection
   await user.selectOptions(
     screen.getByTestId('size-bin-select'),
-    'ccef720a-a1c9-4956-906d-09ed56f16249',
+    'ab91e41a-c0d5-477f-baf3-f0571d7c0dcf',
   )
   await waitFor(() => expect(within(sizeBinRow).queryByText('Ignored')).not.toBeInTheDocument())
 

--- a/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertValidationIgnoring2.test.jsx
+++ b/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertValidationIgnoring2.test.jsx
@@ -471,10 +471,10 @@ test('Validation: user edits non-observation input with ignored validation reset
     expect(within(lengthSurveyedRow).queryByText('Ignored')).not.toBeInTheDocument(),
   )
 
-  // Width selection 10m
+  // Width selection 2m
   await user.selectOptions(
     screen.getByTestId('width-select'),
-    '228c932d-b5da-4464-b0df-d15a05c05c02',
+    'e1a133d3-70fe-403c-aed2-a70d630ef910',
   )
   await waitFor(() => expect(within(widthRow).queryByText('Ignored')).not.toBeInTheDocument())
 

--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
@@ -44,7 +44,6 @@ interface ChoiceCollection<T> {
 interface BeltInvertChoices {
   invertbelttransectwidths?: ChoiceCollection<WidthChoice>
   invertsizebins?: ChoiceCollection<NamedChoice>
-  fishsizebins?: ChoiceCollection<NamedChoice>
   reefslopes?: ChoiceCollection<NamedChoice>
   visibilities?: ChoiceCollection<NamedChoice>
   currents?: ChoiceCollection<NamedChoice>

--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
@@ -29,8 +29,8 @@ const VISIBILITY_VALIDATION_PATH = 'data.beltinvert_transect.visibility'
 const WIDTH_VALIDATION_PATH = 'data.beltinvert_transect.width'
 
 interface WidthChoice {
-  id: string | number
-  val: string | number
+  id: string
+  val: number
 }
 
 interface NamedChoice {
@@ -44,7 +44,6 @@ interface ChoiceCollection<T> {
 
 interface BeltInvertChoices {
   invertbelttransectwidths?: ChoiceCollection<WidthChoice>
-  belttransectwidths?: ChoiceCollection<WidthChoice>
   invertsizebins?: ChoiceCollection<NamedChoice>
   fishsizebins?: ChoiceCollection<NamedChoice>
   reefslopes?: ChoiceCollection<NamedChoice>
@@ -90,10 +89,10 @@ const BeltInvertTransectInputs = ({
 }: BeltInvertTransectInputsProps) => {
   const { t } = useTranslation()
 
-  // Keep compatibility while API choice keys finish propagating to all environments.
-  const widthChoices = choices.invertbelttransectwidths ?? choices.belttransectwidths
+  const widthChoices = choices.invertbelttransectwidths
   const sizeBinChoices = choices.invertsizebins ?? choices.fishsizebins
 
+  // This pattern is different from other protocols because the api returns the values differently
   const transectWidthOptions = sortArrayByObjectKey(
     (widthChoices?.data ?? []).map(({ val, id }) => ({
       label: `${val} m`,

--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
@@ -28,11 +28,37 @@ const TRANSECT_NUMBER_VALIDATION_PATH = 'data.beltinvert_transect.number'
 const VISIBILITY_VALIDATION_PATH = 'data.beltinvert_transect.visibility'
 const WIDTH_VALIDATION_PATH = 'data.beltinvert_transect.width'
 
+interface WidthChoice {
+  id: string | number
+  val: string | number
+}
+
+interface NamedChoice {
+  id: string | number
+  name: string
+}
+
+interface ChoiceCollection<T> {
+  data: T[]
+}
+
+interface BeltInvertChoices {
+  invertbelttransectwidths?: ChoiceCollection<WidthChoice>
+  belttransectwidths?: ChoiceCollection<WidthChoice>
+  invertsizebins?: ChoiceCollection<NamedChoice>
+  fishsizebins?: ChoiceCollection<NamedChoice>
+  reefslopes?: ChoiceCollection<NamedChoice>
+  visibilities?: ChoiceCollection<NamedChoice>
+  currents?: ChoiceCollection<NamedChoice>
+  relativedepths?: ChoiceCollection<NamedChoice>
+  tides?: ChoiceCollection<NamedChoice>
+}
+
 interface BeltInvertTransectInputsProps {
   observationsDispatch: (action: { type: string; payload?: unknown }) => void
   observationsState: ObservationRecord[]
   areValidationsShowing: boolean
-  choices: Record<string, { data: unknown[] }>
+  choices: BeltInvertChoices
   formik: {
     values: Record<string, unknown>
     handleBlur: (event: React.FocusEvent<HTMLElement>) => void
@@ -65,20 +91,14 @@ const BeltInvertTransectInputs = ({
   const { t } = useTranslation()
 
   // Keep compatibility while API choice keys finish propagating to all environments.
-  const widthChoices = choices.invertbelttransectwidths
+  const widthChoices = choices.invertbelttransectwidths ?? choices.belttransectwidths
   const sizeBinChoices = choices.invertsizebins ?? choices.fishsizebins
 
   const transectWidthOptions = sortArrayByObjectKey(
-    (widthChoices?.data ?? [])
-      .map((choice) => {
-        const { val, id } = choice as { val: number; id: string }
-
-        return {
-          label: `${val} m`,
-          value: id,
-        }
-      })
-      .filter((option): option is { label: string; value: string } => option !== null),
+    (widthChoices?.data ?? []).map(({ val, id }) => ({
+      label: `${val} m`,
+      value: id,
+    })),
     'label',
   )
   const invertSizeBinOptions = getOptions(sizeBinChoices?.data ?? [])

--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import { useTranslation, Trans } from 'react-i18next'
 
 import { getOptions } from '../../../../library/getOptions'
-import { sortArrayByObjectKey } from '../../../../library/arrays/sortArrayByObjectKey'
 import { H2 } from '../../../generic/text'
 import { InputWrapper } from '../../../generic/form'
 import getValidationPropertiesForInput from '../getValidationPropertiesForInput'
@@ -90,16 +89,16 @@ const BeltInvertTransectInputs = ({
   const { t } = useTranslation()
 
   const widthChoices = choices.invertbelttransectwidths
-  const sizeBinChoices = choices.invertsizebins ?? choices.fishsizebins
+  const sizeBinChoices = choices.invertsizebins
 
   // This pattern is different from other protocols because the api returns the values differently
-  const transectWidthOptions = sortArrayByObjectKey(
-    (widthChoices?.data ?? []).map(({ val, id }) => ({
+  const transectWidthOptions = (widthChoices?.data ?? [])
+    .slice()
+    .sort((a, b) => a.val - b.val)
+    .map(({ val, id }) => ({
       label: `${val} m`,
       value: id,
-    })),
-    'label',
-  )
+    }))
   const invertSizeBinOptions = getOptions(sizeBinChoices?.data ?? [])
   const reefSlopeOptions = getOptions(choices.reefslopes?.data ?? [])
   const visibilityOptions = getOptions(choices.visibilities?.data ?? [])

--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertTransectInputs.tsx
@@ -65,10 +65,22 @@ const BeltInvertTransectInputs = ({
   const { t } = useTranslation()
 
   // Keep compatibility while API choice keys finish propagating to all environments.
-  const widthChoices = choices.invertbelttransectwidths ?? choices.belttransectwidths
+  const widthChoices = choices.invertbelttransectwidths
   const sizeBinChoices = choices.invertsizebins ?? choices.fishsizebins
 
-  const transectWidthOptions = sortArrayByObjectKey(getOptions(widthChoices?.data ?? []), 'label')
+  const transectWidthOptions = sortArrayByObjectKey(
+    (widthChoices?.data ?? [])
+      .map((choice) => {
+        const { val, id } = choice as { val: number; id: string }
+
+        return {
+          label: `${val} m`,
+          value: id,
+        }
+      })
+      .filter((option): option is { label: string; value: string } => option !== null),
+    'label',
+  )
   const invertSizeBinOptions = getOptions(sizeBinChoices?.data ?? [])
   const reefSlopeOptions = getOptions(choices.reefslopes?.data ?? [])
   const visibilityOptions = getOptions(choices.visibilities?.data ?? [])

--- a/src/testUtilities/mockCollectRecords/mockBeltInvertCollectRecords.js
+++ b/src/testUtilities/mockCollectRecords/mockBeltInvertCollectRecords.js
@@ -13,7 +13,7 @@ export default [
       beltinvert_transect: {
         depth: 20,
         label: 'FB-1',
-        width: 'ab438b26-1ddf-4f62-b683-75dd364e614b',
+        width: 'e1a133d3-70fe-403c-aed2-a70d630ef910',
         size_bin: 'ab91e41a-c0d5-477f-baf3-f0571d7c0dcf',
         reef_slope: 'c04bcf7e-2d5a-48d3-817a-5eb2a213b6fa',
         notes: 'some fish notes',
@@ -53,7 +53,7 @@ export default [
       beltinvert_transect: {
         depth: 10,
         label: 'FB-2',
-        width: 'ab438b26-1ddf-4f62-b683-75dd364e614b',
+        width: 'e1a133d3-70fe-403c-aed2-a70d630ef910',
         size_bin: 'ab91e41a-c0d5-477f-baf3-f0571d7c0dcf',
         reef_slope: 'c04bcf7e-2d5a-48d3-817a-5eb2a213b6fa',
         notes: 'some fish notes',

--- a/src/testUtilities/mockCollectRecords/mockBeltInvertCollectRecords.js
+++ b/src/testUtilities/mockCollectRecords/mockBeltInvertCollectRecords.js
@@ -54,7 +54,7 @@ export default [
         depth: 10,
         label: 'FB-2',
         width: 'e1a133d3-70fe-403c-aed2-a70d630ef910',
-        size_bin: 'ab91e41a-c0d5-477f-baf3-f0571d7c0dcf',
+        size_bin: 'f0c1e3d5-4a7b-4f8e-9c6e-2f1b5c3d9e2a',
         reef_slope: 'c04bcf7e-2d5a-48d3-817a-5eb2a213b6fa',
         notes: 'some fish notes',
         number: 2,

--- a/src/testUtilities/mockMermaidData.js
+++ b/src/testUtilities/mockMermaidData.js
@@ -612,6 +612,29 @@ const project_managements = [
 ]
 
 const choices = {
+  invertbelttransectwidths: {
+    name: 'invertbelttransectwidths',
+    data: [
+      {
+        id: 'e1a133d3-70fe-403c-aed2-a70d630ef910',
+        name: '2.0',
+        updated_on: '2026-05-05T14:59:33.040520Z',
+        val: 2,
+      },
+      {
+        id: '18fc5c30-1786-4fe1-9536-4ee41ef3c08a',
+        name: '4.0',
+        updated_on: '2026-05-05T14:59:38.500671Z',
+        val: 4,
+      },
+      {
+        id: 'fdc582d4-f093-49f3-81a7-c84ddeee2c95',
+        name: '5.0',
+        updated_on: '2026-05-05T14:59:46.341115Z',
+        val: 5,
+      },
+    ],
+  },
   belttransectwidths: {
     name: 'belttransectwidths',
     data: [

--- a/src/testUtilities/mockMermaidData.js
+++ b/src/testUtilities/mockMermaidData.js
@@ -635,6 +635,29 @@ const choices = {
       },
     ],
   },
+  invertsizebins: {
+    name: 'invertsizebins',
+    data: [
+      {
+        id: 'ab91e41a-c0d5-477f-baf3-f0571d7c0dcf',
+        name: '1',
+        updated_on: '2026-05-05T14:59:51.905155Z',
+        val: '1',
+      },
+      {
+        id: 'f0c1e3d5-4a7b-4f8e-9c6e-2f1b5c3d9e2a',
+        name: '5',
+        updated_on: '2026-05-05T14:59:55.123456Z',
+        val: '5',
+      },
+      {
+        id: 'c0d5e4f6-7a8b-4c9e-9d1f-3e2b4c5d6e7f',
+        name: '10',
+        updated_on: '2026-05-05T14:59:59.789012Z',
+        val: '10',
+      },
+    ],
+  },
   belttransectwidths: {
     name: 'belttransectwidths',
     data: [


### PR DESCRIPTION
Ref: https://trello.com/c/hMC8SVRL/2006-macroinvertebrate-width-should-follow-the-same-format-as-other-transects

Fix the format of the width selection options in the dropdown

Before:
<img width="600" height="136" alt="image" src="https://github.com/user-attachments/assets/e56d601d-8459-400f-bc33-b4b0db942e89" />



After:
<img width="588" height="183" alt="image" src="https://github.com/user-attachments/assets/cda31a0d-f551-4fee-ac77-8546bd1151d7" />



---Every PR---

- [x] Changes have been tested locally
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Unit tests have run and passed

---Transitional Changes---

- [x] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [x] Any language.js tokens no longer used are removed
- [x] Any necessary updates to the documentation have been made
- [x] Unit tests have been added or updated, where possible, to prevent future regressions
- [x] styled-components code in changed files has been updated to CSS modules in the styles folder
- [x] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved belt invert transect width options to display consistently formatted, numerically sorted values (for example, “2 m”, “4 m”, “5 m”).

* **Bug Fixes**
  * Fixed belt invert create, edit, and validation flows to show the expected width formatting (including the spacing in unit labels) and keep success/error states aligned.

* **Tests**
  * Updated integration tests and mock data/fixtures to reflect the revised width selection options and displayed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->