### PR TITLE
fix: [M2005] Switch GFCR nav to businesses_finance_solutions

### DIFF
--- a/src/components/pages/gfcrPages/GfcrIndicatorSetNav/GfcrIndicatorSetNav.jsx
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetNav/GfcrIndicatorSetNav.jsx
@@ -146,7 +146,7 @@ const GfcrIndicatorSetNav = ({ selectedNavItem, setSelectedNavItem }) => {
           setSelectedNavItem(e.currentTarget.id)
         }}
       >
-        {t('gfcr.facilities_solutions')}
+        {t('gfcr.businesses_finance_solutions')}
       </NavSubHeader>
       <NavSubHeader
         id="investments"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -242,7 +242,6 @@
       "non_standard_title": "Please select a standard title"
     },
     "exporting": "Exporting",
-    "facilities_solutions": "Facilities / solutions",
     "form_errors": "Form errors:",
     "forms": {
       "common": {


### PR DESCRIPTION
- Update GfcrIndicatorSetNav to consume the intended businesses_finance_solutions key instead of the stale facilities_solutions, so translated locales render their proper label.
- Drop the orphaned facilities_solutions key from the English source. The key must also be deleted in Lokalise, or the next pull will re-add it.

---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a navigation subheader label to show the correct finance solutions wording.
  * Removed an outdated translation entry from the English language file, keeping the navigation text consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->