### PR TITLE
fix: [M1710] Repair unverified-email login flow

### DIFF
--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -28,6 +28,7 @@ import Header from '../components/Header'
 import Layout from '../components/Layout'
 import LoadingIndicator from '../components/LoadingIndicator/LoadingIndicator'
 import PageNotFound from '../components/pages/PageNotFound'
+import EmailVerificationRequired from '../components/pages/EmailVerificationRequired'
 import SyncApiDataIntoOfflineStorage from './mermaidData/syncApiDataIntoOfflineStorage/SyncApiDataIntoOfflineStorage'
 import theme from '../theme'
 import useAuthentication from './useAuthentication'
@@ -47,9 +48,10 @@ function App({ dexieCurrentUserInstance }) {
   const pushSyncErrorUnsavedDataText = t('api_errors.unsaved_sync_data')
   const pushSyncErrorMessageStatusCode500 = t('api_errors.unspecified_error')
 
-  const { getAccessToken, isMermaidAuthenticated, logoutMermaid } = useAuthentication({
-    dexieCurrentUserInstance,
-  })
+  const { getAccessToken, isMermaidAuthenticated, logoutMermaid, loginMermaid, emailNotVerified } =
+    useAuthentication({
+      dexieCurrentUserInstance,
+    })
 
   const handleHttpResponseErrorWithLogoutAndSetServerNotReachableApplied = useCallback(
     ({ error, callback, shouldShowServerNonResponseMessage }) =>
@@ -278,6 +280,8 @@ function App({ dexieCurrentUserInstance }) {
                               <Route path="/*" element={<PageNotFound />} />
                             </Routes>
                           </ErrorBoundary>
+                        ) : emailNotVerified ? (
+                          <EmailVerificationRequired onLogin={loginMermaid} />
                         ) : (
                           <LoadingIndicator />
                         )

--- a/src/App/useAuthentication.ts
+++ b/src/App/useAuthentication.ts
@@ -17,6 +17,8 @@ interface UseAuthenticationParams {
 interface UseAuthenticationReturn {
   isMermaidAuthenticated: boolean
   logoutMermaid: () => void
+  loginMermaid: () => void
+  emailNotVerified: boolean
   getAccessToken: () => Promise<string>
 }
 
@@ -25,6 +27,7 @@ const useAuthentication = ({
 }: UseAuthenticationParams): UseAuthenticationReturn => {
   const { isAppOnline } = useOnlineStatus()
   const [isMermaidAuthenticated, setIsMermaidAuthenticated] = useState(false)
+  const [emailNotVerified, setEmailNotVerified] = useState(false)
   const navigate = useNavigate()
 
   const setAuthenticatedStates = useCallback(() => {
@@ -106,13 +109,12 @@ const useAuthentication = ({
       if (error && error === 'access_denied') {
         const errorDescription = urlParams.get('error_description')
         if (errorDescription && errorDescription === 'email_not_verified') {
-          const returnMsg = 'You must verify your email before you can login.'
-          const clientId = import.meta.env.VITE_AUTH0_CLIENT_ID
-          window.location.href = `https://${
-            import.meta.env.VITE_AUTH0_DOMAIN
-          }/login?client=${clientId}&error=${error}&error_description=${encodeURIComponent(
-            returnMsg,
-          )}`
+          // Do NOT redirect to Auth0's /login page directly here. That bypasses the
+          // OAuth PKCE flow (no redirect_uri/state/code_challenge/nonce), which leaves
+          // Auth0 with no valid transaction to complete and produces the
+          // "Oops! something went wrong" error page on /login/callback.
+          // Instead surface a dedicated screen and let loginMermaid start a proper flow.
+          setEmailNotVerified(true)
         }
       } else {
         const { pathname, search } = window.location
@@ -159,6 +161,21 @@ const useAuthentication = ({
     handlePostLoginRedirect,
   ])
 
+  const loginMermaid = useCallback(() => {
+    setEmailNotVerified(false)
+
+    const { pathname, search } = window.location
+    const isValidReturnPath = pathname.startsWith('/') && !pathname.startsWith('//')
+
+    // Route through the SDK so the full OAuth PKCE flow is initialized
+    // (redirect_uri, state, code_challenge, nonce).
+    auth0LoginWithRedirect({
+      appState: {
+        returnTo: isValidReturnPath ? `${pathname}${search}` : '/',
+      },
+    })
+  }, [auth0LoginWithRedirect])
+
   const logoutMermaid = useCallback(() => {
     if (isAppOnline) {
       sessionStorage.removeItem('auth0_returnTo')
@@ -175,6 +192,8 @@ const useAuthentication = ({
   return {
     isMermaidAuthenticated,
     logoutMermaid,
+    loginMermaid,
+    emailNotVerified,
     getAccessToken: getAuth0AccessTokenSilently,
   }
 }

--- a/src/components/pages/EmailVerificationRequired/EmailVerificationRequired.module.scss
+++ b/src/components/pages/EmailVerificationRequired/EmailVerificationRequired.module.scss
@@ -1,0 +1,10 @@
+@use '../../../style/theme.scss' as *;
+@use '../../../style/_mixins.scss' as *;
+
+.container {
+  @include column(center);
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  padding: $spacing-large;
+}

--- a/src/components/pages/EmailVerificationRequired/EmailVerificationRequired.tsx
+++ b/src/components/pages/EmailVerificationRequired/EmailVerificationRequired.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import styles from './EmailVerificationRequired.module.scss'
+import buttonStyles from '../../../style/buttons.module.scss'
+
+interface EmailVerificationRequiredProps {
+  onLogin: () => void
+}
+
+const EmailVerificationRequired = ({ onLogin }: EmailVerificationRequiredProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className={styles.container} data-testid="email-verification-required">
+      <h1>{t('auth.email_not_verified_heading')}</h1>
+      <p>{t('auth.email_not_verified_message')}</p>
+      <button type="button" className={buttonStyles['button--primary']} onClick={onLogin}>
+        {t('auth.try_login_again')}
+      </button>
+    </div>
+  )
+}
+
+export default EmailVerificationRequired

--- a/src/components/pages/EmailVerificationRequired/index.ts
+++ b/src/components/pages/EmailVerificationRequired/index.ts
@@ -1,0 +1,1 @@
+export { default } from './EmailVerificationRequired'

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -33,6 +33,11 @@
     "small_reef": "Small reef",
     "terrestrial_reef_flat": "Terrestrial reef flat"
   },
+  "auth": {
+    "email_not_verified_heading": "Please verify your email",
+    "email_not_verified_message": "We sent a verification link to your email address. Open it to verify your account, then try logging in again.",
+    "try_login_again": "Try logging in"
+  },
   "benthic_observations": {
     "add_benthic_attribute": "Propose new benthic attribute",
     "attribute_already_exists": "Proposed attribute {{attribute}} already exists in the list. Observation has been updated with this attribute.",


### PR DESCRIPTION
After signing up, users could land on Auth0's **"Oops!, something went wrong"** page at `.../login/callback` (seen during a training session with 18 concurrent sign-ups - a refresh worked around it).

### Root cause

On `error_description=email_not_verified`, `useAuthentication.ts` did a raw `window.location.href` redirect to Auth0's `/login` page. That skipped the OAuth PKCE flow (no `redirect_uri`/`state`/`code_challenge`/`nonce`), so Auth0 had no transaction to complete and errors out on `/login/callback`.

### Fix

- **`useAuthentication.ts`** - Replaced the raw redirect with an `emailNotVerified` state and a `loginMermaid` callback that restarts a proper flow via `loginWithRedirect`.
- **`EmailVerificationRequired`** (new) - Page prompting the user to verify their email, with a "Try logging in" button. Clicking before verifying just re-shows this page instead of the broken error page.
- **`App.jsx`** - Renders the new page instead of the loading spinner when `emailNotVerified` is set.
- **`translation.json`** - Added the three `auth.*` keys.

### Notes

New component follows the migration: TypeScript + CSS module, no styled-components. `App.jsx` left as JS (root-component conversion is out of scope). A follow-up ticket will cover low-connectivity resilience for the login handshake. `tsc` and ESLint pass.

---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an email verification screen for accounts that have not yet verified their email address.
  - Provides guidance and a button to try signing in again after verification.
  - Added English translations for the new verification messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->