### PR TITLE
fix [m2007] address pr comments

### DIFF
--- a/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
@@ -6,7 +6,6 @@ import { matchSorter } from 'match-sorter'
 import { Menu, Item } from './InputAutocomplete.styles'
 import { Input, HelperText } from '../form'
 import { inputOptionsPropTypes } from '../../../library/miscPropTypes'
-import theme from '../../../theme'
 
 const AutoCompleteInput = styled(Input)`
   width: 100%;
@@ -14,22 +13,6 @@ const AutoCompleteInput = styled(Input)`
 `
 const AutoCompleteResultsWrapper = styled.div`
   position: relative;
-
-  & > div {
-    z-index: 110;
-    position: absolute;
-    display: block;
-    width: 100%;
-    top: 4rem;
-    outline: ${theme.color.outline};
-    outline-offset: -2px;
-    background: ${theme.color.white};
-
-    > p {
-      margin: 0;
-      padding: ${theme.spacing.buttonPadding};
-    }
-  }
 `
 
 const InputAutocomplete = ({
@@ -173,9 +156,13 @@ const InputAutocomplete = ({
             >
               {isMenuOpen && menuItems.length > 0 && getMenuContents(downshiftObject)}
               {isMenuOpen && !menuItems.length && noResultsText && (
-                <Item data-testid="noResult">{noResultsText}</Item>
+                <Item role="presentation" data-testid="noResult">
+                  {noResultsText}
+                </Item>
               )}
-              {isMenuOpen && !menuItems.length && noResultsAction && <Item>{noResultsAction}</Item>}
+              {isMenuOpen && !menuItems.length && noResultsAction && (
+                <Item role="presentation">{noResultsAction}</Item>
+              )}
             </Menu>
           </AutoCompleteResultsWrapper>
         )


### PR DESCRIPTION
Ref: https://trello.com/c/NA7EB6Ss/2007-add-padding-to-the-genus-dropdown-when-proposing-a-new-species

Addresses comments from the PR https://github.com/data-mermaid/mermaid-webapp/pull/1639
---Every PR---

- [x] Changes have been tested locally
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Unit tests have run and passed

---Transitional Changes---

- [x] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [x] Any language.js tokens no longer used are removed
- [x] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [x] styled-components code in changed files has been updated to CSS modules in the styles folder
- [x] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)
