### PR TITLE
fix: [M2014] Fix dropdown wrapping for Macroinvertebrate belt label

### DIFF
--- a/src/components/MethodsFilterDropDown/MethodsFilterDropDown.tsx
+++ b/src/components/MethodsFilterDropDown/MethodsFilterDropDown.tsx
@@ -25,13 +25,14 @@ const MenuProps = {
   PaperProps: {
     style: {
       maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
-      width: 230,
+      width: 'max-content',
+      minWidth: 230,
       color: theme.color.textColor,
     },
   },
 }
 
-const fontStyle = { fontFamily: 'Open Sans', fontSize: '1.6rem' }
+const fontStyle = { fontFamily: 'Open Sans', fontSize: '1.6rem', whiteSpace: 'nowrap' }
 
 const SelectStyle = { borderRadius: 0, height: '36px' }
 

--- a/src/components/generic/ButtonSecondaryDropdown/ButtonSecondaryDropdown.jsx
+++ b/src/components/generic/ButtonSecondaryDropdown/ButtonSecondaryDropdown.jsx
@@ -10,6 +10,7 @@ const ButtonSecondaryDropdown = ({
   label,
   className = undefined,
   disabled = false,
+  align = 'left',
   ...props
 }) => {
   return (
@@ -19,7 +20,11 @@ const ButtonSecondaryDropdown = ({
           {label} <IconDown />
         </ButtonSecondary>
       }
-      contents={<StyledDropdownContainer>{children}</StyledDropdownContainer>}
+      contents={
+        <StyledDropdownContainer $alignRight={align === 'right'}>
+          {children}
+        </StyledDropdownContainer>
+      }
     />
   )
 }
@@ -29,6 +34,7 @@ ButtonSecondaryDropdown.propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   className: PropTypes.string,
   disabled: PropTypes.bool,
+  align: PropTypes.oneOf(['left', 'right']),
 }
 
 export default ButtonSecondaryDropdown

--- a/src/components/generic/ButtonSecondaryDropdown/ButtonSecondaryDropdown.styles.js
+++ b/src/components/generic/ButtonSecondaryDropdown/ButtonSecondaryDropdown.styles.js
@@ -6,6 +6,13 @@ import theme from '../../../theme'
 export const StyledDropdownContainer = styled(DropdownContainer)`
   background-color: ${theme.color.white};
   border: solid 1px ${theme.color.border};
+  white-space: nowrap;
+  ${({ $alignRight }) =>
+    $alignRight &&
+    css`
+      left: auto;
+      right: 0;
+    `}
 `
 
 export const DropdownItemStyle = styled.button`

--- a/src/components/pages/Collect/AddSampleUnitButton.jsx
+++ b/src/components/pages/Collect/AddSampleUnitButton.jsx
@@ -31,7 +31,7 @@ const AddSampleUnitButton = () => {
   )
 
   return (
-    <StyledButtonSecondaryDropdown label={label} data-testid="add-sample-unit-button">
+    <StyledButtonSecondaryDropdown label={label} align="right" data-testid="add-sample-unit-button">
       <Column as="nav" data-testid="new-sample-unit-nav">
         <CustomNavLink to={`${currentProjectPath}/collecting/fishbelt`} data-testid="fishbelt-link">
           {t('protocol_titles.fishbelt')}

--- a/src/components/pages/Submitted/SubmittedToolbarSection.tsx
+++ b/src/components/pages/Submitted/SubmittedToolbarSection.tsx
@@ -122,7 +122,7 @@ const SubmittedToolbarSection = ({
             />
           ) : null}
         </FilterItems>
-        <ButtonSecondaryDropdown label={label}>
+        <ButtonSecondaryDropdown label={label} align="right">
           <Column as="nav" data-testid="export-to-csv">
             <DropdownItemStyle
               as="button"


### PR DESCRIPTION
Prevents the "Macroinvertebrate belt" protocol label from wrapping in the Add sample unit, Export data, and Filter by method dropdowns.

- Added `white-space: nowrap` to shared dropdown container
- Added `align="right"` prop to right-edge dropdowns so they don't overflow off-screen
- Changed MUI filter menu width from fixed `230` to `max-content

---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown display so menu items stay on one line and dropdowns can align to the right when needed.
  * Updated several dropdown buttons to open in a better position, reducing clipping near the edge of the screen.
  * Adjusted one filter dropdown to size itself more naturally for its contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->