### PR TITLE
fix: [M2041] Keep autocomplete dropdown in view

### DIFF
--- a/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
+++ b/src/components/generic/InputAutocomplete/InputAutocomplete.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { styled } from 'styled-components'
 import Downshift from 'downshift'
@@ -38,6 +38,7 @@ const InputAutocomplete = ({
   const [selectedValue, setSelectedValue] = useState(optionMatchingValueProp)
   const [menuItems, setMenuItems] = useState(options)
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const menuRef = useRef(null)
 
   const _updateSelectedValueWhenPropsChange = useEffect(() => {
     setIsMenuOpen(false)
@@ -87,9 +88,14 @@ const InputAutocomplete = ({
 
   const handleInputValueChange = useCallback(
     (inputValueItem) => {
-      // scroll to bottom of page to show full menu contents
+      // Nudge the open dropdown into view when it's the last row, without
+      // jumping the whole page to the bottom (which overshoots when other
+      // content is rendered below the table, e.g. the density summary).
+      // Deferred a frame so the scroll uses the freshly filtered menu height.
       if (isLastRow && isMenuOpen) {
-        window.scrollTo(0, document.body.scrollHeight)
+        requestAnimationFrame(() => {
+          menuRef.current?.scrollIntoView?.({ block: 'nearest' })
+        })
       }
 
       const matchingMenuItems = inputValueItem
@@ -152,6 +158,7 @@ const InputAutocomplete = ({
               {...getMenuProps({
                 $isOpen: isMenuOpen,
                 'data-testid': menuTestId,
+                ref: menuRef,
               })}
             >
               {isMenuOpen && menuItems.length > 0 && getMenuContents(downshiftObject)}


### PR DESCRIPTION
## Summary

Fixes M2041. Typing in the last row's taxon autocomplete jumped the page to the bottom on each keystroke, leaving the dropdown detached from the viewport. `InputAutocomplete` now nudges the open dropdown into view instead of scrolling to the document bottom.

## Root cause

The last-row helper called `window.scrollTo(0, document.body.scrollHeight)` on every keystroke (added in #804 to reveal the downward-opening dropdown). It assumes the observation table is the last thing on the page. The macroinvertebrate belt form breaks that: the "Density per group of interest" summary renders below the table and grows with each observation, so scrolling to the body bottom overshoots past the input. The dropdown is anchored to the input, so it scrolls out of view too.

## The fix

Replace the page-bottom scroll with `menuRef.current?.scrollIntoView({ block: 'nearest' })`, deferred one frame. `block: 'nearest'` reveals the dropdown with the minimum scroll and is a no-op when it's already visible, preserving the original behaviour for the fish belt and benthic forms. The menu ref is merged through Downshift's `getMenuProps`, which avoids overwriting the menu `id` that the input's `aria-controls` relies on.

## Testing

Verified manually in the macroinvertebrate belt form. `InputAutocomplete` unit tests plus belt invert (create, duplicate rows) and fish belt create integration tests pass.

---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the autocomplete dropdown so it stays visible without scrolling the entire page when opened near the bottom.
  * Made dropdown positioning feel smoother and less disruptive in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->