### PR TITLE
fix: [M2049] Translate table filter indicator pill

### DIFF
--- a/src/components/generic/FilterIndicatorPill/FilterIndicatorPill.jsx
+++ b/src/components/generic/FilterIndicatorPill/FilterIndicatorPill.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { styled } from 'styled-components'
 import PropTypes from 'prop-types'
+import { useTranslation } from 'react-i18next'
 import { IconClose } from '../../icons'
 import theme from '../../../theme'
 import { IconButton } from '../buttons'
@@ -32,6 +33,7 @@ const FilterIndicatorPill = ({
   unfilteredRowLength,
   clearFilters,
 }) => {
+  const { t } = useTranslation()
   const [filteredAmountToDisplay, setFilteredAmountToDisplay] = useState(null)
 
   const _findFilteredAmountToDisplay = useEffect(() => {
@@ -54,7 +56,7 @@ const FilterIndicatorPill = ({
 
   return (
     <FilterIndictorPillContainer>
-      Filtered{' '}
+      {t('filters.filtered')}{' '}
       <FilterAmount>
         {filteredAmountToDisplay} / {unfilteredRowLength}
       </FilterAmount>{' '}

--- a/src/components/generic/FilterIndicatorPill/FilterIndicatorPill.test.jsx
+++ b/src/components/generic/FilterIndicatorPill/FilterIndicatorPill.test.jsx
@@ -1,0 +1,49 @@
+import { expect, test, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import React from 'react'
+import { renderAuthenticatedOnline, screen } from '../../../testUtilities/testingLibraryWithHelpers'
+import { mockT } from '../../../testUtilities/mockT'
+import FilterIndicatorPill from './FilterIndicatorPill'
+
+// The react-i18next mock (see setupTests.js) makes t() return the key it is
+// called with, so assertions target stable token keys rather than English text.
+
+const defaultProps = {
+  unfilteredRowLength: 87,
+  clearFilters: () => {},
+}
+
+test('FilterIndicatorPill tokenises the "filtered" label instead of hardcoding English', () => {
+  renderAuthenticatedOnline(<FilterIndicatorPill {...defaultProps} />)
+
+  expect(mockT).toHaveBeenCalledWith('filters.filtered')
+  expect(screen.getByText('filters.filtered', { exact: false })).toBeInTheDocument()
+})
+
+test('FilterIndicatorPill shows the search filtered count over the unfiltered count', () => {
+  renderAuthenticatedOnline(
+    <FilterIndicatorPill {...defaultProps} searchFilteredRowLength={15} isSearchFilterEnabled />,
+  )
+
+  expect(screen.getByText('15 / 87')).toBeInTheDocument()
+})
+
+test('FilterIndicatorPill shows the method filtered count when only the method filter is on', () => {
+  renderAuthenticatedOnline(
+    <FilterIndicatorPill {...defaultProps} methodFilteredRowLength={40} isMethodFilterEnabled />,
+  )
+
+  expect(screen.getByText('40 / 87')).toBeInTheDocument()
+})
+
+test('FilterIndicatorPill calls clearFilters when the close button is clicked', async () => {
+  const handleClearFilters = vi.fn()
+
+  const { user } = renderAuthenticatedOnline(
+    <FilterIndicatorPill {...defaultProps} clearFilters={handleClearFilters} />,
+  )
+
+  await user.click(screen.getByRole('button'))
+
+  expect(handleClearFilters).toHaveBeenCalledTimes(1)
+})

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -201,6 +201,7 @@
     "by_site": "Filter by site",
     "by_site_management_observer": "Filter by site, management, or observer",
     "by_title_date": "Filter by title or date",
+    "filtered": "Filtered",
     "method": "Filter by method",
     "projects_by_name_year": "Filter by name or country",
     "search_helper_text": "<b>Use double quotes to search exact phrases.</b><br>For example, search North Shore to find records with the words North or Shore (records with South Shore would match). Or search \"North Shore\" to find records that have exactly the words North Shore (records with South Shore would not match)."
@@ -1019,7 +1020,6 @@
   "show_fish_count_info": "Show fish count info",
   "show_fish_name_info": "Show fish name info",
   "show_fish_size_info": "Show fish size info",
-  "showing": "Showing",
   "sites": {
     "cannot_delete": "You cannot delete this site because it is used in the following sample units:",
     "confirm_delete": "Are you sure you want to delete this site?",


### PR DESCRIPTION
## What

Tokenises the hardcoded `Filtered` in `FilterIndicatorPill` (the pill above filtered tables reading `Filtered 15 / 87`) using a new `filters.filtered` token, and removes the now-dead top-level `showing` token from `en`.

## Why

Follow-up to #1663 (M2049), which tokenised the `PageSizeSelector` line. The pill is a separate shared component sitting alongside it and wasn't in that PR's scope, so its hardcoded `Filtered` was missed. The component didn't import `useTranslation` at all.

#1663 also moved the selector to `page_size_selector.showing`, orphaning the old top-level `showing`. Nothing references it: the only `showing` references in `src` are `page_size_selector.showing`, and no dynamic `t()` key can resolve to it (every template-literal key in the codebase is `protocol_titles.*`). Removed from `en` only, for a translator to delete in Lokalise so it clears from the other locales on the next pull.

## Notes

- `filters.filtered` is English-only per the usual workflow, so other languages fall back to English until the next Lokalise pull. Expected, not a regression.
- `FilterIndicatorPill` had no test file. Added four tests following the `PageSizeSelector.test.tsx` convention of asserting token keys, not English text.
- 58 tests pass across `src/components/generic`, `Collect` and `Submitted`. ESLint clean. Prettier flags `en/translation.json`, but that's pre-existing on develop (the Lokalise pull writes it without a trailing newline).


---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized text for the filtered-results indicator.

* **Bug Fixes**
  * Improved filter indicator behavior and display for search and method filters.
  * Ensured the close button clears active filters.

* **Tests**
  * Added coverage for translated labels, filter counts, and clearing filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->