### PR TITLE
fix [m2013] add decimal place to submitted abundance

### DIFF
--- a/src/components/pages/submittedRecordPages/SubmittedBeltInvert/SubmittedBeltInvertObservationTable.jsx
+++ b/src/components/pages/submittedRecordPages/SubmittedBeltInvert/SubmittedBeltInvertObservationTable.jsx
@@ -147,7 +147,7 @@ const SubmittedBeltInvertObservationTable = ({
             </Tr>
             <Tr>
               <Th>{t('total_abundance')}</Th>
-              <Td>{abundance}</Td>
+              <Td>{abundance.toFixed(1)}</Td>
             </Tr>
           </tbody>
         </MacroinvertebrateObservationsSummaryStats>


### PR DESCRIPTION
Ref: https://trello.com/c/Uqc7cE4o/2013-macroinvertrebrate-summary-table-needs-to-use-the-same-number-of-decimal-places

Implement QA feedback to add a .0 decimal place to total abundance in the submitted macroinvertebrate summary

<img width="421" height="256" alt="image" src="https://github.com/user-attachments/assets/5201d132-97f8-4beb-9a36-8e7a9c9fdced" />


---Every PR---

- [x] Changes have been tested locally
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Unit tests have run and passed

---Transitional Changes---

- [x] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [x] Any language.js tokens no longer used are removed
- [x] Any necessary updates to the documentation have been made
- [x] Unit tests have been added or updated, where possible, to prevent future regressions
- [x] styled-components code in changed files has been updated to CSS modules in the styles folder
- [x] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the total abundance summary to always display one decimal place, improving consistency in the submitted belt invert observation table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->