### PR TITLE
[2047] allow non-last admin to remove self from project

### DIFF
--- a/src/components/RemoveUserModal/RemoveUserModal.jsx
+++ b/src/components/RemoveUserModal/RemoveUserModal.jsx
@@ -101,7 +101,9 @@ const RemoveUserModal = ({
   const footerContentPageTwo = (
     <RightFooter>
       {cancelButton}
-      <ButtonCaution onClick={handleOnSubmit}>{t('users.remove_user')}</ButtonCaution>
+      <ButtonCaution onClick={handleOnSubmit} disabled={isLoading}>
+        {t('users.remove_user')}
+      </ButtonCaution>
     </RightFooter>
   )
 

--- a/src/components/RemoveUserModal/RemoveUserModal.jsx
+++ b/src/components/RemoveUserModal/RemoveUserModal.jsx
@@ -38,9 +38,14 @@ const RemoveUserModal = ({
   }
 
   const handleOnSubmit = () => {
-    onSubmit().then(() => {
-      closeModal()
-    })
+    onSubmit()
+      .then(() => {
+        closeModal()
+      })
+      .catch(() => {
+        // Error feedback (toast) is already shown by onSubmit; leave the modal open
+        // so the user can see it and decide whether to retry or cancel.
+      })
   }
 
   const title = {

--- a/src/components/pages/Users/Users.jsx
+++ b/src/components/pages/Users/Users.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import { toast } from 'react-toastify'
 import { useGlobalFilter, usePagination, useSortBy, useTable } from 'react-table'
-import { useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -98,9 +98,10 @@ const Users = () => {
     setShowRemoveUserWithActiveSampleUnitsWarning,
   ] = useState(false)
   const [userToBeRemoved, setUserToBeRemoved] = useState({})
-  const { currentUser } = useCurrentUser()
+  const { currentUser, refreshCurrentUser } = useCurrentUser()
   const { databaseSwitchboardInstance } = useDatabaseSwitchboardInstance()
   const { isAppOnline } = useOnlineStatus()
+  const navigate = useNavigate()
   const { projectId } = useParams()
   const { setIsSyncInProgress, isSyncInProgress } = useSyncStatus()
   const isAdminUser = getIsUserAdminForProject(currentUser, projectId)
@@ -348,25 +349,45 @@ const Users = () => {
   const removeUserProfile = () => {
     setIsTableUpdating(true)
 
-    databaseSwitchboardInstance
+    const isCurrentUserBeingRemoved = userToBeRemoved.profile === currentUser.id
+
+    return databaseSwitchboardInstance
       .removeUser(userToBeRemoved, projectId)
       .then(() => {
-        return fetchProjectProfiles()
-      })
-      .then(() => {
-        setIsTableUpdating(false)
-        toast.success(...getToastArguments(t('users.messages.user_removed')))
+        if (isCurrentUserBeingRemoved) {
+          setIsTableUpdating(false)
+          toast.success(...getToastArguments(t('users.messages.user_removed')))
+
+          // The user no longer has access to this project, so re-fetching its profiles
+          // would just 403. The pull triggered by removeUser() above already redirects
+          // to /noProjectAccess/<project>; replace that history entry with the projects
+          // list so the Back button doesn't lead to a dead-end error page.
+          navigate('/projects', { replace: true })
+
+          return undefined
+        }
+
+        return fetchProjectProfiles().then(() => {
+          setIsTableUpdating(false)
+          toast.success(...getToastArguments(t('users.messages.user_removed')))
+        })
       })
       .catch((error) => {
+        setIsTableUpdating(false)
         handleHttpResponseError({
           error,
           callback: () => {
-            setIsTableUpdating(false)
+            toast.error(
+              ...getToastArguments(
+                t('users.messages.user_remove_error', {
+                  userName: getProfileNameOrEmailForPendingUser(userToBeRemoved),
+                }),
+              ),
+            )
           },
         })
+        throw error
       })
-
-    return Promise.resolve()
   }
 
   const handleRoleChange = useCallback(
@@ -390,6 +411,14 @@ const Users = () => {
           )
 
           setObserverProfiles(updatedObserverProfiles)
+
+          if (editedProfile.profile === currentUser.id) {
+            // Our own project role just changed - refresh currentUser so admin-gated
+            // UI (this table, the Add User button, etc.) reflects it immediately
+            // instead of staying stale until the next navigation or reload.
+            refreshCurrentUser()
+          }
+
           toast.success(
             ...getToastArguments(
               t('users.messages.role_changed_success', {
@@ -419,10 +448,12 @@ const Users = () => {
         })
     },
     [
+      currentUser,
       databaseSwitchboardInstance,
       observerProfiles,
       projectId,
       handleHttpResponseError,
+      refreshCurrentUser,
       t,
       roleLabels,
     ],
@@ -578,6 +609,7 @@ function UsersTableSection({
   const userRoleHeaderText = t('users.role')
   const unsubmittedSampleUnitsHeaderText = t('users.unsubmitted_sample_units')
   const removeFromProjectHeaderText = t('users.remove_from_project')
+  const lastAdminTooltipText = t('users.messages.last_admin_tooltip')
   const adminHeaderText = t('users.roles.admin')
   const collectorHeaderText = t('users.roles.collector')
   const readOnlyHeaderText = t('users.roles.read_only')
@@ -733,6 +765,11 @@ function UsersTableSection({
     ]
   }, [nameHeaderText, userRoleHeaderText])
 
+  const projectAdminCount = useMemo(
+    () => observerProfiles.filter((profile) => profile.role === userRole.admin).length,
+    [observerProfiles],
+  )
+
   const tableCellDataForAdmin = useMemo(() => {
     return observerProfiles.map((profile) => {
       const {
@@ -748,10 +785,19 @@ function UsersTableSection({
       const userHasActiveSampleUnits = getDoesUserHaveActiveSampleUnits(profile)
       const isUserRoleReadOnly = getIsProjectProfileReadOnly(profile)
       const isCurrentUser = userId === currentUser.id
+      // Only the sole remaining admin needs to be blocked from self-editing/self-removal.
+      // Any other row, including the current user's when a co-admin exists, is safe to enable
+      // and mirrors the "last admin" guard enforced server-side.
+      const isOnlyAdmin = isCurrentUser && role === userRole.admin && projectAdminCount < 2
       const isActiveSampleUnitsWarningShowing = userHasActiveSampleUnits && isUserRoleReadOnly
+      const disabledRemoveTooltipText = isDemoProject
+        ? t('projects.demo.delete_users_unavailable')
+        : isOnlyAdmin
+        ? lastAdminTooltipText
+        : null
 
       const getCursorType = () => {
-        if (isCurrentUser) {
+        if (isOnlyAdmin) {
           return 'not-allowed'
         }
         if (isTableUpdating) {
@@ -772,7 +818,7 @@ function UsersTableSection({
             onChange={(event) => {
               handleRoleChange({ event, projectProfileId })
             }}
-            disabled={isCurrentUser || isTableUpdating}
+            disabled={isOnlyAdmin || isTableUpdating}
           />
         </TableRadioLabel>
       )
@@ -824,11 +870,11 @@ function UsersTableSection({
           <button
             className={buttonStyles['button--caution']}
             type="button"
-            disabled={isCurrentUser || isTableUpdating || isDemoProject}
+            disabled={isOnlyAdmin || isTableUpdating || isDemoProject}
             onClick={() => openRemoveUserModal(profile)}
           >
-            {isDemoProject ? (
-              <MuiTooltip title={t('projects.demo.delete_users_unavailable')}>
+            {disabledRemoveTooltipText ? (
+              <MuiTooltip title={disabledRemoveTooltipText}>
                 {' '}
                 {/*' ' is a hack to make the tooltip populate on disabled state*/}
                 <IconAccountRemove />
@@ -849,6 +895,8 @@ function UsersTableSection({
     isTableUpdating,
     openTransferSampleUnitsModal,
     openRemoveUserModal,
+    projectAdminCount,
+    lastAdminTooltipText,
   ])
 
   const tableCellDataForNonAdmin = useMemo(

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1081,6 +1081,7 @@
       "enter_email": "Please enter an email address",
       "failed_sample_units_transfer": "Sample units failed to transfer",
       "invalid_email": "Invalid email address",
+      "last_admin_tooltip": "You are the only admin on this project. Assign another admin before changing your role or removing yourself.",
       "new_user_added": "New user added",
       "pending_user_added": "Sign-up email sent. New user added as pending user.",
       "role_changed_error": "{{userName}}'s role has not been changed",
@@ -1088,7 +1089,8 @@
       "sample_units_transferred_one": "{{count}} sample unit transferred",
       "sample_units_transferred_other": "{{count}} sample units transferred",
       "something_went_wrong": "Something went wrong",
-      "user_removed": "User removed"
+      "user_removed": "User removed",
+      "user_remove_error": "{{userName}} has not been removed from project"
     },
     "not_signed_up": "will need to sign up because they're not already a MERMAID user",
     "pending_user": "Pending user",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved user removal handling so the dialog stays open on failure and preserves error feedback.
  - Removing yourself from a project now redirects to the projects list.
  - Role changes now refresh the current user immediately for updated access control.
  - Prevented removing or demoting the sole project administrator, with updated tooltip guidance.
  - Added a clearer error message when user removal is unsuccessful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->