### PR TITLE
refactor: [M1971] GFCR 4 - finance solution field hiding

### DIFF
--- a/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.jsx
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSet/GfcrIndicatorSet.jsx
@@ -27,7 +27,6 @@ import GfcrIndicatorSetNav from '../GfcrIndicatorSetNav'
 import GfcrIndicatorSetForm from '../GfcrIndicatorSetForm/GfcrIndicatorSetForm'
 import IndicatorSetTitle from './IndicatorSetTitle'
 import { GfcrPageUnavailablePadding } from '../Gfcr/Gfcr.styles'
-import { TITLE_IDS_BY_TYPE } from '../GfcrIndicatorSetForm/subPages/ReportTitleAndDateForm'
 import PageUnavailable from '../../PageUnavailable'
 import IdsNotFound from '../../IdsNotFound/IdsNotFound'
 import { ButtonSecondary } from '../../../generic/buttons'
@@ -242,14 +241,8 @@ const GfcrIndicatorSet = ({ newIndicatorSetType }) => {
     validate: (values) => {
       const errors = {}
 
-      const validTitleIds = TITLE_IDS_BY_TYPE[indicatorSetType] ?? []
       if (!values.title) {
         errors.title = [{ code: t('forms.required_field'), id: 'Required' }]
-      } else if (
-        !validTitleIds.includes(values.title) &&
-        values.title !== initialFormValues.title
-      ) {
-        errors.title = [{ code: t('gfcr.errors.non_standard_title'), id: 'NonStandard' }]
       }
 
       if (!values.report_date) {

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.jsx
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.jsx
@@ -172,10 +172,7 @@ const FinanceSolutionModal = ({
         errors.name = [{ code: t('forms.required_field'), id: 'Required' }]
       }
 
-      const isStandardFsType = (choices.financesolutiontypes?.data || []).some(
-        (c) => c.id === values.fs_type,
-      )
-      if (!values.fs_type || !isStandardFsType) {
+      if (!values.fs_type) {
         errors.fs_type = [{ code: t('forms.required_field'), id: 'Required' }]
       }
 
@@ -251,22 +248,10 @@ const FinanceSolutionModal = ({
 
   const _setIsFormDirty = useEffect(() => setIsFormDirty(!!formik.dirty), [formik.dirty])
 
-  const fsTypeOptions = useMemo(() => {
-    const standardData = choices.financesolutiontypes?.data || []
-    const standard = getOptions(standardData)
-    const storedFsType = financeSolution?.fs_type
-    const isNonStandard = !!storedFsType && !standardData.some((c) => c.id === storedFsType)
-    if (isNonStandard && formik.values.fs_type === storedFsType) {
-      return [
-        {
-          value: storedFsType,
-          label: `${storedFsType} ${t('gfcr.non_standard_title_suffix')}`,
-        },
-        ...standard,
-      ]
-    }
-    return standard
-  }, [choices.financesolutiontypes?.data, financeSolution?.fs_type, formik.values.fs_type, t])
+  const fsTypeOptions = useMemo(
+    () => getOptions(choices.financesolutiontypes?.data || []),
+    [choices.financesolutiontypes?.data],
+  )
 
   const showSector = formik.values.fs_type === 'business'
   const showGeographicalCoverage = formik.values.fs_type === 'ctf'

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/ReportTitleAndDateForm.jsx
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/ReportTitleAndDateForm.jsx
@@ -75,22 +75,13 @@ const ReportTitleAndDateForm = ({
   const allTitleChoices = choices?.indicatorsettitles?.data ?? []
   const standardOptions = getOptions(allTitleChoices.filter(({ id }) => validTitleIds.includes(id)))
 
-  const currentTitle = formik.values.title
-  const isNonStandard = !!currentTitle && !validTitleIds.includes(currentTitle)
-  const titleOptions = isNonStandard
-    ? [
-        { value: currentTitle, label: `${currentTitle} ${t('gfcr.non_standard_title_suffix')}` },
-        ...standardOptions,
-      ]
-    : standardOptions
-
   return (
     <StyledGfcrInputWrapper>
       <InputSelectWithLabelAndValidation
         required
         label={t('title')}
         id="gfcr-title"
-        options={titleOptions}
+        options={standardOptions}
         {...formik.getFieldProps('title')}
         validationType={formik.errors.title && formik.touched.title ? 'error' : null}
         validationMessages={formik.errors.title}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -244,8 +244,7 @@
       "indicator_set_save_failed": "There was an error saving the fund indicator set",
       "indicator_sets_unavailable": "GFCR fund indicator sets are currently unavailable",
       "indicators_disable_failed": "Could not disable GFCR fund indicators for this project",
-      "indicators_enable_failed": "Could not enable GFCR fund indicators for this project",
-      "non_standard_title": "Please select a standard title"
+      "indicators_enable_failed": "Could not enable GFCR fund indicators for this project"
     },
     "exporting": "Exporting",
     "form_errors": "Form errors:",
@@ -413,7 +412,6 @@
     "investments": "Investments",
     "no_indicator_info": "Select 'Create new' to add a fund indicator set to this project",
     "no_indicator_sets": "No fund indicator sets yet",
-    "non_standard_title_suffix": "(non-standard)",
     "partnership": "GFCR is a global partnership that aims to mobilize resources to support coral reef conservation and restoration projects around the world.",
     "people": "People",
     "programme_area": "Programme area",


### PR DESCRIPTION
## Summary

Collect-side follow-up to the GFCR rework (Tickets 1 & 2), paired with the API **Phase 4** enforcement release. With **Phase 3** human migration complete, the DB no longer holds non-conforming finance-solution types or legacy free-text indicator-set titles, so the frontend can drop the Phase-2 legacy-data accommodations and render only standard options.

> **Note on scope:** the ticket's premise - that five finance-solution fields are still shown for all types - is already resolved on `develop`. Ticket 1's QA round (commit `b2489a84`) made all per-type fields conditional, added their submit-time defaulting, and made `sector` required when shown. I re-verified each rule against the May 2026 CSV and they match, so **this PR contains no field-visibility changes** - only the fallback removals and i18n cleanup.

## What changed

### Type dropdown (`FinanceSolutionModal.jsx`)
Removes the synthetic "(non-standard)" option that was prepended when a record's stored `fs_type` wasn't in the current choices, and simplifies the validator back to a plain required check (drops the `isStandardFsType` guard). The dropdown now renders only the `financesolutiontypes` choices.

### Title dropdown (`ReportTitleAndDateForm.jsx` + `GfcrIndicatorSet.jsx`)
Removes the synthetic non-standard title option so the dropdown renders only the options filtered for the set's type, and simplifies the title validator in the parent `GfcrIndicatorSet` back to a plain required check, dropping the `NonStandard` branch and its now-unused `TITLE_IDS_BY_TYPE` import.

### Translations
Removes the two tokens left unused by the above (see Translations section).

## Testing

`tsc`, `eslint`, and `prettier` are clean; the full unit suite passes (638 passed, 7 skipped). No automated tests cover this GFCR area, so verified manually:
- Type dropdown lists only the standard types (no "(non-standard)" entry); per-type field hiding still behaves per the CSV; an empty Type still blocks save.
- Title dropdown lists only the filtered options for the set's type (report vs target); an empty title still blocks save; a valid title saves.
- Ran through the full manual test steps against a local API on `M2002` (data-mermaid/mermaid-api#734) with the Phase 4 migration applied. See the Trello card for the step-by-step plan and expected results.

## Translations

English is the source of truth (`src/locales/en/translation.json`); syncs to Lokalise on merge to `develop`.

**Added:** none

**Removed:**

| Key | Value |
|---|---|
| `gfcr.errors.non_standard_title` | "Please select a standard title" |
| `gfcr.non_standard_title_suffix` | "(non-standard)" |

Both existed only in `en`. ⚠️ The Lokalise **push never deletes keys**, so these two stale keys should be **removed manually in Lokalise** so they don't linger there.

## Notes for reviewer

- **Depends on** the API Phase 4 release and Phase 3 migration being verified complete across all GFCR projects.
- **CSV vs code (out of scope, flagging):** `number_of_solutions_supported_by` shows for `taf`, `ctf`, and `financial_facility` in code, but the May 2026 CSV marks it for **TAF only**. It's a Ticket 1 field and the code reading is arguably more correct (all three are facility types), so it's left unchanged - worth a separate team decision.
- TS conversion of these `.jsx` files is deliberately deferred to a follow-up.


---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated indicator set forms to accept existing custom report titles and finance solution types without validation errors.
  * Simplified title and finance solution validation to require only a value, while retaining required report-date validation.
  * Standardized selectable options to display supported report titles and finance solution types.
  * Removed outdated messaging related to non-standard titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->