### PR TITLE
fix: [M2005] Unescape forward slashes in lokalise pull export

### DIFF
--- a/.github/workflows/lokalise-pull.yml
+++ b/.github/workflows/lokalise-pull.yml
@@ -49,5 +49,6 @@ jobs:
               "export_sort": "a_z",
               "replace_breaks": false,
               "plural_format": "i18next_v4",
+              "json_unescaped_slashes": true,
               "filter_data": ["reviewed_only"]
             }


### PR DESCRIPTION
Adds `"json_unescaped_slashes": true` to the Lokalise pull's export params so downloaded JSON uses `/` instead of `\/`.

**Why:** our repo stores slashes unescaped, but Lokalise escapes them by default. Without this, every slash-containing string shows as a spurious change in the weekly pull PRs and conflicts with the prettier check. This makes pull diffs reflect only real translation changes.

**Scope:** config only - `.github/workflows/lokalise-pull.yml`. No app code, no functional change (`\/` and `/` are identical once parsed). Affects only the pull's *download*; the push uploads already-unescaped repo files.

---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated translation export settings so generated JSON files now preserve forward slashes in a more readable format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->