### PR TITLE
ci: [M1827] Run tests on merge instead of on PR

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -23,12 +23,10 @@ jobs:
     uses: ./.github/workflows/_deps-cache.yml
 
   call-lint:
-    if: github.event.pull_request.draft == false
     needs: [deps-cache]
     uses: ./.github/workflows/_lint.yml
 
   call-test:
-    if: github.event.pull_request.draft == false
     needs: [deps-cache, call-lint]
     uses: ./.github/workflows/_test.yml
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,19 +25,6 @@ jobs:
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/_deps-cache.yml
 
-  call-lint:
-    if: github.event.pull_request.draft == false
-    needs: [deps-cache]
-    uses: ./.github/workflows/_lint.yml
-
-  call-test:
-    if: github.event.pull_request.draft == false
-    needs: [deps-cache, call-lint]
-    uses: ./.github/workflows/_test.yml
-    secrets: inherit
-    with:
-      environment: dev
-
   cdk-nag:
     if: github.event.pull_request.draft == false
     needs: [deps-cache]


### PR DESCRIPTION
## What
Stops lint and tests from running on pull requests. They now run only on merge to `develop` and on release tags, where a failure blocks the deploy.

## Why
PR #1543 added lint/test to `pr.yml`, which runs on every push to a PR branch (via the `synchronize` event) as well as on open/reopen. `deployment.yml` then ran the suite again on merge to `develop`. This reverts to the earlier "test on merge, block the deploy on failure" model: the suite runs once at merge rather than on every PR push plus again at merge, cutting redundant CI runs and their cost.

## Changes
- `pr.yml`: removed the `call-lint` and `call-test` jobs. The `cdk-nag` / `cdk-diff` IaC checks are unchanged.
- `deployment.yml`: no behavioural change. Lint → test → deploy still runs on push to `develop` and on tags, and `call-cdk-deploy` still gates on `needs: [call-lint, call-test]`. Removed two `if: github.event.pull_request.draft == false` guards that never applied on push/tag events.

## Resulting behaviour
| Event | Runs | Blocking effect |
|---|---|---|
| PR to `develop` | cdk-nag + cdk-diff | posts IaC report to PR |
| Push to `develop` | lint → test → deploy (dev) | failure blocks dev deploy |
| Tag `vX.Y[.Z]` | lint → test → deploy (prod) | failure blocks prod deploy |

## Trade-off
Nothing prevents the merge itself based on tests (branch protection requires a review, not a passing test check), so a PR with failing tests can still be merged. When it lands on `develop`, the deploy is correctly blocked, so broken code never reaches the dev environment. However, `develop` stays in a failing state and no deploys can happen. This includes for unrelated work merged afterwards - until someone reverts the bad merge or pushes a fix. This is the accepted, pre-#1543 behaviour.

---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)
