### PR TITLE
chore: Add hotfix release script

### DIFF
--- a/docs/ReleaseWorkflow.md
+++ b/docs/ReleaseWorkflow.md
@@ -10,6 +10,8 @@ How to cut a production release of mermaid-webapp. Production ([app.datamermaid.
 
 That's it - the script handles branches, versioning, tagging, pushing, and the GitHub release. Pick the bump type first (see below).
 
+Shipping a fix that already landed directly on `main`? Use the hotfix flow instead - see [Hotfix release](#hotfix-release).
+
 ## Choosing the bump
 
 Look at what's shipped since the last release and apply [Conventional Commits](https://www.conventionalcommits.org/):
@@ -44,6 +46,51 @@ To see what's shipped, use whichever is easiest:
 5. Pushes `main` and the tag - **this is what triggers the production deploy** (`.github/workflows/deployment.yml`).
 6. Back-merges `main` into `develop` so the version bump lands there too.
 7. Creates a GitHub release with auto-generated notes.
+
+`release.sh` and `hotfix.sh` share their common steps (checks, version verification, bump, push, back-merge, release) via `scripts/_release-lib.sh`, so fixes to that plumbing apply to both.
+
+## Hotfix release
+
+Occasionally a fix is committed **directly to `main`** (bypassing `develop`) and needs to ship on its own, without dragging in unreleased `develop` work. That's a hotfix.
+
+```bash
+./scripts/hotfix.sh <major|minor|patch>   # almost always patch
+```
+
+Same bump rules as above (a `fix:` on its own means `patch`).
+
+### How it differs from a normal release
+
+A hotfix is the normal release flow **minus the develop→main merge**, plus a safety check:
+
+- It only pulls and operates on `main`; it never merges `develop` into `main`.
+- It aborts if `main` isn't ahead of the latest tag (nothing to ship).
+- It prints the exact commits that will be released and asks for confirmation before tagging - your last chance to check that *only* the intended fix is on `main`.
+
+Everything else matches `release.sh`: it verifies `package.json` vs the latest tag, bumps the version, pushes `main` + tag (triggering the deploy), back-merges `main` into `develop` so the fix and version bump land there, and creates the GitHub release.
+
+### Doing it manually
+
+If you'd rather run it by hand (e.g. `v2.35.0` → `v2.35.1`):
+
+```bash
+git checkout main && git pull
+git fetch --tags --force
+
+# Sanity check what's on main since the last tag
+git log $(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1)..HEAD --oneline
+
+npm version patch                                        # creates the bump commit + tag
+SKIP_BRANCH_WARNING=1 git push origin main --follow-tags # triggers the deploy
+
+git checkout develop && git pull                         # back-merge into develop
+git merge main
+SKIP_BRANCH_WARNING=1 git push origin develop
+
+gh release create v2.35.1 --generate-notes --target main
+```
+
+Note the absence of any `git merge develop` step - that's what keeps unreleased work out of the hotfix.
 
 ## Troubleshooting
 

--- a/scripts/_release-lib.sh
+++ b/scripts/_release-lib.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# _release-lib.sh — Shared helpers for release.sh and hotfix.sh.
+#
+# Not executable on its own. Source it from a release script:
+#   source "$(dirname "${BASH_SOURCE[0]}")/_release-lib.sh"
+#
+# Functions communicate results via two globals, set as a side effect:
+#   LATEST_TAG   — set by verify_version_matches_tag (e.g. "v2.35.0")
+#   NEW_VERSION  — set by bump_version              (e.g. "v2.35.1")
+#
+# Callers should run `set -euo pipefail` themselves.
+
+# Abort unless the bump type is major/minor/patch. $2 is the caller's usage line.
+validate_bump_type() {
+  local bump_type="$1" usage="$2"
+  if [[ ! "$bump_type" =~ ^(major|minor|patch)$ ]]; then
+    echo "$usage"
+    exit 1
+  fi
+}
+
+# Abort unless git, npm and gh are all installed.
+require_tools() {
+  local cmd
+  for cmd in git npm gh; do
+    if ! command -v "$cmd" &> /dev/null; then
+      echo "Error: '$cmd' is not installed."
+      exit 1
+    fi
+  done
+}
+
+# Abort unless the working tree is clean (including untracked files).
+require_clean_tree() {
+  if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Error: Working tree is not clean. Commit or stash changes first."
+    exit 1
+  fi
+}
+
+# Check out a branch and pull the latest.
+checkout_and_pull() {
+  git checkout "$1" && git pull
+}
+
+# Fetch tags, force-updating mutable ones.
+# --force lets mutable tags (e.g. lokalise-sync-develop, which the Lokalise
+# workflow keeps moving) update in place instead of aborting with "would
+# clobber existing tag". Annotated release tags (vX.Y.Z) never move, so this
+# only affects sync tags.
+fetch_tags() {
+  git fetch --tags --force
+}
+
+# Verify package.json's version matches the latest semver release tag, and
+# set LATEST_TAG. If they drift (e.g. someone tagged manually without bumping
+# package.json), `npm version` can either fail ("tag already exists") or
+# silently produce a version lower than an existing tag. Abort and let the
+# user reconcile first.
+verify_version_matches_tag() {
+  local pkg_version latest_tag_version
+  pkg_version=$(node -p "require('./package.json').version")
+  # Filter to semver release tags only. Without the grep, a non-version tag
+  # (e.g. lokalise-sync-develop) could sort to the top and break the comparison.
+  LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+  latest_tag_version="${LATEST_TAG#v}"
+  if [[ "$pkg_version" != "$latest_tag_version" ]]; then
+    echo "Error: package.json version ($pkg_version) does not match latest tag ($LATEST_TAG)."
+    echo "Reconcile before releasing. To sync package.json up to the tag:"
+    echo "  npm version $latest_tag_version --no-git-tag-version"
+    echo "  git commit -am \"chore: sync package.json with $LATEST_TAG tag\""
+    echo "  git push origin main"
+    exit 1
+  fi
+}
+
+# Bump the version and set NEW_VERSION.
+# `npm version` updates package.json, creates the version commit, and creates
+# the annotated tag.
+bump_version() {
+  echo "Bumping version ($1)..."
+  NEW_VERSION=$(npm version "$1")
+  echo "New version: $NEW_VERSION"
+}
+
+# Push main + the new tag in one go.
+# --follow-tags: pushes annotated tags reachable from pushed commits (not all local tags)
+# Tag push triggers production deploy via .github/workflows/deployment.yml
+# SKIP_BRANCH_WARNING bypasses the pre-push hook's protected branch prompt
+push_main_and_tag() {
+  echo "Pushing main and tag..."
+  SKIP_BRANCH_WARNING=1 git push origin main --follow-tags
+}
+
+# Merge main back into develop so the version bump (and any main-only commits)
+# don't regress there.
+backmerge_into_develop() {
+  echo "Back-merging main into develop..."
+  git checkout develop && git pull
+  git merge main
+  SKIP_BRANCH_WARNING=1 git push origin develop
+}
+
+# Create the GitHub release with auto-generated changelog.
+# --target main: ensures release creation works even if the tag hasn't propagated yet
+create_github_release() {
+  echo "Creating GitHub release..."
+  gh release create "$NEW_VERSION" --generate-notes --target main
+}

--- a/scripts/hotfix.sh
+++ b/scripts/hotfix.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# hotfix.sh — Hotfix release workflow for mermaid-webapp.
+#
+# Ships whatever is already on `main` as a new release, WITHOUT merging
+# `develop`. Use this when a fix has landed directly on `main` (bypassing the
+# normal develop -> main flow) and needs to go to production on its own.
+#
+# For a normal release (cutting everything on `develop`), use release.sh instead.
+#
+# Usage: ./scripts/hotfix.sh <major|minor|patch>   (almost always 'patch')
+#
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/_release-lib.sh"
+
+BUMP_TYPE="${1:-}"
+validate_bump_type "$BUMP_TYPE" "Usage: ./scripts/hotfix.sh <major|minor|patch>  (a hotfix is almost always 'patch')"
+
+require_tools
+require_clean_tree
+
+# Deliberately do NOT touch develop yet — a hotfix ships what's on main, so
+# develop's unreleased work must stay out of it.
+echo "Pulling latest main..."
+checkout_and_pull main
+fetch_tags
+
+verify_version_matches_tag
+
+# Guard: there must be something on main to release. If main is not ahead of the
+# latest tag, `npm version` would produce an empty release (a version bump with
+# no actual changes) — almost certainly a mistake.
+COMMIT_COUNT=$(git rev-list "$LATEST_TAG..HEAD" --count)
+if [[ "$COMMIT_COUNT" -eq 0 ]]; then
+  echo "Error: main is not ahead of $LATEST_TAG — nothing to hotfix."
+  echo "A hotfix expects fix commits already on main. Did you forget to merge the fix?"
+  exit 1
+fi
+
+# Show exactly what will ship and require confirmation. A hotfix skips the usual
+# develop -> main review path, so this is the operator's last chance to sanity
+# check that ONLY the intended fix is on main.
+echo ""
+echo "The following $COMMIT_COUNT commit(s) on main will be released (since $LATEST_TAG):"
+echo ""
+git log "$LATEST_TAG..HEAD" --oneline
+echo ""
+read -r -p "Hotfix-release these as a '$BUMP_TYPE' bump? [y/N] " CONFIRM
+if [[ ! "$CONFIRM" =~ ^[Yy]$ ]]; then
+  echo "Aborted."
+  exit 1
+fi
+
+# No `git merge develop` here — that's the key difference from release.sh.
+bump_version "$BUMP_TYPE"
+push_main_and_tag
+backmerge_into_develop
+create_github_release
+
+echo ""
+echo "Hotfix $NEW_VERSION complete!"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,85 +2,40 @@
 #
 # release.sh — Release workflow for mermaid-webapp.
 #
+# Cuts a production release of everything on `develop`: merges develop into
+# main, bumps the version, tags, pushes (which triggers the deploy), back-merges
+# into develop, and creates the GitHub release.
+#
+# For shipping a fix that's already on `main` on its own, use hotfix.sh instead.
+#
 # Usage: ./scripts/release.sh <major|minor|patch>
 #
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/_release-lib.sh"
+
 BUMP_TYPE="${1:-}"
+validate_bump_type "$BUMP_TYPE" "Usage: ./scripts/release.sh <major|minor|patch>"
 
-if [[ ! "$BUMP_TYPE" =~ ^(major|minor|patch)$ ]]; then
-  echo "Usage: ./scripts/release.sh <major|minor|patch>"
-  exit 1
-fi
+require_tools
+require_clean_tree
 
-# Prerequisites
-for cmd in git npm gh; do
-  if ! command -v "$cmd" &> /dev/null; then
-    echo "Error: '$cmd' is not installed."
-    exit 1
-  fi
-done
-
-if [[ -n "$(git status --porcelain)" ]]; then
-  echo "Error: Working tree is not clean. Commit or stash changes first."
-  exit 1
-fi
-
-# Pull latest
 echo "Pulling latest develop and main..."
-git checkout develop && git pull
-git checkout main && git pull
-# --force lets mutable tags (e.g. lokalise-sync-develop, which the Lokalise
-# workflow keeps moving) update in place instead of aborting with "would
-# clobber existing tag". Annotated release tags (vX.Y.Z) never move, so this
-# only affects sync tags.
-git fetch --tags --force
+checkout_and_pull develop
+checkout_and_pull main
+fetch_tags
 
-# Verify package.json version matches the latest git tag.
-# If they drift (e.g. someone tagged manually without bumping package.json),
-# `npm version` can either fail ("tag already exists") or silently produce a
-# version lower than an existing tag. Abort and let the user reconcile first.
-PKG_VERSION=$(node -p "require('./package.json').version")
-# Filter to semver release tags only. Without the grep, a non-version tag
-# (e.g. lokalise-sync-develop) could sort to the top and break the comparison.
-LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
-LATEST_TAG_VERSION="${LATEST_TAG#v}"
-if [[ "$PKG_VERSION" != "$LATEST_TAG_VERSION" ]]; then
-  echo "Error: package.json version ($PKG_VERSION) does not match latest tag ($LATEST_TAG)."
-  echo "Reconcile before releasing. To sync package.json up to the tag:"
-  echo "  npm version $LATEST_TAG_VERSION --no-git-tag-version"
-  echo "  git commit -am \"chore: sync package.json with $LATEST_TAG tag\""
-  echo "  git push origin main"
-  exit 1
-fi
+verify_version_matches_tag
 
 # Merge develop into main
 # --no-ff: forces a merge commit so releases are visible in history and individually revertable
 echo "Merging develop into main..."
 git merge develop --no-ff -m "Merge develop into main for release"
 
-# Bump version — updates package.json, creates commit, creates annotated tag
-echo "Bumping version ($BUMP_TYPE)..."
-NEW_VERSION=$(npm version "$BUMP_TYPE")
-echo "New version: $NEW_VERSION"
-
-# Push main + tag in one go
-# --follow-tags: pushes annotated tags reachable from pushed commits (not all local tags)
-# Tag push triggers production deploy via .github/workflows/deployment.yml
-# SKIP_BRANCH_WARNING bypasses the pre-push hook's protected branch prompt
-echo "Pushing main and tag..."
-SKIP_BRANCH_WARNING=1 git push origin main --follow-tags
-
-# Back-merge version bump into develop
-echo "Back-merging main into develop..."
-git checkout develop
-git merge main
-SKIP_BRANCH_WARNING=1 git push origin develop
-
-# Create GitHub release with auto-generated changelog
-# --target main: ensures release creation works even if the tag hasn't propagated yet
-echo "Creating GitHub release..."
-gh release create "$NEW_VERSION" --generate-notes --target main
+bump_version "$BUMP_TYPE"
+push_main_and_tag
+backmerge_into_develop
+create_github_release
 
 echo ""
 echo "Release $NEW_VERSION complete!"


### PR DESCRIPTION
## Summary

Adds a dedicated hotfix release flow and factors the code shared with the normal release out into one place. No application code changes - scripts and docs only.

The most recent production fix went directly to `main` (bypassing `develop`) and was released manually as `v2.35.1`. This PR captures that flow in a script so it's repeatable and documented.

## What changed

`scripts/hotfix.sh` (new) ships whatever is already on `main` as a release without merging `develop`, so unreleased `develop` work stays out of the hotfix. It aborts if `main` isn't ahead of the latest tag, and prints the exact commits to be released for confirmation before tagging.

`scripts/_release-lib.sh` (new) holds the steps common to both scripts (prerequisite/clean-tree checks, version-vs-tag verification, bump, push, back-merge, GitHub release), so a fix to that plumbing applies to both.

`scripts/release.sh` is refactored to source the shared library; behaviour is unchanged except the back-merge now pulls `develop` first (a safe no-op in the normal flow).

`docs/ReleaseWorkflow.md` gains a "Hotfix release" section covering when to use it, how it differs from a normal release, and a manual fallback.

## Testing

Validated `bash -n` on all three scripts, confirmed the shared library sources cleanly and all functions resolve, and checked that bump-type validation accepts `patch` and rejects bad input. The hotfix flow itself was exercised manually to ship `v2.35.1`.

---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hotfix release workflow for shipping fixes directly from `main`.
  * Added safety checks to confirm version alignment, pending commits, required tools, and a clean working tree before release.
  * Added confirmation of the exact commits included in a hotfix.
  * Hotfix releases now update the version, deploy from `main`, synchronize with `develop`, and create release notes automatically.

* **Documentation**
  * Added Quick Start guidance and manual instructions for completing hotfix releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->