### PR TITLE
fix: [M1947b] Trim copy facility / solution table

### DIFF
--- a/src/App/mermaidData/mermaidDataTypes.ts
+++ b/src/App/mermaidData/mermaidDataTypes.ts
@@ -454,6 +454,7 @@ export interface FinanceSolution {
 export interface IndicatorSet {
   id: string
   title: string
+  indicator_set_type: string
   report_date: string
   finance_solutions: FinanceSolution[]
 }

--- a/src/App/mermaidData/mermaidDataTypes.ts
+++ b/src/App/mermaidData/mermaidDataTypes.ts
@@ -454,6 +454,7 @@ export interface FinanceSolution {
 export interface IndicatorSet {
   id: string
   title: string
+  report_date: string
   finance_solutions: FinanceSolution[]
 }
 

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/CopyFinanceSolutionsModal.tsx
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/CopyFinanceSolutionsModal.tsx
@@ -27,7 +27,7 @@ import { useCurrentUser } from '../../../../../App/CurrentUserContext'
 import { useCurrentProject } from '../../../../../App/CurrentProjectContext'
 import { useDatabaseSwitchboardInstance } from '../../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 import { useHttpResponseErrorHandler } from '../../../../../App/HttpResponseErrorHandlerContext'
-import IconCheckLabel from '../subPages/IconCheckLabel'
+import { formatReportDate } from '../../../../../library/formatDateTime'
 import { stripId } from './copyHelpers'
 import {
   Choices,
@@ -83,16 +83,9 @@ const CopyFinanceSolutionsModal = ({
   const indicatorSetSaveSuccessText = t('gfcr.success.indicator_set_save')
   const indicatorSetSaveFailedText = t('gfcr.errors.indicator_set_save_failed')
   const indicatorSetHeaderText = t('gfcr.forms.finance_solutions.indicator_set')
+  const reportingDateHeaderText = t('gfcr.reporting_date')
   const nameHeaderText = t('gfcr.forms.finance_solutions.business_finance_solution_name')
   const fsTypeHeaderText = t('gfcr.forms.finance_solutions.fs_type')
-  const sectorHeaderText = t('gfcr.forms.finance_solutions.sector')
-  const usedAnIncubatorHeaderText = t('gfcr.forms.finance_solutions.used_an_incubator')
-  const gender2xCriteriaHeaderText = t('gfcr.forms.finance_solutions.gender_program_criteria')
-  const localEnterpriseHeaderText = t('gfcr.forms.finance_solutions.local_enterprise')
-  const sustainableFinanceMechanismsHeaderText = t(
-    'gfcr.forms.finance_solutions.sustainable_finance_mechanisms',
-  )
-  const noIncubatorText = t('gfcr.forms.finance_solutions.no_incubator')
 
   const copyableEntries = useMemo(() => {
     return gfcrIndicatorSets
@@ -100,6 +93,7 @@ const CopyFinanceSolutionsModal = ({
       .flatMap((set) =>
         (set.finance_solutions ?? []).map((financeSolution) => ({
           indicatorSetTitle: set.title,
+          reportDate: set.report_date,
           financeSolution,
         })),
       )
@@ -123,42 +117,18 @@ const CopyFinanceSolutionsModal = ({
         accessor: 'indicatorSetTitle',
         sortType: reactTableNaturalSort,
       },
+      {
+        Header: reportingDateHeaderText,
+        accessor: 'report_date',
+        // Sorts on the raw YYYY-MM-DD value, not the localized text the Cell renders,
+        // so the order stays chronological rather than alphabetical by month name.
+        sortType: reactTableNaturalSort,
+        Cell: ({ value }) => formatReportDate(value),
+      },
       { Header: nameHeaderText, accessor: 'name', sortType: reactTableNaturalSort },
       { Header: fsTypeHeaderText, accessor: 'fs_type', sortType: reactTableNaturalSort },
-      { Header: sectorHeaderText, accessor: 'sector', sortType: reactTableNaturalSort },
-      {
-        Header: usedAnIncubatorHeaderText,
-        accessor: 'used_an_incubator',
-        sortType: reactTableNaturalSort,
-      },
-      {
-        Header: gender2xCriteriaHeaderText,
-        accessor: 'gender_smart',
-        sortType: reactTableNaturalSort,
-        align: 'center',
-      },
-      {
-        Header: localEnterpriseHeaderText,
-        accessor: 'local_enterprise',
-        sortType: reactTableNaturalSort,
-        align: 'center',
-      },
-      {
-        Header: sustainableFinanceMechanismsHeaderText,
-        accessor: 'sustainable_finance_mechanisms',
-        sortType: reactTableNaturalSort,
-      },
     ],
-    [
-      indicatorSetHeaderText,
-      nameHeaderText,
-      fsTypeHeaderText,
-      sectorHeaderText,
-      usedAnIncubatorHeaderText,
-      gender2xCriteriaHeaderText,
-      localEnterpriseHeaderText,
-      sustainableFinanceMechanismsHeaderText,
-    ],
+    [indicatorSetHeaderText, reportingDateHeaderText, nameHeaderText, fsTypeHeaderText],
   )
 
   const tableCellData = useMemo(() => {
@@ -166,50 +136,22 @@ const CopyFinanceSolutionsModal = ({
       return []
     }
 
-    return copyableEntries.map(({ indicatorSetTitle, financeSolution }) => {
-      const {
-        id,
-        name,
-        fs_type,
-        sector,
-        used_an_incubator,
-        gender_smart,
-        local_enterprise,
-        sustainable_finance_mechanisms,
-      } = financeSolution
+    return copyableEntries.map(({ indicatorSetTitle, reportDate, financeSolution }) => {
+      const { id, name, fs_type } = financeSolution
 
       const fsTypeName = choices.financesolutiontypes?.data?.find(
         (fsTypeChoice) => fsTypeChoice.id === fs_type,
       )?.name
-      const sectorName = choices.sectors?.data?.find(
-        (sectorChoice) => sectorChoice.id === sector,
-      )?.name
-      const incubatorName = choices.incubatortypes?.data?.find(
-        (incubatorTypeChoice) => incubatorTypeChoice.id === used_an_incubator,
-      )?.name
-      const sustainableFinanceMechanismNames = sustainable_finance_mechanisms
-        .map(
-          (mechanism) =>
-            choices.sustainablefinancemechanisms?.data?.find(
-              // eslint-disable-next-line max-nested-callbacks
-              (sfmChoice) => sfmChoice.id === mechanism,
-            )?.name,
-        )
-        .join(', ')
 
       return {
         id,
         indicatorSetTitle,
+        report_date: reportDate,
         name,
         fs_type: fsTypeName,
-        sector: sectorName,
-        used_an_incubator: incubatorName || noIncubatorText,
-        gender_smart: <IconCheckLabel isCheck={!!gender_smart} />,
-        local_enterprise: <IconCheckLabel isCheck={!!local_enterprise} />,
-        sustainable_finance_mechanisms: sustainableFinanceMechanismNames,
       }
     })
-  }, [choices, copyableEntries, noIncubatorText])
+  }, [choices, copyableEntries])
 
   const tableDefaultPrefs = useMemo(() => {
     return {

--- a/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/CopyFinanceSolutionsModal.tsx
+++ b/src/components/pages/gfcrPages/GfcrIndicatorSetForm/modals/CopyFinanceSolutionsModal.tsx
@@ -27,7 +27,7 @@ import { useCurrentUser } from '../../../../../App/CurrentUserContext'
 import { useCurrentProject } from '../../../../../App/CurrentProjectContext'
 import { useDatabaseSwitchboardInstance } from '../../../../../App/mermaidData/databaseSwitchboard/DatabaseSwitchboardContext'
 import { useHttpResponseErrorHandler } from '../../../../../App/HttpResponseErrorHandlerContext'
-import { formatReportDate } from '../../../../../library/formatDateTime'
+import { formatDateOnlyIntl } from '../../../../../library/formatDateTime'
 import { stripId } from './copyHelpers'
 import {
   Choices,
@@ -83,7 +83,10 @@ const CopyFinanceSolutionsModal = ({
   const indicatorSetSaveSuccessText = t('gfcr.success.indicator_set_save')
   const indicatorSetSaveFailedText = t('gfcr.errors.indicator_set_save_failed')
   const indicatorSetHeaderText = t('gfcr.forms.finance_solutions.indicator_set')
+  const indicatorSetTypeHeaderText = t('gfcr.indicator_set_type')
   const reportingDateHeaderText = t('gfcr.reporting_date')
+  const reportText = t('gfcr.report')
+  const targetText = t('gfcr.target')
   const nameHeaderText = t('gfcr.forms.finance_solutions.business_finance_solution_name')
   const fsTypeHeaderText = t('gfcr.forms.finance_solutions.fs_type')
 
@@ -93,6 +96,7 @@ const CopyFinanceSolutionsModal = ({
       .flatMap((set) =>
         (set.finance_solutions ?? []).map((financeSolution) => ({
           indicatorSetTitle: set.title,
+          indicatorSetType: set.indicator_set_type,
           reportDate: set.report_date,
           financeSolution,
         })),
@@ -118,17 +122,28 @@ const CopyFinanceSolutionsModal = ({
         sortType: reactTableNaturalSort,
       },
       {
-        Header: reportingDateHeaderText,
-        accessor: 'report_date',
-        // Sorts on the raw YYYY-MM-DD value, not the localized text the Cell renders,
-        // so the order stays chronological rather than alphabetical by month name.
+        Header: indicatorSetTypeHeaderText,
+        accessor: 'indicatorSetType',
         sortType: reactTableNaturalSort,
-        Cell: ({ value }) => formatReportDate(value),
+      },
+      {
+        Header: reportingDateHeaderText,
+        // Sorts on the raw YYYY-MM-DD value rather than the localized label, so the order
+        // stays chronological instead of alphabetical by month name.
+        accessor: 'reportDate',
+        sortType: reactTableNaturalSort,
+        Cell: ({ row }) => row.original.reportDateLabel,
       },
       { Header: nameHeaderText, accessor: 'name', sortType: reactTableNaturalSort },
       { Header: fsTypeHeaderText, accessor: 'fs_type', sortType: reactTableNaturalSort },
     ],
-    [indicatorSetHeaderText, reportingDateHeaderText, nameHeaderText, fsTypeHeaderText],
+    [
+      indicatorSetHeaderText,
+      indicatorSetTypeHeaderText,
+      reportingDateHeaderText,
+      nameHeaderText,
+      fsTypeHeaderText,
+    ],
   )
 
   const tableCellData = useMemo(() => {
@@ -136,22 +151,28 @@ const CopyFinanceSolutionsModal = ({
       return []
     }
 
-    return copyableEntries.map(({ indicatorSetTitle, reportDate, financeSolution }) => {
-      const { id, name, fs_type } = financeSolution
+    return copyableEntries.map(
+      ({ indicatorSetTitle, indicatorSetType, reportDate, financeSolution }) => {
+        const { id, name, fs_type } = financeSolution
 
-      const fsTypeName = choices.financesolutiontypes?.data?.find(
-        (fsTypeChoice) => fsTypeChoice.id === fs_type,
-      )?.name
+        const fsTypeName = choices.financesolutiontypes?.data?.find(
+          (fsTypeChoice) => fsTypeChoice.id === fs_type,
+        )?.name
 
-      return {
-        id,
-        indicatorSetTitle,
-        report_date: reportDate,
-        name,
-        fs_type: fsTypeName,
-      }
-    })
-  }, [choices, copyableEntries])
+        return {
+          id,
+          indicatorSetTitle,
+          indicatorSetType: indicatorSetType === 'report' ? reportText : targetText,
+          reportDate,
+          // The label the date column renders, kept alongside the raw value so the filter can
+          // match what the user actually sees ("February 2024") instead of "2024-02-10"
+          reportDateLabel: formatDateOnlyIntl(reportDate),
+          name,
+          fs_type: fsTypeName,
+        }
+      },
+    )
+  }, [choices, copyableEntries, reportText, targetText])
 
   const tableDefaultPrefs = useMemo(() => {
     return {
@@ -166,7 +187,8 @@ const CopyFinanceSolutionsModal = ({
   })
 
   const tableGlobalFilters = useCallback((rows, id, query) => {
-    const keys = ['values.indicatorSetTitle', 'values.name']
+    // reportDateLabel has no column of its own, so it is read from the row rather than its values
+    const keys = ['values.indicatorSetTitle', 'original.reportDateLabel', 'values.name']
 
     const queryTerms = splitSearchQueryStrings(query)
     const filteredRows =
@@ -351,7 +373,7 @@ const CopyFinanceSolutionsModal = ({
       <CopyModalToolbarWrapper>
         <FilterSearchToolbar
           id="copy-finance-solutions-filter"
-          name={t('filters.by_indicator_set_or_solution_name')}
+          name={t('filters.by_indicator_set_date_or_solution_name')}
           globalSearchText={globalFilter}
           handleGlobalFilterChange={handleGlobalFilterChange}
         />

--- a/src/library/formatDateTime.test.ts
+++ b/src/library/formatDateTime.test.ts
@@ -1,0 +1,26 @@
+import { formatDateOnlyIntl } from './formatDateTime'
+
+describe('formatDateOnlyIntl', () => {
+  // Somewhere west of UTC, where a UTC-midnight date lands on the previous day locally.
+  // Without it the test passes on a UTC runner whether or not the formatting is correct.
+  beforeAll(() => {
+    vi.stubEnv('TZ', 'America/Vancouver')
+  })
+
+  afterAll(() => {
+    vi.unstubAllEnvs()
+  })
+
+  test('formats a date-only string as the same calendar day the API sent', () => {
+    // jsdom reports navigator.language as en-US
+    expect(formatDateOnlyIntl('2024-01-01')).toBe('January 1, 2024')
+  })
+
+  test.each([
+    ['an empty string', ''],
+    ['null', null],
+    ['an unparseable date', 'not a date'],
+  ])('returns an empty string for %s', (_description, value) => {
+    expect(formatDateOnlyIntl(value)).toBe('')
+  })
+})

--- a/src/library/formatDateTime.ts
+++ b/src/library/formatDateTime.ts
@@ -21,6 +21,27 @@ export const formatDistanceNoQuarters = (date: Date, baseDate: Date): string => 
   return intlFormatDistance(date, baseDate)
 }
 
+// GFCR reporting dates are plain YYYY-MM-DD, so they parse as UTC midnight. Format in UTC
+// too, otherwise anyone west of UTC sees the previous day. e.g. "February 10, 2024"
+export const formatReportDate = (reportDate: string): string => {
+  if (!reportDate) {
+    return ''
+  }
+
+  const date = new Date(reportDate)
+
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+
+  return date.toLocaleDateString(navigator.language, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
 // e.g. "Wednesday, February 4, 2026 at 14:34"
 export const formatDateTimeIntl = (date: Date | string | number): string =>
   intlFormat(date instanceof Date ? date : new Date(date), {

--- a/src/library/formatDateTime.ts
+++ b/src/library/formatDateTime.ts
@@ -21,25 +21,25 @@ export const formatDistanceNoQuarters = (date: Date, baseDate: Date): string => 
   return intlFormatDistance(date, baseDate)
 }
 
-// GFCR reporting dates are plain YYYY-MM-DD, so they parse as UTC midnight. Format in UTC
-// too, otherwise anyone west of UTC sees the previous day. e.g. "February 10, 2024"
-export const formatReportDate = (reportDate: string): string => {
-  if (!reportDate) {
+// Date-only values (YYYY-MM-DD) parse as UTC midnight, so they must be formatted in UTC too -
+// otherwise anyone west of UTC sees the previous day. e.g. "February 10, 2024"
+export const formatDateOnlyIntl = (dateOnly: string): string => {
+  // new Date(null) is the epoch rather than an invalid date, so falsy values need their own guard
+  if (!dateOnly) {
     return ''
   }
 
-  const date = new Date(reportDate)
+  const date = new Date(dateOnly)
 
   if (Number.isNaN(date.getTime())) {
     return ''
   }
 
-  return date.toLocaleDateString(navigator.language, {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    timeZone: 'UTC',
-  })
+  return intlFormat(
+    date,
+    { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' },
+    { locale: navigator.language },
+  )
 }
 
 // e.g. "Wednesday, February 4, 2026 at 14:34"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -189,7 +189,7 @@
   },
   "filters": {
     "by_finance_solution": "Filter by facility / solution",
-    "by_indicator_set_or_solution_name": "Filter by indicator set or solution name",
+    "by_indicator_set_date_or_solution_name": "Filter by indicator set, date, or solution name",
     "by_investment": "Filter by investment",
     "by_name_email": "Filter by name or email",
     "by_name_project_country": "Filter by name, project, or country",
@@ -417,6 +417,7 @@
     "indicator_set": "Fund indicator set",
     "indicator_set_date_info": "End date of the reporting period of the GFCR Programme, e.g., an end-year report may have December 31 as the reporting date.",
     "indicator_set_title_info": "Recommended naming conventions: For targets, use \"Phase 1 target\", \"Mid-term target\", or \"Final target\". For bi-annual progress reports, use \"Mid-year report\" or \"End-year report\".",
+    "indicator_set_type": "Indicator set type",
     "investments": "Investments",
     "no_indicator_info": "Select 'Create new' to add a fund indicator set to this project",
     "no_indicator_sets": "No fund indicator sets yet",


### PR DESCRIPTION
Closes M1947b. Follow-up to #1674 after QA.

## Problem

The copy modal put a red cross under Gender 2X criteria and Local enterprise, and "None" under Used a TAF, on rows where those fields do not apply to the facility / solution type. The Facilities / solutions tab leaves them blank.

The two tables are separate implementations. This modal was branched off before the M1981 changes (#1666) landed, so it kept the old cell logic. Rather than realign the columns, QA asked for a smaller table.

## Changes

The modal now shows: Indicator set, Indicator set type, Reporting date, Facility / solution name, Type. Sector, Used a TAF (incubator)?, Gender 2X criteria, Local enterprise and Sustainable financial mechanisms are removed, which removes the crosses and the "None" with them.

Reporting date is new, and disambiguates indicator sets that share a title. New `formatDateOnlyIntl` in `library/formatDateTime.ts` formats in UTC, since reporting dates are plain `YYYY-MM-DD` and would otherwise show the previous day west of UTC. The column sorts on the raw date, not the rendered text.

Indicator set type is also new, and is the one place I have gone past the four columns asked for. Title and reporting date alone still do not separate a report from a target covering the same period, so a solution could be copied from the wrong kind of set without noticing. It renders Report / Target exactly as the GFCR landing page does. Happy to drop it if you would rather keep the table at four.

The filter now matches the reporting date as it is displayed, so "February 2024" finds the row rather than only "2024-02".

`report_date` and `indicator_set_type` added to the `IndicatorSet` type.

What gets copied is unchanged. Only the picker's columns changed.

## Screenshots

After:
<img width="1227" height="677" alt="image" src="https://github.com/user-attachments/assets/3cde18b4-4c3b-463c-835f-b2e1f47a0cb5" />

## Testing

`formatDateOnlyIntl` has unit tests, which pin the timezone so the UTC handling cannot regress unnoticed. The rest is manual, as GFCR has no automated coverage. `tsc`, eslint and prettier pass.

1. Two indicator sets sharing a title with different reporting dates, each with a facility / solution. Open Copy from a third set: no crosses, no "None", and the two sets can be told apart.
2. Sort by Reporting date with dates where alphabetical and chronological disagree, e.g. December 2023 and February 2024. Order must be chronological.
3. Filter by "February 2024", and by an indicator set name and a solution name.
4. Copy a Business solution that has Sector, Gender 2X criteria and Local enterprise set. Confirm all three survive in the destination table and in the edit form.

## Out of scope

`IndicatorSetTitle.jsx:36` calls `getFullYear()` on a date built from a `YYYY-MM-DD` string, so the year badge is off by one for a 1 January reporting date west of UTC. Pre-existing, same root cause the new formatter avoids. Ticket to follow.

The GFCR landing page repeats this date formatting inline, and because it puts a React node in the row data its Reporting date column cannot sort or filter. Pointing it at `formatDateOnlyIntl` fixes both. Ticket to follow.



---Every PR---

- [ ] Changes have been tested locally
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Unit tests have run and passed

---Transitional Changes---

- [ ] Any hard-coded text in the file(s) worked has been refactored into key-value tokens
- [ ] Any language.js tokens no longer used are removed
- [ ] Any necessary updates to the documentation have been made
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] styled-components code in changed files has been updated to CSS modules in the styles folder
- [ ] Touched JS files are migrated to TypeScript where in scope; PropTypes are replaced with TypeScript interfaces in converted files and not added for shapes already typed in `mermaidDataTypes.ts`.

---Post-Merge---

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reporting dates to indicator sets.
  - Copy Finance Solutions now shows reporting dates in a clear, localized format.
  - Simplified the finance solution list to highlight the indicator set, date, name, and solution type.

- **Bug Fixes**
  - Improved date handling to prevent reporting dates from shifting due to timezone differences.
  - Invalid or missing dates are now displayed safely without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
