### PR TITLE
ci: [M2005] Force-push Lokalise pull branch each run

### DIFF
--- a/.github/workflows/lokalise-pull.yml
+++ b/.github/workflows/lokalise-pull.yml
@@ -35,6 +35,11 @@ jobs:
           always_pull_base: true
           skip_include_tags: true
           override_branch_name: chore/lokalise-translations
+          # Replace the branch history with a single fresh commit on every run
+          # instead of appending. Nobody edits this branch (all corrections are
+          # made back in Lokalise), so the PR should mirror Lokalise's current
+          # export rather than accumulate weekly commits. Keeps the same PR/thread.
+          force_push: true
           override_base_branch: develop
           git_commit_message: "chore(i18n): pull latest translations from Lokalise"
           pr_title: "chore(i18n): pull latest translations from Lokalise"

--- a/docs/TranslationSyncWorkflow.md
+++ b/docs/TranslationSyncWorkflow.md
@@ -41,6 +41,7 @@ flowchart LR
 
 - Opens a PR against `develop` (branch `chore/lokalise-translations`, labels `i18n,automated`).
 - Runs **weekly (Mondays 09:00 UTC)** and **on demand** (`workflow_dispatch`). The PR body says "Automated weekly pull" vs "Manual pull" depending on the trigger.
+- **Force-pushes a single fresh commit each run** (`force_push: true`) rather than appending. The branch (and its existing PR, same number/thread) is rewritten to one commit representing the full diff between `develop` and Lokalise's current export. This works because **nobody edits this branch** - all corrections go back through Lokalise - so there is no branch-local work to preserve, and the PR always mirrors Lokalise's current state instead of accumulating weeks of stacked "pull latest" commits. See [Critical configuration](#critical-configuration-and-why).
 - **Overwrites** the locale files with what Lokalise exports (it does not merge). The app falls back to English for anything missing.
 - **Includes English** via `always_pull_base: true` - without it the action drops base-language changes and `en/translation.json` never updates (see [Critical configuration](#critical-configuration-and-why)).
 - Pulls **all enabled languages** (currently `en`, `id`, `es`, `fr`, `pt`, `tl`).
@@ -55,6 +56,7 @@ The intended design is to export **reviewed-only** strings (`filter_data: ["revi
 
 - **Key filenames must be `src/locales/%LANG_ISO%/translation.json`.** This is what maps Lokalise files to the repo. Bare filenames (e.g. `translation.json`) silently break the pull with "No changes detected". Set in Lokalise via bulk **File: assign**.
 - **`always_pull_base: true`** (pull config) - the pull action **defaults this to `false`**, which silently drops base-language (English) changes: target languages sync but `en/translation.json` is never updated. It **must** be set to `true` for Lokalise's English source-of-truth edits on existing keys to flow back (see [Pull](#pull-lokalise--code)).
+- **`force_push: true`** (pull config) - each run replaces the `chore/lokalise-translations` branch with one fresh commit instead of appending. Safe because the branch is never hand-edited (corrections are made in Lokalise), and it keeps the PR a clean, always-current mirror of Lokalise rather than a growing stack of weekly commits (see [Pull](#pull-lokalise--code)).
 - **`plural_format: i18next_v4`** - matches the code's `_one` / `_other` plural keys (i18next v4). The older `i18next` (v3, `_plural`) would break pluralization.
 - **`json_unescaped_slashes: true`** - exports `/` instead of `\/`, matching the repo and prettier (avoids diff noise).
 - **`filter_data: ["reviewed_only"]`** - the reviewed-only filter, **currently disabled/removed** (see [Reviewed-only filter](#reviewed-only-filter-currently-disabled)). `export_empty_as: skip`, `export_sort: a_z`, 2-space indent.


### PR DESCRIPTION
### What
Adds `force_push: true` to the Lokalise pull workflow (`.github/workflows/lokalise-pull.yml`) so each run rewrites the `chore/lokalise-translations` branch to a single fresh commit instead of appending. Docs updated accordingly.

### Why
Previously, each weekly pull appended a new commit to the same long-lived branch and PR. Over time the PR accumulated several weeks of stacked "pull latest" commits, mixed multiple exports into one diff, and could drift from `develop`.

Since nobody edits this branch all translation corrections are made back in Lokalise - there's no branch-local work to preserve. Force-pushing is safe and makes the PR a clean, always-current mirror of Lokalise's export.

### Behaviour change (reviewer perspective)
- **Same PR** (same number, URL, and comment thread) is reused.
- Each run replaces the branch with **one commit** = the full diff between `develop` and Lokalise's current export.
- No more stacked weekly commits; the diff always reflects the current state, nothing historical.

### Changes
- `.github/workflows/lokalise-pull.yml` — add `force_push: true` (with explaining comment).
- `docs/TranslationSyncWorkflow.md` — document the force-push behaviour and rationale in the *Pull* and *Critical configuration* sections.

### Notes
- Action pin left at `@v5.0.1` (latest is v5.3.0); `force_push` is supported at the current pin, no bump needed.
- No app/runtime code affected.
****

---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that translation syncs replace the existing branch history with a single fresh commit.
  * Documented how this keeps the translation pull request aligned with the latest export without accumulating older commits.

* **Chores**
  * Updated the translation sync process to maintain a clean, current branch on each run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->