### PR TITLE
fix: [M1812] Remove as observer button appearing on new line

### DIFF
--- a/src/components/pages/collectRecordFormPages/ObserversInput/ObserversInput.jsx
+++ b/src/components/pages/collectRecordFormPages/ObserversInput/ObserversInput.jsx
@@ -141,7 +141,7 @@ const ObserversInput = ({
                       <Trans
                         i18nKey="removed_from_project_message"
                         values={{ userName: getObserverNameToUse(removedObserver) }}
-                      />
+                      />{' '}
                       <ButtonThatLooksLikeLinkUnderlined
                         type="button"
                         data-testid="remove-observer-button"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -901,7 +901,7 @@
   "remove_sort": "Remove sort",
   "remove_user": "Remove user",
   "remove_user_confirmation": "Are you sure you want to remove <strong>{{userName}}</strong> as an observer?",
-  "removed_from_project_message": "<strong>{{userName}}</strong> is an observer on this sample unit but is no longer a part of this project.<br />",
+  "removed_from_project_message": "<strong>{{userName}}</strong> is an observer on this sample unit but is no longer a part of this project.",
   "sample_units": {
     "add": "Add sample unit",
     "collect": "Collect",


### PR DESCRIPTION
## What changed:
- Removed `<br />` from the `removed_from_project_message` translation string, which was pushing the button to a new line
- Added a space between the message and the "Remove as observer" button so it sits inline after the period

---Every PR---

- [x] Changes have been tested locally
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing in the removed-observer warning message.
  * Removed an unnecessary line break from the related notification text for cleaner display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->