### PR TITLE
fix: [M2035] Proposed attributes should not be usable by non-author

### DIFF
--- a/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertProposedAttributeSelectability.test.jsx
+++ b/src/App/integrationTests/collectRecords/beltinvert/App.beltInvertProposedAttributeSelectability.test.jsx
@@ -1,0 +1,65 @@
+import { expect, test } from 'vitest'
+import '@testing-library/jest-dom'
+import React from 'react'
+
+import {
+  renderAuthenticatedOffline,
+  screen,
+  within,
+} from '../../../../testUtilities/testingLibraryWithHelpers'
+import App from '../../../App'
+import { getMockDexieInstancesAllSuccess } from '../../../../testUtilities/mockDexie'
+import { initiallyHydrateOfflineStorageWithMockData } from '../../../../testUtilities/initiallyHydrateOfflineStorageWithMockData'
+
+test('Macroinvertebrate observations: another users proposed attribute is not selectable, but the current users own proposed attribute is', async () => {
+  const { dexiePerUserDataInstance, dexieCurrentUserInstance } = getMockDexieInstancesAllSuccess()
+
+  await initiallyHydrateOfflineStorageWithMockData(dexiePerUserDataInstance)
+
+  // Simulate another user's proposed attribute having ended up in offline storage,
+  // eg from viewing a submitted record that references it (see ensureAttributesLoaded).
+  await dexiePerUserDataInstance.invert_attributes.put({
+    id: 'other-users-proposed-invert-attribute',
+    name: 'Other Users Proposed Invert Attribute',
+    status: 10,
+    created_by: 'some-other-user-profile-id',
+    parent: '8b70dc27-598e-47ef-b413-53f8d02e5750',
+    uiState_pushToApi: false,
+  })
+
+  const { user } = renderAuthenticatedOffline(
+    <App dexieCurrentUserInstance={dexieCurrentUserInstance} />,
+    {
+      initialEntries: ['/projects/5/collecting/macroinvertebrate/'],
+      dexiePerUserDataInstance,
+      dexieCurrentUserInstance,
+    },
+  )
+
+  await screen.findByTestId('macroinvertebrate-page-title')
+
+  await user.click(await screen.findByTestId('add-observation-row'))
+
+  const observationsTable = await screen.findByTestId('invert-observations-table')
+  const speciesNameInput = within(observationsTable).getAllByTestId('species-name-autocomplete')[0]
+
+  // the other user's proposed attribute is not offered as an option
+  await user.type(speciesNameInput, 'Other Users Proposed Invert Attribute')
+
+  expect(await screen.findByTestId('propose-new-species-button')).toBeInTheDocument()
+  expect(
+    screen.queryByRole('option', { name: 'Other Users Proposed Invert Attribute' }),
+  ).not.toBeInTheDocument()
+
+  // the current user's own proposed attribute is offered as an option
+  await user.clear(speciesNameInput)
+  await user.type(speciesNameInput, 'Test Proposed Invert Attribute')
+
+  const ownProposedAttributeOption = await screen.findByRole('option', {
+    name: 'Test Proposed Invert Attribute',
+  })
+
+  await user.click(ownProposedAttributeOption)
+
+  expect(speciesNameInput).toHaveValue('Test Proposed Invert Attribute')
+})

--- a/src/App/mermaidData/getSelectableAttributes.test.ts
+++ b/src/App/mermaidData/getSelectableAttributes.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from 'vitest'
+import getSelectableAttributes, { PROPOSED_ATTRIBUTE_STATUS } from './getSelectableAttributes'
+
+const currentUserProfileId = 'current-user-profile-id'
+const otherUserProfileId = 'other-user-profile-id'
+
+const approvedAttribute = {
+  id: 'approved',
+  status: 90,
+  created_by: null,
+}
+const currentUsersProposedAttribute = {
+  id: 'own-proposed',
+  status: PROPOSED_ATTRIBUTE_STATUS,
+  created_by: currentUserProfileId,
+}
+const otherUsersProposedAttribute = {
+  id: 'other-users-proposed',
+  status: PROPOSED_ATTRIBUTE_STATUS,
+  created_by: otherUserProfileId,
+}
+// locally created proposals (see eg addInvertSpecies) have no status or created_by
+const localNotYetPushedProposedAttribute = {
+  id: 'local-proposed',
+  status: undefined,
+  uiState_pushToApi: true,
+}
+
+test('getSelectableAttributes keeps approved attributes regardless of who created them', () => {
+  expect(getSelectableAttributes([approvedAttribute], currentUserProfileId)).toEqual([
+    approvedAttribute,
+  ])
+})
+
+test('getSelectableAttributes keeps proposed attributes created by the current user', () => {
+  expect(getSelectableAttributes([currentUsersProposedAttribute], currentUserProfileId)).toEqual([
+    currentUsersProposedAttribute,
+  ])
+})
+
+test('getSelectableAttributes removes proposed attributes created by other users', () => {
+  expect(getSelectableAttributes([otherUsersProposedAttribute], currentUserProfileId)).toEqual([])
+})
+
+test('getSelectableAttributes keeps locally proposed attributes that have not been pushed to the API yet', () => {
+  expect(
+    getSelectableAttributes([localNotYetPushedProposedAttribute], currentUserProfileId),
+  ).toEqual([localNotYetPushedProposedAttribute])
+})
+
+test('getSelectableAttributes handles a mixed list', () => {
+  expect(
+    getSelectableAttributes(
+      [
+        approvedAttribute,
+        currentUsersProposedAttribute,
+        otherUsersProposedAttribute,
+        localNotYetPushedProposedAttribute,
+      ],
+      currentUserProfileId,
+    ),
+  ).toEqual([approvedAttribute, currentUsersProposedAttribute, localNotYetPushedProposedAttribute])
+})

--- a/src/App/mermaidData/getSelectableAttributes.ts
+++ b/src/App/mermaidData/getSelectableAttributes.ts
@@ -1,0 +1,26 @@
+// MERMAID attribute status codes are shared by benthic attributes, fish species,
+// and macroinvertebrate attributes: 10 = proposed (pending review), 90 = approved.
+export const PROPOSED_ATTRIBUTE_STATUS = 10
+
+interface AttributeWithProposalInfo {
+  status?: number | null
+  created_by?: string | null
+}
+
+// Proposed attributes are only usable by the user who proposed them. The pull API
+// enforces this, but attributes lazy-loaded by id for read-only display (see
+// ensureAttributesLoaded) can add other users' proposed attributes to offline storage,
+// so they must be excluded wherever the user can select an attribute for an observation.
+// Locally proposed attributes that have not been pushed to the API yet have no status,
+// so they are kept.
+const getSelectableAttributes = <T extends AttributeWithProposalInfo>(
+  attributes: T[],
+  currentUserProfileId: string | undefined,
+): T[] =>
+  (attributes ?? []).filter(
+    (attribute) =>
+      attribute.status !== PROPOSED_ATTRIBUTE_STATUS ||
+      attribute.created_by === currentUserProfileId,
+  )
+
+export default getSelectableAttributes

--- a/src/components/pages/ImageClassification/useSelectNewAttribute.js
+++ b/src/components/pages/ImageClassification/useSelectNewAttribute.js
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import { getBenthicOptions } from '../../../library/getOptions'
+import getSelectableAttributes from '../../../App/mermaidData/getSelectableAttributes'
 import { toast } from 'react-toastify'
+import { useCurrentUser } from '../../../App/CurrentUserContext'
 import { useHttpResponseErrorHandler } from '../../../App/HttpResponseErrorHandlerContext'
 
 const isAClassifierGuessOfSelectedPoint = (annotations, ba_gr) =>
@@ -19,6 +21,7 @@ export const useSelectNewAttribute = ({
   const [selectedBenthicAttr, setSelectedBenthicAttr] = useState('')
   const [selectedGrowthForm, setSelectedGrowthForm] = useState('')
   const handleHttpResponseError = useHttpResponseErrorHandler()
+  const { currentUser } = useCurrentUser()
 
   const handleDisplayNewRowSelection = () => {
     const promises = [
@@ -28,7 +31,9 @@ export const useSelectNewAttribute = ({
 
     Promise.all(promises)
       .then(([benthicAttributes, choices]) => {
-        const benthicOptions = getBenthicOptions(benthicAttributes)
+        const benthicOptions = getBenthicOptions(
+          getSelectableAttributes(benthicAttributes, currentUser?.id),
+        )
         const growthFormOptions = choices.growthforms.data
         setBenthicAttributeSelectOptions(benthicOptions)
         setGrowthFormSelectOptions(growthFormOptions)

--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertForm.tsx
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertForm.tsx
@@ -10,6 +10,7 @@ import {
 } from '../collectRecordFormInitialValues'
 import { getDataForSubNavNode } from '../../../../library/getDataForSubNavNode'
 import { getOptions } from '../../../../library/getOptions'
+import getSelectableAttributes from '../../../../App/mermaidData/getSelectableAttributes'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import { reformatFormValuesIntoBeltInvertRecord } from '../reformatFormValuesIntoRecord'
 import { sortArrayByObjectKey } from '../../../../library/arrays/sortArrayByObjectKey'
@@ -211,9 +212,11 @@ const BeltInvertForm = ({ isNewRecord = true }: BeltInvertFormProps) => {
 
   const invertAttributeParentOptions = useMemo(() => {
     // Filter to only genus-level attributes for species creation
-    const genusList = invertAttributes.filter((attr) => attr.taxonomic_rank === 'genus')
+    const genusList = getSelectableAttributes(invertAttributes, currentUser?.id).filter(
+      (attr) => attr.taxonomic_rank === 'genus',
+    )
     return getOptions(genusList)
-  }, [invertAttributes])
+  }, [invertAttributes, currentUser])
 
   const onSubmitNewInvertAttribute = (
     submissionValues: NewAttributeModalSubmissionValues,

--- a/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertObservationTable.tsx
+++ b/src/components/pages/collectRecordFormPages/BeltInvertForm/BeltInvertObservationTable.tsx
@@ -20,6 +20,8 @@ import { IconClose, IconPlus } from '../../../icons'
 import { InputWrapper, LabelContainer, RequiredIndicator } from '../../../generic/form'
 import { MacroinvertebrateObservationsSummaryStats, Tr, Td, Th } from '../../../generic/Table/table'
 import { getObservationsPropertyNames } from '../../../../App/mermaidData/recordProtocolHelpers'
+import getSelectableAttributes from '../../../../App/mermaidData/getSelectableAttributes'
+import { useCurrentUser } from '../../../../App/CurrentUserContext'
 import getObservationValidationInfo from '../CollectRecordFormPage/getObservationValidationInfo'
 import InputNumberNumericCharactersOnly from '../../../generic/InputNumberNumericCharctersOnly/InputNumberNumericCharactersOnly'
 import ObservationValidationInfo from '../ObservationValidationInfo'
@@ -66,6 +68,8 @@ interface InvertAttributeOptionInput {
   parent?: string | null
   taxonomic_rank?: string | null
   group_of_interest?: string | null
+  status?: number | null
+  created_by?: string | null
 }
 
 interface SelectOption {
@@ -402,6 +406,7 @@ const BeltInvertObservationTable = ({
   testId,
 }: BeltInvertObservationTableProps) => {
   const { t } = useTranslation()
+  const { currentUser } = useCurrentUser()
   const sizeBinSelected = formik?.values?.size_bin
   const transectLengthSurveyed = Number(formik?.values?.len_surveyed)
   const selectedWidthId = formik?.values?.width
@@ -443,13 +448,18 @@ const BeltInvertObservationTable = ({
   }
 
   const invertAttributeOptions = useMemo(() => {
-    return ((invertAttributes as InvertAttributeOptionInput[]) ?? []).map(
-      ({ id, name, display_name }) => ({
-        label: display_name ?? name,
-        value: id,
-      }),
+    // Other users' proposed attributes can be present in offline storage for
+    // read-only display purposes, but must not be selectable for observations.
+    const selectableInvertAttributes = getSelectableAttributes(
+      (invertAttributes as InvertAttributeOptionInput[]) ?? [],
+      currentUser?.id,
     )
-  }, [invertAttributes])
+
+    return selectableInvertAttributes.map(({ id, name, display_name }) => ({
+      label: display_name ?? name,
+      value: id,
+    }))
+  }, [invertAttributes, currentUser])
   const sizeOptions = useMemo(
     () => buildSizeOptionsFromBinLabel(sizeBinSelectedLabel),
     [sizeBinSelectedLabel],

--- a/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitForm.jsx
+++ b/src/components/pages/collectRecordFormPages/BenthicLitForm/BenthicLitForm.jsx
@@ -10,6 +10,7 @@ import {
 } from '../collectRecordFormInitialValues'
 
 import { getBenthicOptions } from '../../../../library/getOptions'
+import getSelectableAttributes from '../../../../App/mermaidData/getSelectableAttributes'
 import { getDataForSubNavNode } from '../../../../library/getDataForSubNavNode'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import { reformatFormValuesIntoBenthicLitRecord } from '../reformatFormValuesIntoRecord'
@@ -102,7 +103,11 @@ const BenthicLitform = ({ isNewRecord = true }) => {
               )
 
               setCollectRecordBeingEdited(collectRecordResponse)
-              setBenthicAttributeSelectOptions(getBenthicOptions(resolvedBenthicAttributes))
+              setBenthicAttributeSelectOptions(
+                getBenthicOptions(
+                  getSelectableAttributes(resolvedBenthicAttributes, currentUser.id),
+                ),
+              )
               setSites(sitesResponse)
 
               setIsLoading(false)
@@ -127,6 +132,7 @@ const BenthicLitform = ({ isNewRecord = true }) => {
       handleHttpResponseError,
       isSyncInProgress,
       errorMessage,
+      currentUser,
     ],
   )
 
@@ -158,10 +164,12 @@ const BenthicLitform = ({ isNewRecord = true }) => {
   const updateBenthicAttributeOptionsStateWithOfflineStorageData = useCallback(() => {
     if (databaseSwitchboardInstance) {
       databaseSwitchboardInstance.getBenthicAttributes().then((benthicAttributes) => {
-        setBenthicAttributeSelectOptions(getBenthicOptions(benthicAttributes))
+        setBenthicAttributeSelectOptions(
+          getBenthicOptions(getSelectableAttributes(benthicAttributes, currentUser.id)),
+        )
       })
     }
-  }, [databaseSwitchboardInstance])
+  }, [databaseSwitchboardInstance, currentUser])
 
   const closeNewBenthicAttributeModal = () => {
     setIsNewBenthicAttributeModalOpen(false)

--- a/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.jsx
+++ b/src/components/pages/collectRecordFormPages/BenthicPhotoQuadratForm/BenthicPhotoQuadratForm.jsx
@@ -11,6 +11,7 @@ import {
 } from '../collectRecordFormInitialValues'
 
 import { getBenthicOptions } from '../../../../library/getOptions'
+import getSelectableAttributes from '../../../../App/mermaidData/getSelectableAttributes'
 import { getDataForSubNavNode } from '../../../../library/getDataForSubNavNode'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import { reformatFormValuesIntoBenthicPQTRecord } from '../reformatFormValuesIntoRecord'
@@ -118,7 +119,11 @@ const BenthicPhotoQuadratForm = ({ isNewRecord = true }) => {
               )
 
               setCollectRecordBeingEdited(collectRecordResponse)
-              setBenthicAttributeSelectOptions(getBenthicOptions(resolvedBenthicAttributes))
+              setBenthicAttributeSelectOptions(
+                getBenthicOptions(
+                  getSelectableAttributes(resolvedBenthicAttributes, currentUser.id),
+                ),
+              )
               setSites(sitesResponse)
 
               setIsLoading(false)
@@ -143,6 +148,7 @@ const BenthicPhotoQuadratForm = ({ isNewRecord = true }) => {
       handleHttpResponseError,
       isSyncInProgress,
       errorMessage,
+      currentUser,
     ],
   )
 
@@ -180,12 +186,14 @@ const BenthicPhotoQuadratForm = ({ isNewRecord = true }) => {
   const updateBenthicAttributeOptionsStateWithOfflineStorageData = useCallback(() => {
     if (databaseSwitchboardInstance) {
       databaseSwitchboardInstance.getBenthicAttributes().then((benthicAttributes) => {
-        const updatedBenthicAttributeOptions = getBenthicOptions(benthicAttributes)
+        const updatedBenthicAttributeOptions = getBenthicOptions(
+          getSelectableAttributes(benthicAttributes, currentUser.id),
+        )
 
         setBenthicAttributeSelectOptions(updatedBenthicAttributeOptions)
       })
     }
-  }, [databaseSwitchboardInstance])
+  }, [databaseSwitchboardInstance, currentUser])
 
   const onSubmitNewBenthicAttribute = ({
     benthicAttributeParentId,

--- a/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitForm.jsx
+++ b/src/components/pages/collectRecordFormPages/BenthicPitForm/BenthicPitForm.jsx
@@ -11,6 +11,7 @@ import {
 } from '../collectRecordFormInitialValues'
 
 import { getBenthicOptions } from '../../../../library/getOptions'
+import getSelectableAttributes from '../../../../App/mermaidData/getSelectableAttributes'
 import { getDataForSubNavNode } from '../../../../library/getDataForSubNavNode'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import { reformatFormValuesIntoBenthicPitRecord } from '../reformatFormValuesIntoRecord'
@@ -104,7 +105,11 @@ const BenthicPitForm = ({ isNewRecord = true }) => {
               )
 
               setCollectRecordBeingEdited(collectRecordResponse)
-              setBenthicAttributeSelectOptions(getBenthicOptions(resolvedBenthicAttributes))
+              setBenthicAttributeSelectOptions(
+                getBenthicOptions(
+                  getSelectableAttributes(resolvedBenthicAttributes, currentUser.id),
+                ),
+              )
               setSites(sitesResponse)
 
               setIsLoading(false)
@@ -129,6 +134,7 @@ const BenthicPitForm = ({ isNewRecord = true }) => {
       handleHttpResponseError,
       isSyncInProgress,
       errorMessage,
+      currentUser,
     ],
   )
 
@@ -161,10 +167,12 @@ const BenthicPitForm = ({ isNewRecord = true }) => {
   const updateBenthicAttributeOptionsStateWithOfflineStorageData = useCallback(() => {
     if (databaseSwitchboardInstance) {
       databaseSwitchboardInstance.getBenthicAttributes().then((benthicAttributes) => {
-        setBenthicAttributeSelectOptions(getBenthicOptions(benthicAttributes))
+        setBenthicAttributeSelectOptions(
+          getBenthicOptions(getSelectableAttributes(benthicAttributes, currentUser.id)),
+        )
       })
     }
-  }, [databaseSwitchboardInstance])
+  }, [databaseSwitchboardInstance, currentUser])
 
   const closeNewBenthicAttributeModal = () => {
     setIsNewBenthicAttributeModalOpen(false)

--- a/src/components/pages/collectRecordFormPages/BleachingForm/BleachingForm.jsx
+++ b/src/components/pages/collectRecordFormPages/BleachingForm/BleachingForm.jsx
@@ -9,6 +9,7 @@ import {
   getSampleInfoInitialValues,
 } from '../collectRecordFormInitialValues'
 import { getBenthicOptions } from '../../../../library/getOptions'
+import getSelectableAttributes from '../../../../App/mermaidData/getSelectableAttributes'
 import { getDataForSubNavNode } from '../../../../library/getDataForSubNavNode'
 import { getToastArguments } from '../../../../library/getToastArguments'
 import { reformatFormValuesIntoBleachingRecord } from '../reformatFormValuesIntoRecord'
@@ -105,7 +106,11 @@ const BleachingForm = ({ isNewRecord = true }) => {
               )
 
               setCollectRecordBeingEdited(collectRecordResponse)
-              setBenthicAttributeSelectOptions(getBenthicOptions(resolvedBenthicAttributes))
+              setBenthicAttributeSelectOptions(
+                getBenthicOptions(
+                  getSelectableAttributes(resolvedBenthicAttributes, currentUser.id),
+                ),
+              )
               setSites(sitesResponse)
               setIsLoading(false)
             }
@@ -129,6 +134,7 @@ const BleachingForm = ({ isNewRecord = true }) => {
       handleHttpResponseError,
       isSyncInProgress,
       errorMessage,
+      currentUser,
     ],
   )
 
@@ -160,12 +166,14 @@ const BleachingForm = ({ isNewRecord = true }) => {
   const updateBenthicAttributeOptionsStateWithOfflineStorageData = useCallback(() => {
     if (databaseSwitchboardInstance) {
       databaseSwitchboardInstance.getBenthicAttributes().then((benthicAttributes) => {
-        const updatedBenthicAttributeOptions = getBenthicOptions(benthicAttributes)
+        const updatedBenthicAttributeOptions = getBenthicOptions(
+          getSelectableAttributes(benthicAttributes, currentUser.id),
+        )
 
         setBenthicAttributeSelectOptions(updatedBenthicAttributeOptions)
       })
     }
-  }, [databaseSwitchboardInstance])
+  }, [databaseSwitchboardInstance, currentUser])
 
   const closeNewBenthicAttributeModal = () => {
     setIsNewBenthicAttributeModalOpen(false)

--- a/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltForm.jsx
+++ b/src/components/pages/collectRecordFormPages/FishBeltForm/FishBeltForm.jsx
@@ -14,6 +14,7 @@ import {
 } from '../collectRecordFormInitialValues'
 import { getDataForSubNavNode } from '../../../../library/getDataForSubNavNode'
 import { getToastArguments } from '../../../../library/getToastArguments'
+import getSelectableAttributes from '../../../../App/mermaidData/getSelectableAttributes'
 import { reformatFormValuesIntoFishBeltRecord } from '../reformatFormValuesIntoRecord'
 import { sortArrayByObjectKey } from '../../../../library/arrays/sortArrayByObjectKey'
 import { useCurrentUser } from '../../../../App/CurrentUserContext'
@@ -121,7 +122,7 @@ const FishBeltForm = ({ isNewRecord = true }) => {
               })
 
               const updateFishNameOptions = getFishNameOptions({
-                species: resolvedFishSpecies,
+                species: getSelectableAttributes(resolvedFishSpecies, currentUser.id),
                 genera: fishGeneraResponse,
                 families: fishFamiliesResponse,
                 groupings: fishGroupingsResponse,
@@ -172,6 +173,7 @@ const FishBeltForm = ({ isNewRecord = true }) => {
     handleHttpResponseError,
     isSyncInProgress,
     errorMessage,
+    currentUser,
   ])
 
   const closeNewObservationModal = () => {
@@ -214,7 +216,7 @@ const FishBeltForm = ({ isNewRecord = true }) => {
         databaseSwitchboardInstance.getFishFamilies(),
       ]).then(([species, genera, families]) => {
         const updateFishNameOptions = getFishNameOptions({
-          species,
+          species: getSelectableAttributes(species, currentUser.id),
           genera,
           families,
         })
@@ -222,7 +224,7 @@ const FishBeltForm = ({ isNewRecord = true }) => {
         setFishNameOptions(updateFishNameOptions)
       })
     }
-  }, [databaseSwitchboardInstance])
+  }, [databaseSwitchboardInstance, currentUser])
 
   const onSubmitNewFishSpecies = ({ genusId, genusName, speciesName }) => {
     databaseSwitchboardInstance

--- a/src/testUtilities/mockMermaidData.js
+++ b/src/testUtilities/mockMermaidData.js
@@ -3156,8 +3156,9 @@ const benthic_attributes = [
     status: 10,
     created_on: '2021-01-25T09:47:50.448879Z',
     updated_on: '2021-06-16T13:29:10.087019Z',
+    // proposed by the mock current user, so it remains selectable in observation inputs
     name: 'Dead Coral with Algae',
-    created_by: '8aab2cc3-d76e-4c78-ab45-6b59b387c7b0',
+    created_by: 'fake-id',
     parent: 'abde283f-5dd4-4a67-bc0b-e7403ad9c517',
     life_history: null,
     regions: [],
@@ -3256,8 +3257,9 @@ const invert_attributes = [
     status: 10,
     created_on: '2022-11-03T10:08:03.777000Z',
     updated_on: '2022-11-03T10:08:03.777000Z',
+    // proposed by the mock current user, so it remains selectable in observation inputs
     name: 'Test Proposed Invert Attribute',
-    created_by: '8aab2cc3-d76e-4c78-ab45-6b59b387c7b0',
+    created_by: 'fake-id',
     parent: '8b70dc27-598e-47ef-b413-53f8d02e5750',
     life_history: null,
     regions: [],


### PR DESCRIPTION
### Problem

Proposed attributes (status `10`, pending review) were selectable by users who didn't propose them. Viewing a submitted record that references another user's proposed attribute lazy-loads it into the viewer's IndexedDB (`ensureAttributesLoaded`), and the pickers offered everything in storage without checking status or authorship.

### Fix

Adds a shared `getSelectableAttributes` helper that keeps an attribute only when it isn't proposed, or was created by the current user. Approved attributes and the user's own not-yet-synced proposals stay selectable; only other users' proposals are removed. Applied to every attribute picker, since they all share the same offline-storage exposure: fish belt, benthic PIT/LIT/photo quadrat/bleaching, macroinvertebrate, and image classification.

### Testing

Unit tests cover the helper (approved kept, own proposal kept, other users' removed, unsynced local kept, mixed list). A new integration test asserts another user's proposed attribute isn't offered in the macroinvertebrate picker while the current user's own still is. `tsc`, ESLint, and the `collectRecords` + `mermaidData` suites pass locally.


---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select lists now respect the active user, showing only attributes they can choose while keeping approved items available.
  * This behavior now applies across multiple recording and classification screens.

* **Bug Fixes**
  * Fixed cases where proposed attributes from other users could appear as selectable options.
  * Improved offline behavior so locally created proposals still remain available.

* **Tests**
  * Added coverage for user-scoped attribute selection and end-to-end autocomplete behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->