### PR TITLE
feat [M2005] add Lokalise push workflow + trigger-aware pull PR body

### DIFF
--- a/.github/workflows/lokalise-pull.yml
+++ b/.github/workflows/lokalise-pull.yml
@@ -35,7 +35,7 @@ jobs:
           git_commit_message: "chore(i18n): pull latest translations from Lokalise"
           pr_title: "chore(i18n): pull latest translations from Lokalise"
           pr_body: |
-            Automated weekly pull of translated strings from [Lokalise](https://lokalise.com/).
+            ${{ github.event_name == 'workflow_dispatch' && 'Manual pull of reviewed translations from' || 'Automated weekly pull of reviewed translations from' }} [Lokalise](https://lokalise.com/).
 
             **Review checklist:**
             - [ ] Verify translation values look correct

--- a/.github/workflows/lokalise-push.yml
+++ b/.github/workflows/lokalise-push.yml
@@ -1,0 +1,47 @@
+name: Push Source Translations to Lokalise
+
+on:
+  # Upload the English source whenever it changes on develop (e.g. a merged PR)
+  push:
+    branches:
+      - develop
+    paths:
+      - 'src/locales/en/**'
+  workflow_dispatch: # Allow manual trigger (e.g. backfilling source)
+
+# Prevent overlapping uploads from racing on the change-tracking tag
+concurrency:
+  group: lokalise-push
+  cancel-in-progress: false
+
+permissions:
+  contents: write # required to push the change-tracking tag
+
+jobs:
+  push-translations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: develop
+          fetch-depth: 0 # full history required for change detection / tag tracking
+
+      - name: Push source translations to Lokalise
+        id: lokalise-push
+        uses: lokalise/lokalise-push-action@v5.3.2
+        with:
+          api_token: ${{ secrets.LOKALISE_API_TOKEN }}
+          project_id: ${{ secrets.LOKALISE_PROJECT_ID }}
+          # Uploads the base language only (source of truth lives in code);
+          # target-language values are authored and reviewed in Lokalise.
+          translations_path: src/locales
+          file_ext: json
+          base_lang: en
+          # Track the last-synced commit via a git tag so multi-commit pushes
+          # (e.g. squash/merge PRs) reliably detect every changed source file.
+          use_tag_tracking: true
+          # Keep i18next {{placeholders}} and custom tags (<helperTextLink>,
+          # $t(...)) literal; do not convert to Lokalise universal placeholders.
+          additional_params: |
+            convert_placeholders: false

--- a/.github/workflows/lokalise-push.yml
+++ b/.github/workflows/lokalise-push.yml
@@ -1,12 +1,14 @@
 name: Push Source Translations to Lokalise
 
 on:
+  # Temporarily disabled: do not auto-upload on push to develop.
+  # Re-enable by uncommenting the block below.
   # Upload the English source whenever it changes on develop (e.g. a merged PR)
-  push:
-    branches:
-      - develop
-    paths:
-      - 'src/locales/en/**'
+  # push:
+  #   branches:
+  #     - develop
+  #   paths:
+  #     - 'src/locales/en/**'
   workflow_dispatch: # Allow manual trigger (e.g. backfilling source)
 
 # Prevent overlapping uploads from racing on the change-tracking tag


### PR DESCRIPTION
- Adds `lokalise-push.yml`: uploads English source to Lokalise on merge to `develop` (+ manual dispatch), token-based, base-lang only, tag-tracked. Replaces the broken OAuth auto-pull as the code→Lokalise sync.
 - Pull PR body now reads "Manual pull…" on `workflow_dispatch` vs "Automated weekly pull…" on schedule.

Requires `LOKALISE_API_TOKEN` to have write scope. First run should be a manual dispatch to verify it updates (not duplicates) keys.

### Required first-run validation (before relying on this workflow)

The push action registers Lokalise filenames from the uploaded path, and our keys were recently set to the `src/locales/%LANG_ISO%/translation.json` pattern. The push/pull actions are designed to round-trip on this pattern, but it hasn't been verified against our project yet - and a mismatch could create duplicate keys or reset filenames. So after merging, **do not enable reliance on the automatic trigger until a manual run is verified:**

1. Take a **snapshot** of the Lokalise project (rollback safety).
2. Trigger this workflow manually via **`workflow_dispatch`** and watch the run.
3. In Lokalise, confirm:
   - **No duplicate keys** (total key count unchanged).
   - **Filenames unchanged** - still `src/locales/%LANG_ISO%/translation.json`.
   - English **values updated** as expected.
4. Only after this passes should the automatic `push: develop` trigger be trusted.

If duplicates or filename changes appear, restore the snapshot and revisit before merging dependents.

---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual workflow to upload the app’s source translation files to Lokalise.
  * Updated the Lokalise pull workflow’s PR description to clearly indicate whether it was triggered manually or on the weekly schedule (and whether it includes reviewed translations).

* **Chores**
  * Improved workflow reliability by preventing overlapping translation uploads.
  * Updated workflow permissions and checkout settings to support tag tracking and full-history operations; ensured translation placeholders are preserved during upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->