### PR TITLE
feat: [M1981] Add columns to GFCR facility / solution table

### DIFF
--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.jsx
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/FinanceSolutionModal.jsx
@@ -34,11 +34,11 @@ import { getOptions } from '../../../../../library/getOptions'
 import { IconInfo } from '../../../../icons'
 import { displayErrorMessagesGFCR } from '../../../../../library/displayErrorMessagesGFCR'
 import GfcrHelperLinks from '../subPages/GfcrHelperLinks'
-
-// Field visibility per fs_type — see "GFCR change requests - May_2026.csv"
-const BUSINESS_OR_FINANCIAL_MECHANISM_TYPES = ['business', 'financial_mechanism']
-const LOCAL_ENTERPRISE_TYPES = ['financial_facility', 'business', 'financial_mechanism']
-const NUMBER_OF_SOLUTIONS_SUPPORTED_BY_TYPES = ['taf', 'ctf', 'financial_facility']
+import {
+  BUSINESS_OR_FINANCIAL_MECHANISM_TYPES,
+  LOCAL_ENTERPRISE_TYPES,
+  NUMBER_OF_SOLUTIONS_SUPPORTED_BY_TYPES,
+} from './financeSolutionFieldVisibility'
 
 const isTafNameVisible = (fs_type, used_an_incubator) =>
   BUSINESS_OR_FINANCIAL_MECHANISM_TYPES.includes(fs_type) &&

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/financeSolutionFieldVisibility.js
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/financeSolutionFieldVisibility.js
@@ -1,0 +1,17 @@
+// Field applicability per finance solution type. Kept in one place so the edit
+// modal and the finance solutions table agree on which fields apply to which
+// fs_type. See "GFCR change requests - May_2026.csv".
+export const BUSINESS_OR_FINANCIAL_MECHANISM_TYPES = ['business', 'financial_mechanism']
+export const LOCAL_ENTERPRISE_TYPES = ['financial_facility', 'business', 'financial_mechanism']
+export const NUMBER_OF_SOLUTIONS_SUPPORTED_BY_TYPES = ['taf', 'ctf', 'financial_facility']
+
+export const isGenderSmartApplicable = (fsType) =>
+  BUSINESS_OR_FINANCIAL_MECHANISM_TYPES.includes(fsType)
+
+export const isLocalEnterpriseApplicable = (fsType) => LOCAL_ENTERPRISE_TYPES.includes(fsType)
+
+export const isUsedAnIncubatorApplicable = (fsType) =>
+  BUSINESS_OR_FINANCIAL_MECHANISM_TYPES.includes(fsType)
+
+export const isNumberOfSolutionsSupportedApplicable = (fsType) =>
+  NUMBER_OF_SOLUTIONS_SUPPORTED_BY_TYPES.includes(fsType)

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/FinanceSolutions.jsx
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/FinanceSolutions.jsx
@@ -44,7 +44,7 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
   const geographicalCoverageHeaderText = t('gfcr.forms.finance_solutions.geographical_coverage')
   const tafNameHeaderText = t('gfcr.forms.finance_solutions.taf_name')
   const numberOfSolutionsSupportedByHeaderText = t(
-    'gfcr.forms.finance_solutions.number_of_solutions_supported_by',
+    'gfcr.forms.finance_solutions.number_of_solutions_supported_by_table_header',
   )
 
   const { currentUser } = useCurrentUser()
@@ -85,14 +85,14 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
         sortType: reactTableNaturalSort,
       },
       {
-        Header: gender2xCriteriaHeaderText,
-        accessor: 'gender_smart',
+        Header: localEnterpriseHeaderText,
+        accessor: 'local_enterprise',
         sortType: reactTableNaturalSort,
         align: 'center',
       },
       {
-        Header: localEnterpriseHeaderText,
-        accessor: 'local_enterprise',
+        Header: gender2xCriteriaHeaderText,
+        accessor: 'gender_smart',
         sortType: reactTableNaturalSort,
         align: 'center',
       },
@@ -114,8 +114,8 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
       geographicalCoverageHeaderText,
       usedAnIncubatorHeaderText,
       tafNameHeaderText,
-      gender2xCriteriaHeaderText,
       localEnterpriseHeaderText,
+      gender2xCriteriaHeaderText,
       numberOfSolutionsSupportedByHeaderText,
       sustainableFinanceMechanismsHeaderText,
     ],

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/FinanceSolutions.jsx
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/FinanceSolutions.jsx
@@ -41,6 +41,11 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
   const sustainableFinanceMechanismsHeaderText = t(
     'gfcr.forms.finance_solutions.sustainable_finance_mechanisms',
   )
+  const geographicalCoverageHeaderText = t('gfcr.forms.finance_solutions.geographical_coverage')
+  const tafNameHeaderText = t('gfcr.forms.finance_solutions.taf_name')
+  const numberOfSolutionsSupportedByHeaderText = t(
+    'gfcr.forms.finance_solutions.number_of_solutions_supported_by',
+  )
 
   const { currentUser } = useCurrentUser()
   const [searchFilteredRowsLength, setSearchFilteredRowsLength] = useState(null)
@@ -65,8 +70,18 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
         sortType: reactTableNaturalSort,
       },
       {
+        Header: geographicalCoverageHeaderText,
+        accessor: 'geographical_coverage',
+        sortType: reactTableNaturalSort,
+      },
+      {
         Header: usedAnIncubatorHeaderText,
         accessor: 'used_an_incubator',
+        sortType: reactTableNaturalSort,
+      },
+      {
+        Header: tafNameHeaderText,
+        accessor: 'taf_name',
         sortType: reactTableNaturalSort,
       },
       {
@@ -82,6 +97,11 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
         align: 'center',
       },
       {
+        Header: numberOfSolutionsSupportedByHeaderText,
+        accessor: 'number_of_solutions_supported_by',
+        sortType: reactTableNaturalSort,
+      },
+      {
         Header: sustainableFinanceMechanismsHeaderText,
         accessor: 'sustainable_finance_mechanisms',
         sortType: reactTableNaturalSort,
@@ -91,9 +111,12 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
       businessFinanceSolutionNameHeaderText,
       fsTypeHeaderText,
       sectorHeaderText,
+      geographicalCoverageHeaderText,
       usedAnIncubatorHeaderText,
+      tafNameHeaderText,
       gender2xCriteriaHeaderText,
       localEnterpriseHeaderText,
+      numberOfSolutionsSupportedByHeaderText,
       sustainableFinanceMechanismsHeaderText,
     ],
   )
@@ -123,9 +146,12 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
         name,
         fs_type,
         sector,
+        geographical_coverage,
         used_an_incubator,
+        taf_name,
         gender_smart,
         local_enterprise,
+        number_of_solutions_supported_by,
         sustainable_finance_mechanisms,
       } = indicatorSet
 
@@ -134,6 +160,9 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
       )?.name
       const sectorName = choices.sectors.data?.find(
         (sectorChoice) => sectorChoice.id === sector,
+      )?.name
+      const geographicalCoverageName = choices.geographicalcoverage?.data?.find(
+        (geographicalCoverageChoice) => geographicalCoverageChoice.id === geographical_coverage,
       )?.name
       const incubatorName = choices.incubatortypes.data?.find(
         (incubatorTypeChoice) => incubatorTypeChoice.id === used_an_incubator,
@@ -153,9 +182,12 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
         ),
         fs_type: fsTypeName,
         sector: sectorName,
+        geographical_coverage: geographicalCoverageName,
         used_an_incubator: incubatorName ? incubatorName : 'None',
+        taf_name,
         gender_smart: <IconCheckLabel isCheck={!!gender_smart} />,
         local_enterprise: <IconCheckLabel isCheck={!!local_enterprise} />,
+        number_of_solutions_supported_by,
         sustainable_finance_mechanisms: sustainableFinanceMechanismNames.join(', '),
       }
     })
@@ -184,9 +216,12 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
         'values.name.props.children',
         'values.fs_type',
         'values.sector',
+        'values.geographical_coverage',
         'values.used_an_incubator',
+        'values.taf_name',
         'values.gender_smart',
         'values.local_enterprise',
+        'values.number_of_solutions_supported_by',
         'values.sustainable_finance_mechanisms',
       ]
 

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/FinanceSolutions.jsx
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/FinanceSolutions.jsx
@@ -127,12 +127,18 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
         accessor: 'local_enterprise',
         sortType: reactTableNaturalSort,
         align: 'center',
+        // eslint-disable-next-line react/prop-types
+        Cell: ({ value }) =>
+          typeof value === 'boolean' ? <IconCheckLabel isCheck={value} /> : null,
       },
       {
         Header: gender2xCriteriaHeaderText,
         accessor: 'gender_smart',
         sortType: reactTableNaturalSort,
         align: 'center',
+        // eslint-disable-next-line react/prop-types
+        Cell: ({ value }) =>
+          typeof value === 'boolean' ? <IconCheckLabel isCheck={value} /> : null,
       },
       {
         Header: numberOfSolutionsSupportedHeaderText,
@@ -227,16 +233,10 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
         fs_type: fsTypeName,
         sector: sectorName,
         geographical_coverage: geographicalCoverageName,
-        used_an_incubator: isUsedAnIncubatorApplicable(fs_type)
-          ? incubatorName || 'None'
-          : null,
+        used_an_incubator: isUsedAnIncubatorApplicable(fs_type) ? incubatorName || 'None' : null,
         taf_name,
-        local_enterprise: isLocalEnterpriseApplicable(fs_type) ? (
-          <IconCheckLabel isCheck={!!local_enterprise} />
-        ) : null,
-        gender_smart: isGenderSmartApplicable(fs_type) ? (
-          <IconCheckLabel isCheck={!!gender_smart} />
-        ) : null,
+        local_enterprise: isLocalEnterpriseApplicable(fs_type) ? !!local_enterprise : null,
+        gender_smart: isGenderSmartApplicable(fs_type) ? !!gender_smart : null,
         number_of_solutions_supported_by: isNumberOfSolutionsSupportedApplicable(fs_type)
           ? number_of_solutions_supported_by
           : null,

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/FinanceSolutions.jsx
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/subPages/FinanceSolutions.jsx
@@ -26,6 +26,12 @@ import FinanceSolutionModal from '../modals/FinanceSolutionModal'
 import { choicesPropType } from '../../../../../App/mermaidData/mermaidDataProptypes'
 import GfcrGenericTable from '../../GfcrGenericTable'
 import IconCheckLabel from './IconCheckLabel'
+import {
+  isGenderSmartApplicable,
+  isLocalEnterpriseApplicable,
+  isNumberOfSolutionsSupportedApplicable,
+  isUsedAnIncubatorApplicable,
+} from '../modals/financeSolutionFieldVisibility'
 
 const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp }) => {
   const { t } = useTranslation()
@@ -43,8 +49,8 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
   )
   const geographicalCoverageHeaderText = t('gfcr.forms.finance_solutions.geographical_coverage')
   const tafNameHeaderText = t('gfcr.forms.finance_solutions.taf_name')
-  const numberOfSolutionsSupportedByHeaderText = t(
-    'gfcr.forms.finance_solutions.number_of_solutions_supported_by_table_header',
+  const numberOfSolutionsSupportedHeaderText = t(
+    'gfcr.forms.finance_solutions.number_of_solutions_supported_table_header',
   )
 
   const { currentUser } = useCurrentUser()
@@ -52,8 +58,40 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [financeSolutionBeingEdited, setFinanceSolutionBeingEdited] = useState()
 
-  const tableColumns = useMemo(
-    () => [
+  // A column is hidden when it is blank for every row. For the applicability
+  // driven columns (the yes/no columns, "used an incubator" and "number of
+  // solutions supported") "blank" means the field does not apply to any row's
+  // type (see decision on M1981); for the text columns it means no value was
+  // entered.
+  const columnHasData = useMemo(() => {
+    const financeSolutions = indicatorSet.finance_solutions
+
+    return {
+      sector: financeSolutions.some((financeSolution) => !!financeSolution.sector),
+      geographical_coverage: financeSolutions.some(
+        (financeSolution) => !!financeSolution.geographical_coverage,
+      ),
+      used_an_incubator: financeSolutions.some((financeSolution) =>
+        isUsedAnIncubatorApplicable(financeSolution.fs_type),
+      ),
+      taf_name: financeSolutions.some((financeSolution) => !!financeSolution.taf_name),
+      local_enterprise: financeSolutions.some((financeSolution) =>
+        isLocalEnterpriseApplicable(financeSolution.fs_type),
+      ),
+      gender_smart: financeSolutions.some((financeSolution) =>
+        isGenderSmartApplicable(financeSolution.fs_type),
+      ),
+      number_of_solutions_supported_by: financeSolutions.some((financeSolution) =>
+        isNumberOfSolutionsSupportedApplicable(financeSolution.fs_type),
+      ),
+      sustainable_finance_mechanisms: financeSolutions.some(
+        (financeSolution) => financeSolution.sustainable_finance_mechanisms?.length > 0,
+      ),
+    }
+  }, [indicatorSet.finance_solutions])
+
+  const tableColumns = useMemo(() => {
+    const columns = [
       {
         Header: businessFinanceSolutionNameHeaderText,
         accessor: 'name',
@@ -97,7 +135,7 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
         align: 'center',
       },
       {
-        Header: numberOfSolutionsSupportedByHeaderText,
+        Header: numberOfSolutionsSupportedHeaderText,
         accessor: 'number_of_solutions_supported_by',
         sortType: reactTableNaturalSort,
       },
@@ -106,20 +144,26 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
         accessor: 'sustainable_finance_mechanisms',
         sortType: reactTableNaturalSort,
       },
-    ],
-    [
-      businessFinanceSolutionNameHeaderText,
-      fsTypeHeaderText,
-      sectorHeaderText,
-      geographicalCoverageHeaderText,
-      usedAnIncubatorHeaderText,
-      tafNameHeaderText,
-      localEnterpriseHeaderText,
-      gender2xCriteriaHeaderText,
-      numberOfSolutionsSupportedByHeaderText,
-      sustainableFinanceMechanismsHeaderText,
-    ],
-  )
+    ]
+
+    // Drop any column that columnHasData marks as blank for every row. Columns
+    // not listed in columnHasData (e.g. name, fs_type) are always shown.
+    return columns.filter(
+      (column) => !(column.accessor in columnHasData) || columnHasData[column.accessor],
+    )
+  }, [
+    businessFinanceSolutionNameHeaderText,
+    fsTypeHeaderText,
+    sectorHeaderText,
+    geographicalCoverageHeaderText,
+    usedAnIncubatorHeaderText,
+    tafNameHeaderText,
+    localEnterpriseHeaderText,
+    gender2xCriteriaHeaderText,
+    numberOfSolutionsSupportedHeaderText,
+    sustainableFinanceMechanismsHeaderText,
+    columnHasData,
+  ])
 
   const handleEditFinanceSolution = useCallback(
     (event) => {
@@ -183,11 +227,19 @@ const FinanceSolutions = ({ indicatorSet, setIndicatorSet, choices, displayHelp 
         fs_type: fsTypeName,
         sector: sectorName,
         geographical_coverage: geographicalCoverageName,
-        used_an_incubator: incubatorName ? incubatorName : 'None',
+        used_an_incubator: isUsedAnIncubatorApplicable(fs_type)
+          ? incubatorName || 'None'
+          : null,
         taf_name,
-        gender_smart: <IconCheckLabel isCheck={!!gender_smart} />,
-        local_enterprise: <IconCheckLabel isCheck={!!local_enterprise} />,
-        number_of_solutions_supported_by,
+        local_enterprise: isLocalEnterpriseApplicable(fs_type) ? (
+          <IconCheckLabel isCheck={!!local_enterprise} />
+        ) : null,
+        gender_smart: isGenderSmartApplicable(fs_type) ? (
+          <IconCheckLabel isCheck={!!gender_smart} />
+        ) : null,
+        number_of_solutions_supported_by: isNumberOfSolutionsSupportedApplicable(fs_type)
+          ? number_of_solutions_supported_by
+          : null,
         sustainable_finance_mechanisms: sustainableFinanceMechanismNames.join(', '),
       }
     })

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -352,6 +352,7 @@
         "name_helper": "Enter the name of each business or financial mechanism solution financed by the GFCR Programme separately. You may copy solutions from previous reports. Indicators F8, F9, and F10 will be disaggregated by both solution and sector. New solutions financed by the Programme will be added here progressively.<br /><gfcrPdfLink>View M&E Toolkit PDF</gfcrPdfLink>",
         "no_finance_solutions": "No facilities / solutions yet",
         "number_of_solutions_supported_by": "Number of solutions supported by",
+        "number_of_solutions_supported_by_table_header": "Total number of solutions supported",
         "pcf_revenues_error": "Remove revenues before changing type to Programmatic co-financing",
         "save": "Save facility / solution",
         "sector": "Sector",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -352,7 +352,7 @@
         "name_helper": "Enter the name of each business or financial mechanism solution financed by the GFCR Programme separately. You may copy solutions from previous reports. Indicators F8, F9, and F10 will be disaggregated by both solution and sector. New solutions financed by the Programme will be added here progressively.<br /><gfcrPdfLink>View M&E Toolkit PDF</gfcrPdfLink>",
         "no_finance_solutions": "No facilities / solutions yet",
         "number_of_solutions_supported_by": "Number of solutions supported by",
-        "number_of_solutions_supported_by_table_header": "Total number of solutions supported",
+        "number_of_solutions_supported_table_header": "Total number of solutions supported",
         "pcf_revenues_error": "Remove revenues before changing type to Programmatic co-financing",
         "save": "Save facility / solution",
         "sector": "Sector",


### PR DESCRIPTION
> [!NOTE]
> PR #1666 contained this same work but was accidentally merged into `feat/gfcr/feature-branch` when it should have targeted `develop`. This PR re-targets `develop`. It also includes the follow-up refinement (blank / hide of non-applicable columns) that was committed after #1666 had already merged, so it was never part of that PR's merged diff.

See M1981 trello card for more discussion around this.

Adds columns to the facility / solution table (Collect / GFCR) and refines how per-type fields are displayed.

The originally requested fields (Geographical coverage, Name of TAF (incubator), and Total number of solutions supported) already existed on the add/edit form and are persisted with the indicator set; this change surfaces them in the table. Columns are sortable and included in the search filter. No model, form, or API changes were needed.

### Column display

Following discussion on the ticket, fields that do not apply to a row's solution type now render **blank** rather than a cross, "None" or `0`:

- Gender 2X criteria and Local enterprise show only for the types they apply to.
- Used a TAF (incubator)? keeps "None" where an applicable type answered no, but is blank for types the question doesn't apply to.
- Total number of solutions supported shows its value (including a genuine `0`) only for applicable types.

Each of these columns, alongside the existing text columns, is **hidden when no row in the set can populate it**.

Field applicability now lives in a shared `financeSolutionFieldVisibility` module used by both the table and the edit modal, so the two agree on which fields apply to which type.

### Notes

- Existing `Type` column is kept; Local enterprise is ordered before Gender 2X to match the modal.
- Headers use the wording confirmed on the ticket ("Total number of solutions supported", "Name of TAF (incubator)").
- Renames the `number_of_solutions_supported_by_table_header` token to drop the redundant `_by` fragment.

### Testing

- Manually verified by adding solutions of each type: non-applicable cells render blank, a real `0` still shows for applicable types, and each applicability-driven column hides when no row can populate it. Lint passes.

---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Finance solution tables now display only applicable fields and hide columns with no available data.
  * Added support for geographical coverage, TAF name, and total solutions supported in table rows and search.
  * Updated conditional indicators for incubator use, gender-smart solutions, and local enterprise support.
  * Added the “Total number of solutions supported” table header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->